### PR TITLE
Add shell classifier for compound commands and wrapper invocations

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,30 @@ Add to `~/.claude/settings.json`:
 > `Bash(aws ecs list-services*)`) are fine; they just short-circuit YOLT
 > for the matching subset.
 
+## User allowlist as a secondary upgrade pass
+
+YOLT reads your `permissions.allow` Bash() entries from
+`~/.claude/settings.json`, the project's `.claude/settings.json`, and
+`.claude/settings.local.json`. After the rule classifier runs, any
+*decomposed segment* that would otherwise be `unknown` is upgraded to
+`safe` if it matches one of those patterns.
+
+This earns its keep on compound forms. The built-in matcher only sees
+the outer wrapper, so a `for ... do CMD; done` whose `CMD` you've
+already allowlisted (`Bash(mycli list*)`) still prompts. YOLT splits the
+loop into atomic segments, each of which gets the allowlist match.
+
+Two rules apply:
+
+- The match works on the segment string after substitution extraction
+  and top-level splitting, using `fnmatch` glob semantics - the same
+  semantics Claude Code's outer matcher uses. `Bash(env)` matches
+  `env` exactly; `Bash(aws s3 ls*)` matches anything that starts with
+  `aws s3 ls`.
+- A match **never weakens an `unsafe` decision**. If your rules say
+  `aws iam delete-user` is mutating, a permissive `Bash(aws *)` does
+  not turn it into safe - YOLT keeps flagging mutating calls.
+
 ## What the shell classifier handles
 
 Example decisions (see `rules/shell.json` for the full rule set):

--- a/README.md
+++ b/README.md
@@ -1,18 +1,57 @@
 # YOLT - You Only Live Twice
 
-A Claude Code hook that statically analyzes Python scripts before execution,
-auto-allowing safe scripts and flagging destructive ones for review.
+A Claude Code hook that statically analyzes commands before execution,
+auto-allowing read-only invocations and flagging mutating ones for review.
+
+YOLT closes two gaps in Claude Code's built-in allowlist matcher:
+
+1. **Arbitrary-execution wrappers.** Interpreters (`python3`, `bash`, `node`,
+   ...) and dual-use CLIs (`gh api`, `curl`, `kubectl`, ...) can't be
+   allowlisted with a wildcard without granting arbitrary execution, so a
+   long tail of clearly read-only invocations prompt every time.
+2. **Compound shell commands.** The built-in matcher sees the outer wrapper
+   (`for`, `while`, `bash -c "..."`, `$(...)`), not the inner commands it
+   runs, so loops and command substitutions prompt even when every inner
+   command would be allowlisted on its own.
+
+YOLT ships with two analyzers that share a single `PreToolUse` hook entry:
+
+- **Shell classifier** (`hooks/shell_classifier.py`) - decomposes compound
+  commands, strips wrapper syntax, and classifies each atomic command
+  against `rules/shell.json`.
+- **Python analyzer** (`hooks/yolt_analyzer.py`) - parses Python source via
+  the AST and walks all calls against `rules/default.json`. Invoked by the
+  shell classifier for `python3 -c ...` and `python3 script.py`.
 
 ## How it works
 
-YOLT registers as a `PreToolUse` hook on the `Bash` tool. When Claude Code
-runs `python3 script.py`, YOLT:
+YOLT registers as a `PreToolUse` hook on the `Bash` tool. For every Bash
+invocation the hook:
 
-1. Extracts the script path (or `-c` inline code)
-2. Parses the Python AST (zero external dependencies)
-3. Walks all function calls, checking against configurable safety rules
-4. **Safe** scripts get auto-allowed (no permission prompt)
-5. **Destructive** scripts prompt for user review with details on what was detected
+1. Extracts `$(...)` and `` `...` `` substitutions, classifying each inner
+   command.
+2. Splits the remainder on top-level `;`, `&&`, `||`, `|`, `&`, and
+   newlines into simple commands, while respecting quoting.
+3. Strips leading shell keywords (`for VAR in`, `while`, `if`, `do`,
+   `done`, `case PAT in`, ...) and environment-variable assignments
+   (`FOO=bar cmd`).
+4. Strips redirections. If any redirection writes to a file target other
+   than `/dev/null`, the command is left for Claude Code's default prompt
+   instead of being auto-allowed.
+5. Classifies the remaining argv:
+   - Safe shell builtin (`echo`, `pwd`, `test`, `[`, `cd`, ...) -> safe.
+   - Known interpreter (`python3`, `bash`, ...) -> delegate to the Python
+     analyzer or recurse into the shell classifier.
+   - Known command with rules (`aws`, `gh`, `curl`, `kubectl`, `git`,
+     `docker`, `terraform`, `find`, `sed`, ...) -> per-command rule.
+   - Wrappers (`time`, `xargs`, `timeout`, `env`, `nice`, `watch`, ...) ->
+     re-classify the wrapped command.
+   - Anything else -> unknown.
+6. Aggregates decisions with precedence `unsafe > unknown > safe`.
+7. Emits a hook response:
+   - `safe` -> `permissionDecision: allow` with a short reason.
+   - `unsafe` -> `permissionDecision: ask` with the specific reason.
+   - `unknown` -> silent exit; Claude Code falls through to its default.
 
 ## Install
 
@@ -36,16 +75,49 @@ Add to `~/.claude/settings.json`:
 }
 ```
 
-> **Important:** You must **not** have `Bash(python3:*)` in your
-> `settings.local.json` allow list. Static allow rules take precedence over
-> PreToolUse hooks — if `python3` is pre-allowed, YOLT's hook never fires
-> and all scripts (including destructive ones) run without analysis.
-> YOLT replaces the need for that allow rule: safe scripts are auto-approved
-> by the hook's `permissionDecision: "allow"` response.
+> **Important:** A static allow rule in `settings.json` / `settings.local.json`
+> bypasses `PreToolUse` hooks. Do not allowlist `Bash(python3:*)`,
+> `Bash(aws:*)`, `Bash(gh:*)`, etc. with wildcards - YOLT's classifier
+> will never fire and mutating invocations will run without review. Narrow
+> allowlist patterns that don't cover mutating operations (e.g.
+> `Bash(aws ecs list-services*)`) are fine; they just short-circuit YOLT
+> for the matching subset.
 
-## Rules
+## What the shell classifier handles
 
-Default rules cover:
+Example decisions (see `rules/shell.json` for the full rule set):
+
+| Command                                                      | Decision |
+| ------------------------------------------------------------ | -------- |
+| `aws ec2 describe-instances`                                 | allow    |
+| `aws ec2 terminate-instances --instance-ids i-abc`           | ask      |
+| `aws --profile prod --region us-east-1 ec2 describe-instances --no-cli-pager` | allow |
+| `aws s3 ls` / `aws s3 rm s3://bucket/key`                    | allow / ask |
+| `aws logs start-query --log-group-name X --query-string ...` | allow (service override: `start-query` is read-only) |
+| `gh api /repos/x/y/issues`                                   | allow    |
+| `gh api -X POST /repos/x/y/issues`                           | ask      |
+| `gh pr list` / `gh pr merge`                                 | allow / ask |
+| `curl https://api.example.com/users`                         | allow    |
+| `curl -X POST ... -d ...`                                    | ask      |
+| `kubectl get pods` / `kubectl exec -it pod -- bash`          | allow / ask |
+| `terraform plan` / `terraform apply`                         | allow / ask |
+| `terraform state list` / `terraform state rm foo`            | allow / ask |
+| `git status` / `git push`                                    | allow / ask |
+| `find . -name '*.py'`                                        | allow    |
+| `find . -name '*.py' -delete`                                | ask      |
+| `sed 's/a/b/' f` / `sed -i 's/a/b/' f`                       | allow / ask |
+| `python3 -c "print(1+1)"`                                    | allow    |
+| `python3 -c "import os; os.system('rm -rf /')"`              | ask      |
+| `bash -c "ls /tmp"` / `bash -c "rm /etc/passwd"`             | allow / ask |
+| `for svc in $(aws ecs list-services --cluster X); do aws ecs describe-services --cluster X --services "$svc"; done` | allow |
+| `echo foo \| xargs rm` / `echo foo \| xargs cat`             | ask / allow |
+| `time aws ec2 describe-instances`                            | allow    |
+| `cat file > /tmp/out`                                        | unknown (writes to a file) |
+| `aws ec2 describe-instances > /dev/null`                     | allow    |
+
+## Python-analyzer rules
+
+`rules/default.json` covers:
 
 - **AWS boto3** - `describe/list/get/head` safe; `delete/put/create/terminate` destructive
 - **File I/O** - `open()` write modes, `os.remove`, `shutil.rmtree`, etc.
@@ -59,7 +131,7 @@ won't false-positive.
 
 ## Custom rules
 
-Create `~/.claude/yolt/rules.json` to override defaults:
+### Python rules - `~/.claude/yolt/rules.json`
 
 ```json
 {
@@ -75,21 +147,45 @@ Create `~/.claude/yolt/rules.json` to override defaults:
 }
 ```
 
-User overrides merge with (and override) defaults per-key.
+### Shell rules - `~/.claude/yolt/shell.json`
+
+```json
+{
+  "commands": {
+    "mycli": {
+      "default": "subcommand",
+      "safe_subcommands": ["status", "show"],
+      "unsafe_subcommands": ["apply", "reset"]
+    }
+  },
+  "shell_builtins_safe": ["my-safe-wrapper"]
+}
+```
+
+User overrides merge with (and override) defaults per top-level key.
+Examples: `examples/user-overrides.json`, `examples/shell-overrides.json`.
 
 ## CLI usage
 
-Analyze a script directly:
+Analyze a Python script directly:
 
 ```bash
 python3 hooks/yolt_analyzer.py script.py
 ```
 
-Returns JSON with `safe: true/false`, findings, and import analysis.
+Classify a shell command directly:
+
+```bash
+python3 hooks/shell_classifier.py 'for svc in $(aws ecs list-services --cluster X); do aws ecs describe-services --cluster X --services "$svc"; done'
+```
+
+Both return JSON. The shell classifier's output shape is
+`{"decision": "safe|unsafe|unknown", "reason": "..."}`.
 
 ## Design principles
 
-- **Zero dependencies** - stdlib only (`ast`, `json`, `fnmatch`, `shlex`)
-- **False positives OK, false negatives not** - when in doubt, ask
-- **Configurable** - rules are data, not code
-- **Fast** - AST parsing is near-instant for typical scripts
+- **Zero dependencies** - stdlib only (`ast`, `json`, `fnmatch`, `shlex`, `re`)
+- **False positives OK, false negatives not** - unknown commands fall through
+  to Claude Code's default prompt rather than being auto-allowed.
+- **Configurable** - rules are data, not code.
+- **Fast** - classification is purely syntactic; no subprocess fork.

--- a/README.md
+++ b/README.md
@@ -182,6 +182,25 @@ python3 hooks/shell_classifier.py 'for svc in $(aws ecs list-services --cluster 
 Both return JSON. The shell classifier's output shape is
 `{"decision": "safe|unsafe|unknown", "reason": "..."}`.
 
+## Tests and demo
+
+Unit tests cover the decomposition helpers, the classifier, and the hook
+entry point. They use stdlib `unittest` only:
+
+```bash
+python3 -m unittest discover -v tests
+```
+
+For a visual check across a broad range of representative commands (not
+asserted, just printed), run:
+
+```bash
+./examples/demo.sh
+```
+
+This prints the decision (`safe` / `unsafe` / `unknown`) for each
+command, colorized when the terminal supports it.
+
 ## Design principles
 
 - **Zero dependencies** - stdlib only (`ast`, `json`, `fnmatch`, `shlex`, `re`)

--- a/examples/demo.sh
+++ b/examples/demo.sh
@@ -1,0 +1,136 @@
+#!/bin/bash
+# examples/demo.sh - show the shell classifier's decision on a range of
+# representative invocations.
+#
+# This is a "visual" check, not an assertion-backed test: it prints the
+# decision for each command so a human can confirm the classifier behaves
+# sensibly. For programmatic checks see tests/test_shell_classifier.py.
+#
+# Usage:
+#     ./examples/demo.sh
+#
+# Output format:
+#     <decision>  <command>
+# where <decision> is one of safe / unsafe / unknown.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+YOLT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+CLS="$YOLT_ROOT/hooks/shell_classifier.py"
+
+if [[ ! -f "$CLS" ]]; then
+  echo "error: cannot find $CLS" >&2
+  exit 1
+fi
+
+# Each element is a single command. Quoted carefully - this array is the
+# input to the classifier, nothing else evaluates it.
+commands=(
+  # Safe: plain read-only
+  'ls /tmp'
+  'cat /etc/hosts'
+  'grep foo /tmp/log'
+  'find . -name "*.py"'
+  'sed "s/a/b/" file.txt'
+
+  # Safe: AWS reads, with and without the ZoomInfo house style flags
+  'aws ec2 describe-instances'
+  'aws --profile prod --region us-east-1 ec2 describe-instances --no-cli-pager'
+  'aws s3 ls'
+  'aws logs start-query --log-group-name X --query-string "fields @timestamp"'
+
+  # Safe: dual-use tools in read mode
+  'gh api /repos/x/y/issues'
+  'gh pr list'
+  'curl https://api.example.com/users'
+  'kubectl get pods -A'
+  'kubectl describe deployment mydep'
+  'git status'
+  'git log --oneline -5'
+  'terraform plan'
+  'terraform state list'
+
+  # Safe: interpreters with analyzable benign payloads
+  'python3 -c "print(1+1)"'
+  'bash -c "ls /tmp"'
+
+  # Safe: compound forms
+  'ls /tmp && pwd'
+  'for svc in $(aws ecs list-services --cluster X); do aws ecs describe-services --cluster X --services "$svc"; done'
+  'if aws ec2 describe-instances; then echo ok; fi'
+  'case "$x" in a) ls ;; b) cat /etc/passwd ;; esac'
+  '[[ -d /tmp ]] && ls /tmp'
+  '{ ls /tmp; echo done; }'
+  'FOO=bar BAZ=qux aws s3 ls'
+  'time aws ec2 describe-instances'
+  'echo foo | xargs cat'
+  'aws ec2 describe-instances > /dev/null'
+  'aws ec2 describe-instances 2>/dev/null | jq .'
+
+  # Unsafe: direct mutation
+  'rm -rf /tmp/foo'
+  'sed -i "s/a/b/" file.txt'
+  'find . -name "*.py" -delete'
+
+  # Unsafe: AWS writes
+  'aws ec2 terminate-instances --instance-ids i-abc'
+  'aws s3 rm s3://bucket/key'
+
+  # Unsafe: dual-use tools in write mode
+  'gh api -X POST /repos/x/y/issues'
+  'gh api /repos/x/y/issues -f title=bug'
+  'curl -X POST https://api.example.com/users -d bar'
+  'curl --data foo=bar https://api.example.com/users'
+  'kubectl exec -it pod -- bash'
+  'kubectl apply -f manifest.yaml'
+  'git push origin main'
+  'terraform apply'
+  'terraform state rm foo.bar'
+
+  # Unsafe: interpreters with destructive payloads
+  'python3 -c "import os; os.system(\"rm -rf /\")"'
+  'bash -c "rm -rf /etc"'
+  'echo foo | xargs rm'
+
+  # Unsafe: compound forms containing a destructive step
+  'ls /tmp && rm -rf /etc'
+  'case "$x" in a) ls ;; b) rm /tmp/foo ;; esac'
+  '! rm -rf /tmp/foo'
+
+  # Unknown: the classifier has no rule, and /
+  # or the invocation writes to a file, so it falls through to Claude
+  # Code's default prompt.
+  'somecommand_unknown --flag'
+  'aws ec2 describe-instances > out.json'
+  'echo x > /etc/profile'
+)
+
+# Colorize to make scanning easier. Falls back to plain text if the
+# terminal doesn't support colors.
+if [[ -t 1 ]] && command -v tput >/dev/null 2>&1; then
+  GREEN="$(tput setaf 2)"
+  RED="$(tput setaf 1)"
+  YELLOW="$(tput setaf 3)"
+  DIM="$(tput dim)"
+  RESET="$(tput sgr0)"
+else
+  GREEN=""; RED=""; YELLOW=""; DIM=""; RESET=""
+fi
+
+for cmd in "${commands[@]}"; do
+  # The CLI exits 0 for safe, non-0 otherwise; we don't care about the exit
+  # code, we want the JSON decision.
+  decision="$(python3 "$CLS" "$cmd" 2>/dev/null \
+    | python3 -c 'import json,sys; print(json.load(sys.stdin)["decision"])' \
+    2>/dev/null || echo "error")"
+
+  case "$decision" in
+    safe)    color="$GREEN" ;;
+    unsafe)  color="$RED" ;;
+    unknown) color="$YELLOW" ;;
+    *)       color="$DIM" ;;
+  esac
+
+  printf "%s%-8s%s %s\n" "$color" "$decision" "$RESET" "$cmd"
+done

--- a/examples/shell-overrides.json
+++ b/examples/shell-overrides.json
@@ -1,0 +1,31 @@
+{
+  "_comment": "Place this file at ~/.claude/yolt/shell.json to override shell classifier defaults. Overrides merge per top-level key, one level deep.",
+
+  "commands": {
+    "mycli": {
+      "default": "subcommand",
+      "safe_subcommands": ["status", "show", "describe"],
+      "unsafe_subcommands": ["apply", "reset"]
+    },
+
+    "aws": {
+      "service_overrides": {
+        "athena": {
+          "extra_safe_patterns": ["start-query-execution", "stop-query-execution"]
+        }
+      }
+    }
+  },
+
+  "shell_builtins_safe": [
+    "echo", "printf", "pwd", "true", "false",
+    "test", "[", "[[",
+    "cd", "pushd", "popd", "dirs",
+    "type", "command", "hash",
+    "alias", "unalias",
+    "history", "fc",
+    "jobs", "wait",
+    "let", "read",
+    "my-safe-wrapper"
+  ]
+}

--- a/hooks/shell_classifier.py
+++ b/hooks/shell_classifier.py
@@ -68,6 +68,74 @@ def load_shell_rules(rules_dir, user_overrides_path=None):
     return rules
 
 
+BASH_PATTERN_RE = re.compile(r"^Bash\((.*)\)$")
+
+
+def load_allow_patterns(settings_paths):
+    """Read Claude Code settings.json files and return the list of inner
+    Bash() allow patterns (the part between the parentheses).
+
+    Accepts an iterable of file paths in precedence order; later paths add
+    more patterns but never remove ones earlier paths granted. Missing
+    files and malformed JSON are silently skipped - YOLT must not break a
+    user's session by failing to parse their settings.
+
+    Each entry in `permissions.allow` is a string of the form
+    `Bash(<pattern>)`. The inner pattern uses shell glob semantics
+    (matched with fnmatch). Non-Bash entries (e.g. `Read`, `Glob`,
+    `mcp__github__get_file_contents`) are filtered out. Duplicate
+    inner patterns are deduplicated, preserving first-seen order."""
+    patterns = []
+    seen = set()
+    for path in settings_paths:
+        if not path:
+            continue
+        p = Path(path)
+        if not p.exists():
+            continue
+        try:
+            with open(p, "r") as f:
+                data = json.load(f)
+        except (OSError, ValueError):
+            continue
+        permissions = data.get("permissions") or {}
+        allow = permissions.get("allow") or []
+        if not isinstance(allow, list):
+            continue
+        for entry in allow:
+            if not isinstance(entry, str):
+                continue
+            m = BASH_PATTERN_RE.match(entry.strip())
+            if not m:
+                continue
+            inner = m.group(1).strip()
+            if not inner:
+                continue
+            if inner in seen:
+                continue
+            seen.add(inner)
+            patterns.append(inner)
+    retval = patterns
+    return retval
+
+
+def match_allow_patterns(command, patterns):
+    """Return the matching pattern if `command` matches any allow pattern,
+    else None. Matching is fnmatch on the whole command string against the
+    unwrapped inner pattern - the same semantics as Claude Code's built-in
+    Bash matcher applies to the outer command token."""
+    if not patterns:
+        retval = None
+        return retval
+    cmd = command.strip()
+    for pat in patterns:
+        if fnmatch(cmd, pat):
+            retval = pat
+            return retval
+    retval = None
+    return retval
+
+
 def extract_substitutions(command):
     """Extract $(...) and `...` command substitutions, replacing each with a
     placeholder and returning the inner command strings in order.
@@ -479,13 +547,14 @@ def parse_aws_positionals(cmd_args):
 class ShellClassifier:
     MAX_RECURSION_DEPTH = 8
 
-    def __init__(self, rules, python_analyzer_factory=None):
+    def __init__(self, rules, python_analyzer_factory=None, allow_patterns=None):
         self.rules = rules
         self.commands = rules.get("commands", {})
         self.shell_builtins_safe = set(rules.get("shell_builtins_safe", []))
         self.shell_keywords = set(rules.get("shell_keywords", []))
         self.interpreters = rules.get("interpreters", {})
         self.python_analyzer_factory = python_analyzer_factory
+        self.allow_patterns = list(allow_patterns) if allow_patterns else []
 
     def classify(self, command, _depth=0):
         """Classify a shell command string. Returns (decision, reason).
@@ -514,7 +583,20 @@ class ShellClassifier:
         return retval
 
     def classify_segment(self, segment, _depth=0):
-        """Classify one segment (no ;, &&, ||, |, & at its top level)."""
+        """Classify one segment (no ;, &&, ||, |, & at its top level).
+
+        After the rule-based classifier runs, an `unknown` outcome is
+        upgraded to `safe` if the segment matches a user allow pattern
+        from settings.json (`permissions.allow` Bash entries). `unsafe`
+        is never weakened - YOLT keeps flagging mutating calls even when
+        the user's allowlist would otherwise permit them.
+
+        The allowlist match runs against the segment after leading shell
+        keywords (`do`, `then`, `else`, ...) have been stripped, so that
+        `for x in $(...); do mycli list "$x"; done` matches a user
+        pattern of `Bash(mycli list*)`. Redirection tokens are kept in
+        the match string so `Bash(echo *)` covers `echo x > /tmp/file`.
+        """
         if _depth > self.MAX_RECURSION_DEPTH:
             retval = (DECISION_UNKNOWN, "max recursion depth")
             return retval
@@ -522,16 +604,23 @@ class ShellClassifier:
         try:
             tokens = shlex.split(segment, posix=True)
         except ValueError as e:
-            retval = (DECISION_UNKNOWN, "shlex: {}".format(e))
+            retval = self._maybe_allow(segment, (DECISION_UNKNOWN, "shlex: {}".format(e)))
             return retval
 
         tokens, is_word_list = strip_leading_keywords_and_assignments(
             tokens, self.shell_keywords
         )
+        # Snapshot the post-keyword tokens for allowlist matching - it
+        # still contains redirection ops so e.g. `Bash(echo *)` matches
+        # `echo x > /tmp/file` the way Claude Code's outer matcher would.
+        match_string = " ".join(tokens) if tokens else segment
+
         tokens, writes_to_file = strip_redirections(tokens)
 
         if writes_to_file:
-            retval = (DECISION_UNKNOWN, "writes to a file via redirection")
+            retval = self._maybe_allow(
+                match_string, (DECISION_UNKNOWN, "writes to a file via redirection")
+            )
             return retval
 
         if not tokens:
@@ -547,7 +636,23 @@ class ShellClassifier:
             retval = (DECISION_SAFE, "bare substitution result")
             return retval
 
-        retval = self.classify_tokens(tokens, _depth=_depth)
+        result = self.classify_tokens(tokens, _depth=_depth)
+        retval = self._maybe_allow(match_string, result)
+        return retval
+
+    def _maybe_allow(self, match_string, result):
+        """If `result` is unknown and `match_string` matches a user allow
+        pattern, upgrade to safe with an explanatory reason. Otherwise
+        return `result` unchanged."""
+        decision, reason = result
+        if decision != DECISION_UNKNOWN:
+            retval = result
+            return retval
+        match = match_allow_patterns(match_string, self.allow_patterns)
+        if match is None:
+            retval = result
+            return retval
+        retval = (DECISION_SAFE, "matches user allow pattern '{}'".format(match))
         return retval
 
     def classify_tokens(self, tokens, _depth=0):
@@ -894,9 +999,13 @@ class ShellClassifier:
         return retval
 
 
-def classify_command(command, rules, python_analyzer_factory=None):
+def classify_command(command, rules, python_analyzer_factory=None, allow_patterns=None):
     """Module-level convenience wrapper."""
-    classifier = ShellClassifier(rules, python_analyzer_factory=python_analyzer_factory)
+    classifier = ShellClassifier(
+        rules,
+        python_analyzer_factory=python_analyzer_factory,
+        allow_patterns=allow_patterns,
+    )
     retval = classifier.classify(command)
     return retval
 
@@ -916,6 +1025,13 @@ def run_cli():
         user_overrides_path=Path.home() / ".claude" / "yolt" / "shell.json",
     )
 
+    cwd = Path.cwd()
+    allow_patterns = load_allow_patterns([
+        Path.home() / ".claude" / "settings.json",
+        cwd / ".claude" / "settings.json",
+        cwd / ".claude" / "settings.local.json",
+    ])
+
     # Lazy-import the python analyzer for --c / script delegation
     try:
         sys.path.insert(0, str(Path(__file__).resolve().parent))
@@ -932,7 +1048,11 @@ def run_cli():
     except ImportError:
         factory = None
 
-    decision, reason = classify_command(command, rules, python_analyzer_factory=factory)
+    decision, reason = classify_command(
+        command, rules,
+        python_analyzer_factory=factory,
+        allow_patterns=allow_patterns,
+    )
     output = {"decision": decision, "reason": reason}
     print(json.dumps(output, indent=2))
     sys.exit(0 if decision == DECISION_SAFE else 1)

--- a/hooks/shell_classifier.py
+++ b/hooks/shell_classifier.py
@@ -1,0 +1,942 @@
+#!/usr/bin/env python3
+"""YOLT shell classifier - decomposes compound shell commands and classifies
+each atomic command as read-only (safe), mutating (unsafe), or unknown.
+
+Addresses two gaps in Claude Code's built-in allowlist matcher:
+
+1. Interpreter / wrapper invocations (python3, bash, gh api, curl, kubectl
+   exec, ...) that grant arbitrary execution when allowlisted with a
+   wildcard but are benign for many specific read-only invocations.
+
+2. Compound shell forms (for / while / if, $(...), `...`, && / || / ;,
+   xargs, bash -c "...") whose *outer* token doesn't match the user's
+   allowlist even when every *inner* command does.
+
+Zero external dependencies - stdlib only.
+"""
+
+import json
+import os
+import re
+import shlex
+from fnmatch import fnmatch
+from pathlib import Path
+
+
+DECISION_SAFE = "safe"
+DECISION_UNSAFE = "unsafe"
+DECISION_UNKNOWN = "unknown"
+
+
+SHELL_OPERATOR_SEPARATORS = (";", "&&", "||", "|", "&", "\n")
+SUBSTITUTION_PLACEHOLDER = "__YOLT_SUB__"
+
+STANDALONE_REDIRECT_OPS = {
+    ">", ">>", "<", "<<", "<<<",
+    "&>", "&>>",
+    "1>", "1>>", "2>", "2>>",
+    "3>", "4>", "5>", "6>", "7>", "8>", "9>",
+    "3>>", "4>>", "5>>", "6>>", "7>>", "8>>", "9>>",
+    "3<", "4<", "5<", "6<", "7<", "8<", "9<",
+}
+
+ATTACHED_REDIRECT_RE = re.compile(r"^\d*[<>&][<>&]*\S")
+FD_DUP_RE = re.compile(r"^\d+[<>]&\d+-?$")
+ASSIGNMENT_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
+
+
+def load_shell_rules(rules_dir, user_overrides_path=None):
+    """Load shell classification rules from rules_dir/shell.json plus
+    optional user overrides. Overrides merge per-top-level-key, one level
+    deep (same shape as yolt_analyzer.load_rules)."""
+    rules = {}
+
+    default_path = Path(rules_dir) / "shell.json"
+    if default_path.exists():
+        with open(default_path, "r") as f:
+            rules = json.load(f)
+
+    if user_overrides_path and Path(user_overrides_path).exists():
+        with open(user_overrides_path, "r") as f:
+            overrides = json.load(f)
+        for key, value in overrides.items():
+            if key in rules and isinstance(rules[key], dict) and isinstance(value, dict):
+                rules[key].update(value)
+            else:
+                rules[key] = value
+
+    return rules
+
+
+def extract_substitutions(command):
+    """Extract $(...) and `...` command substitutions, replacing each with a
+    placeholder and returning the inner command strings in order.
+
+    Handles nesting of $(...) and mixed with backticks. Respects single and
+    double quotes."""
+    subs = []
+    result_chars = []
+    i = 0
+    in_single = False
+    in_double = False
+
+    def find_balanced_dollar_paren(s, start_after_paren):
+        depth = 1
+        j = start_after_paren
+        q_single = False
+        q_double = False
+        while j < len(s):
+            c = s[j]
+            if q_single:
+                if c == "'":
+                    q_single = False
+                j += 1
+                continue
+            if q_double:
+                if c == '"' and (j == 0 or s[j - 1] != "\\"):
+                    q_double = False
+                elif c == "$" and j + 1 < len(s) and s[j + 1] == "(":
+                    depth += 1
+                    j += 2
+                    continue
+                j += 1
+                continue
+            if c == "'":
+                q_single = True
+            elif c == '"':
+                q_double = True
+            elif c == "$" and j + 1 < len(s) and s[j + 1] == "(":
+                depth += 1
+                j += 2
+                continue
+            elif c == "(":
+                depth += 1
+            elif c == ")":
+                depth -= 1
+                if depth == 0:
+                    retval = j
+                    return retval
+            j += 1
+        retval = -1
+        return retval
+
+    while i < len(command):
+        c = command[i]
+        if in_single:
+            result_chars.append(c)
+            if c == "'":
+                in_single = False
+            i += 1
+            continue
+        if in_double:
+            # Inside double quotes, $(...) substitutions still apply
+            if c == '"' and (i == 0 or command[i - 1] != "\\"):
+                in_double = False
+                result_chars.append(c)
+                i += 1
+                continue
+            if c == "$" and i + 1 < len(command) and command[i + 1] == "(":
+                end = find_balanced_dollar_paren(command, i + 2)
+                if end < 0:
+                    result_chars.append(c)
+                    i += 1
+                    continue
+                inner = command[i + 2:end]
+                inner_stripped, nested = extract_substitutions(inner)
+                subs.extend(nested)
+                subs.append(inner_stripped)
+                result_chars.append(SUBSTITUTION_PLACEHOLDER)
+                i = end + 1
+                continue
+            result_chars.append(c)
+            i += 1
+            continue
+        if c == "'":
+            in_single = True
+            result_chars.append(c)
+            i += 1
+            continue
+        if c == '"':
+            in_double = True
+            result_chars.append(c)
+            i += 1
+            continue
+        if c == "$" and i + 1 < len(command) and command[i + 1] == "(":
+            end = find_balanced_dollar_paren(command, i + 2)
+            if end < 0:
+                result_chars.append(c)
+                i += 1
+                continue
+            inner = command[i + 2:end]
+            inner_stripped, nested = extract_substitutions(inner)
+            subs.extend(nested)
+            subs.append(inner_stripped)
+            result_chars.append(SUBSTITUTION_PLACEHOLDER)
+            i = end + 1
+            continue
+        if c == "`":
+            end = command.find("`", i + 1)
+            while end > 0 and command[end - 1] == "\\":
+                end = command.find("`", end + 1)
+            if end < 0:
+                result_chars.append(c)
+                i += 1
+                continue
+            inner = command[i + 1:end]
+            inner_stripped, nested = extract_substitutions(inner)
+            subs.extend(nested)
+            subs.append(inner_stripped)
+            result_chars.append(SUBSTITUTION_PLACEHOLDER)
+            i = end + 1
+            continue
+        result_chars.append(c)
+        i += 1
+
+    retval = ("".join(result_chars), subs)
+    return retval
+
+
+def split_top_level(command):
+    """Split a shell command on top-level operators ;, &&, ||, |, &, newline.
+    Respects single and double quotes. Returns list of non-empty segment
+    strings."""
+    segments = []
+    current = []
+    i = 0
+    in_single = False
+    in_double = False
+
+    def flush():
+        seg = "".join(current).strip()
+        if seg:
+            segments.append(seg)
+        current.clear()
+
+    while i < len(command):
+        c = command[i]
+        if in_single:
+            current.append(c)
+            if c == "'":
+                in_single = False
+            i += 1
+            continue
+        if in_double:
+            current.append(c)
+            if c == '"' and (i == 0 or command[i - 1] != "\\"):
+                in_double = False
+            i += 1
+            continue
+        if c == "'":
+            in_single = True
+            current.append(c)
+            i += 1
+            continue
+        if c == '"':
+            in_double = True
+            current.append(c)
+            i += 1
+            continue
+        if c == ";":
+            flush()
+            i += 1
+            continue
+        if c == "\n":
+            flush()
+            i += 1
+            continue
+        if c == "&" and i + 1 < len(command) and command[i + 1] == "&":
+            flush()
+            i += 2
+            continue
+        if c == "|" and i + 1 < len(command) and command[i + 1] == "|":
+            flush()
+            i += 2
+            continue
+        if c == "|":
+            flush()
+            i += 1
+            continue
+        if c == "&":
+            flush()
+            i += 1
+            continue
+        current.append(c)
+        i += 1
+    flush()
+    retval = segments
+    return retval
+
+
+CASE_PATTERN_RE = re.compile(r".+\)$")
+
+
+def strip_leading_keywords_and_assignments(tokens, keywords):
+    """Drop leading shell keywords (for, while, do, ...) and VAR=value
+    assignments from the token list.
+
+    Returns (remaining_tokens, is_word_list). is_word_list is True when the
+    remaining tokens are the iteration WORDs of a `for VAR in WORDS` / case
+    selector and should be treated as data, not as a command.
+
+    Handles structured keywords that carry a variable name:
+      - `for VAR in LIST` / `for VAR` (implicit $@)
+      - `select VAR in LIST` / `select VAR`
+      - `case WORD in`
+      - `PAT)` / `PAT1 | PAT2)` case-arm prefix
+    """
+    result = list(tokens)
+    is_word_list = False
+    while result:
+        first = result[0]
+        if first in {"for", "select"}:
+            if len(result) >= 3 and result[2] == "in":
+                result = result[3:]
+                is_word_list = True
+                break
+            if len(result) >= 2:
+                result = result[2:]
+                break
+            result = result[1:]
+            continue
+        if first == "case":
+            if len(result) >= 3 and result[2] == "in":
+                result = result[3:]
+                continue
+            if len(result) >= 2:
+                result = result[2:]
+                continue
+            result = result[1:]
+            continue
+        if first in keywords:
+            result = result[1:]
+            continue
+        if CASE_PATTERN_RE.match(first) and first != ")":
+            # Case-arm pattern prefix, e.g. `a)`, `*)`, `"foo")`
+            result = result[1:]
+            continue
+        if ASSIGNMENT_RE.match(first) and "=" in first:
+            result = result[1:]
+            continue
+        break
+    retval = (result, is_word_list)
+    return retval
+
+
+DISCARD_REDIRECT_TARGETS = {"/dev/null", "/dev/stderr", "/dev/stdout"}
+
+
+def strip_redirections(tokens):
+    """Drop shell redirection tokens and report whether any of them writes to
+    a file target other than /dev/null.
+
+    Returns (cleaned_tokens, writes_to_file_target).
+
+    writes_to_file_target is True when a `>` / `>>` / `&>` / `2>`-style
+    redirection targets anything other than /dev/null. Caller uses that to
+    refuse auto-allow, since a classifier saying "echo is safe" becomes
+    wrong when `echo x > /etc/profile` is the real command."""
+    cleaned = []
+    writes_to_file = False
+    i = 0
+    while i < len(tokens):
+        tok = tokens[i]
+        if tok in STANDALONE_REDIRECT_OPS:
+            is_write_op = "<" not in tok
+            target = tokens[i + 1] if i + 1 < len(tokens) else None
+            if is_write_op and target and target not in DISCARD_REDIRECT_TARGETS:
+                writes_to_file = True
+            i += 2
+            continue
+        if FD_DUP_RE.match(tok):
+            i += 1
+            continue
+        if ATTACHED_REDIRECT_RE.match(tok):
+            # e.g. `2>/dev/null`, `>file`, `&>log`
+            m = re.match(r"^(\d*)([<>&]+)(.*)$", tok)
+            if m:
+                op = m.group(2)
+                target = m.group(3)
+                is_write_op = "<" not in op
+                if is_write_op and target and target not in DISCARD_REDIRECT_TARGETS:
+                    writes_to_file = True
+            i += 1
+            continue
+        cleaned.append(tok)
+        i += 1
+    retval = (cleaned, writes_to_file)
+    return retval
+
+
+def check_unsafe_flags(cmd_args, spec):
+    """Check whether cmd_args contains a flag combination the command spec
+    declares unsafe. Returns a human-readable description of the match, or
+    None."""
+    unsafe_flag_values = spec.get("unsafe_flag_values", {})
+    unsafe_flag_any_value = set(spec.get("unsafe_flag_any_value", []))
+    unsafe_flags_without_value = set(spec.get("unsafe_flags_without_value", []))
+
+    i = 0
+    while i < len(cmd_args):
+        tok = cmd_args[i]
+
+        flag = tok
+        inline_value = None
+        if "=" in tok and tok.startswith("-"):
+            flag, _, inline_value = tok.partition("=")
+
+        if flag in unsafe_flags_without_value:
+            retval = "{} (no value)".format(flag)
+            return retval
+
+        if flag in unsafe_flag_values:
+            value = inline_value
+            if value is None and i + 1 < len(cmd_args):
+                value = cmd_args[i + 1]
+            if value is not None:
+                value_upper = value.upper() if isinstance(value, str) else value
+                for unsafe_val in unsafe_flag_values[flag]:
+                    if value_upper == unsafe_val.upper():
+                        retval = "{} {}".format(flag, value)
+                        return retval
+
+        if flag in unsafe_flag_any_value:
+            # Present at all (with or without value) marks unsafe.
+            retval = flag
+            return retval
+
+        i += 1
+
+    retval = None
+    return retval
+
+
+def aggregate_decisions(decisions):
+    """Combine a list of (decision, reason) results into one. Precedence:
+    unsafe > unknown > safe."""
+    if not decisions:
+        retval = (DECISION_SAFE, "nothing to classify")
+        return retval
+
+    unsafe_reasons = [r for d, r in decisions if d == DECISION_UNSAFE]
+    unknown_reasons = [r for d, r in decisions if d == DECISION_UNKNOWN]
+    safe_reasons = [r for d, r in decisions if d == DECISION_SAFE]
+
+    if unsafe_reasons:
+        retval = (DECISION_UNSAFE, "; ".join(unsafe_reasons))
+        return retval
+    if unknown_reasons:
+        retval = (DECISION_UNKNOWN, "; ".join(unknown_reasons))
+        return retval
+    retval = (DECISION_SAFE, "; ".join(safe_reasons) if safe_reasons else "no commands")
+    return retval
+
+
+def parse_aws_positionals(cmd_args):
+    """Walk aws CLI args skipping flags (--profile prod, --region us-east-1,
+    --no-cli-pager, etc.). Return (service, operation, trailing_positionals).
+    Either may be None."""
+    service = None
+    operation = None
+    trailing = []
+
+    i = 0
+    while i < len(cmd_args):
+        tok = cmd_args[i]
+        if tok.startswith("--"):
+            if "=" in tok:
+                i += 1
+                continue
+            # Known valueless long flags for aws CLI
+            if tok in {"--no-cli-pager", "--no-paginate", "--no-verify-ssl",
+                      "--no-sign-request", "--debug"}:
+                i += 1
+                continue
+            # Default: assume value follows (covers --profile, --region, etc.)
+            if i + 1 < len(cmd_args) and not cmd_args[i + 1].startswith("-"):
+                i += 2
+                continue
+            i += 1
+            continue
+        if tok.startswith("-") and len(tok) > 1:
+            # Short flags - aws only has a few, most long-form
+            i += 1
+            continue
+        if service is None:
+            service = tok
+            i += 1
+            continue
+        if operation is None:
+            operation = tok
+            i += 1
+            continue
+        trailing.append(tok)
+        i += 1
+
+    retval = (service, operation, trailing)
+    return retval
+
+
+class ShellClassifier:
+    MAX_RECURSION_DEPTH = 8
+
+    def __init__(self, rules, python_analyzer_factory=None):
+        self.rules = rules
+        self.commands = rules.get("commands", {})
+        self.shell_builtins_safe = set(rules.get("shell_builtins_safe", []))
+        self.shell_keywords = set(rules.get("shell_keywords", []))
+        self.interpreters = rules.get("interpreters", {})
+        self.python_analyzer_factory = python_analyzer_factory
+
+    def classify(self, command, _depth=0):
+        """Classify a shell command string. Returns (decision, reason).
+        decision in {"safe", "unsafe", "unknown"}."""
+        if _depth > self.MAX_RECURSION_DEPTH:
+            retval = (DECISION_UNKNOWN, "max recursion depth")
+            return retval
+
+        if not command or not command.strip():
+            retval = (DECISION_SAFE, "empty")
+            return retval
+
+        stripped, subs = extract_substitutions(command)
+
+        decisions = []
+        for sub in subs:
+            d, r = self.classify(sub, _depth=_depth + 1)
+            decisions.append((d, "$(...) -> {}".format(r)))
+
+        segments = split_top_level(stripped)
+        for seg in segments:
+            d, r = self.classify_segment(seg, _depth=_depth + 1)
+            decisions.append((d, r))
+
+        retval = aggregate_decisions(decisions)
+        return retval
+
+    def classify_segment(self, segment, _depth=0):
+        """Classify one segment (no ;, &&, ||, |, & at its top level)."""
+        if _depth > self.MAX_RECURSION_DEPTH:
+            retval = (DECISION_UNKNOWN, "max recursion depth")
+            return retval
+
+        try:
+            tokens = shlex.split(segment, posix=True)
+        except ValueError as e:
+            retval = (DECISION_UNKNOWN, "shlex: {}".format(e))
+            return retval
+
+        tokens, is_word_list = strip_leading_keywords_and_assignments(
+            tokens, self.shell_keywords
+        )
+        tokens, writes_to_file = strip_redirections(tokens)
+
+        if writes_to_file:
+            retval = (DECISION_UNKNOWN, "writes to a file via redirection")
+            return retval
+
+        if not tokens:
+            retval = (DECISION_SAFE, "keywords/assignments/redirections only")
+            return retval
+
+        if is_word_list:
+            retval = (DECISION_SAFE, "word list (for/select iteration values)")
+            return retval
+
+        # Drop the placeholder from extract_substitutions if it appears alone
+        if len(tokens) == 1 and tokens[0] == SUBSTITUTION_PLACEHOLDER:
+            retval = (DECISION_SAFE, "bare substitution result")
+            return retval
+
+        retval = self.classify_tokens(tokens, _depth=_depth)
+        return retval
+
+    def classify_tokens(self, tokens, _depth=0):
+        """Classify a simple command given its argv tokens."""
+        if not tokens:
+            retval = (DECISION_SAFE, "empty")
+            return retval
+
+        if all(t == SUBSTITUTION_PLACEHOLDER for t in tokens):
+            retval = (DECISION_SAFE, "only substitution result (classified separately)")
+            return retval
+
+        cmd_name = os.path.basename(tokens[0])
+        cmd_args = tokens[1:]
+
+        if cmd_name in self.shell_builtins_safe:
+            retval = (DECISION_SAFE, "builtin: {}".format(cmd_name))
+            return retval
+
+        if cmd_name in self.interpreters:
+            retval = self.classify_interpreter(cmd_name, cmd_args, _depth=_depth)
+            return retval
+
+        if cmd_name in self.commands:
+            retval = self.classify_known_command(cmd_name, cmd_args, _depth=_depth)
+            return retval
+
+        retval = (DECISION_UNKNOWN, "no rule: {}".format(cmd_name))
+        return retval
+
+    def classify_interpreter(self, name, cmd_args, _depth):
+        spec = self.interpreters[name]
+        inline_flag = spec.get("inline_flag")
+        delegate = spec.get("delegate", "unknown")
+        read_script_file = spec.get("read_script_file", False)
+
+        inline_code = None
+        if inline_flag and inline_flag in cmd_args:
+            idx = cmd_args.index(inline_flag)
+            if idx + 1 < len(cmd_args):
+                inline_code = cmd_args[idx + 1]
+
+        if inline_code is not None:
+            if delegate == "python":
+                retval = self.classify_python_source(
+                    inline_code, "{} {} ...".format(name, inline_flag)
+                )
+                return retval
+            if delegate == "bash":
+                d, r = self.classify(inline_code, _depth=_depth + 1)
+                retval = (d, "{} -c -> {}".format(name, r))
+                return retval
+            retval = (DECISION_UNKNOWN, "cannot analyze inline {}".format(delegate))
+            return retval
+
+        if read_script_file and delegate == "python":
+            script_path = None
+            for arg in cmd_args:
+                if arg.startswith("-"):
+                    continue
+                if arg.endswith(".py") or os.path.isfile(arg):
+                    script_path = arg
+                    break
+            if script_path and os.path.isfile(script_path):
+                try:
+                    with open(script_path, "r") as f:
+                        code = f.read()
+                except (OSError, UnicodeDecodeError) as e:
+                    retval = (DECISION_UNKNOWN, "cannot read {}: {}".format(script_path, e))
+                    return retval
+                retval = self.classify_python_source(
+                    code, "{} {}".format(name, script_path)
+                )
+                return retval
+
+        retval = (DECISION_UNKNOWN, "{} invocation not analyzable".format(name))
+        return retval
+
+    def classify_python_source(self, source, description):
+        if self.python_analyzer_factory is None:
+            retval = (DECISION_UNKNOWN, "python analyzer unavailable")
+            return retval
+        analyzer = self.python_analyzer_factory()
+        result = analyzer.analyze(source)
+        if result.get("safe"):
+            retval = (DECISION_SAFE, "python: {}".format(description))
+            return retval
+        retval = (DECISION_UNSAFE, "python {}: {}".format(
+            description, result.get("reason", "destructive call")
+        ))
+        return retval
+
+    def classify_known_command(self, cmd_name, cmd_args, _depth):
+        spec = self.commands[cmd_name]
+        default = spec.get("default", "unknown")
+
+        unsafe_match = check_unsafe_flags(cmd_args, spec)
+        if unsafe_match:
+            retval = (DECISION_UNSAFE, "{}: flag {}".format(cmd_name, unsafe_match))
+            return retval
+
+        if default == "safe":
+            retval = (DECISION_SAFE, "{}: read-only".format(cmd_name))
+            return retval
+        if default == "unsafe":
+            retval = (DECISION_UNSAFE, "{}: mutating".format(cmd_name))
+            return retval
+        if default == "ask":
+            retval = (DECISION_UNKNOWN, "{}: rules punt".format(cmd_name))
+            return retval
+        if default == "subcommand":
+            retval = self.classify_subcommand(cmd_name, cmd_args, spec, _depth=_depth)
+            return retval
+        if default == "delegate_to_argument":
+            retval = self.classify_delegate_to_argument(cmd_name, cmd_args, spec, _depth=_depth)
+            return retval
+        if default == "aws_cli":
+            retval = self.classify_aws(cmd_args, spec)
+            return retval
+        if default == "gcloud_cli":
+            retval = self.classify_verb_cli(cmd_args, spec, label="gcloud")
+            return retval
+        if default == "az_cli":
+            retval = self.classify_verb_cli(cmd_args, spec, label="az")
+            return retval
+
+        retval = (DECISION_UNKNOWN, "{}: unknown default '{}'".format(cmd_name, default))
+        return retval
+
+    def classify_subcommand(self, cmd_name, cmd_args, spec, _depth):
+        positional = self._skip_flags(cmd_args)
+        if not positional:
+            retval = (DECISION_UNKNOWN, "{}: no subcommand".format(cmd_name))
+            return retval
+
+        sub = positional[0]
+        rest = positional[1:]
+        remaining_args = cmd_args[cmd_args.index(sub) + 1:] if sub in cmd_args else rest
+
+        nested = spec.get("nested_subcommand", {})
+        if sub in nested:
+            nested_spec = nested[sub]
+            nested_unsafe = check_unsafe_flags(remaining_args, nested_spec)
+            if nested_unsafe:
+                retval = (DECISION_UNSAFE, "{} {}: flag {}".format(cmd_name, sub, nested_unsafe))
+                return retval
+
+            if "default" in nested_spec:
+                nested_default = nested_spec["default"]
+                if nested_default == "safe":
+                    retval = (DECISION_SAFE, "{} {}: read-only".format(cmd_name, sub))
+                    return retval
+                if nested_default == "unsafe":
+                    retval = (DECISION_UNSAFE, "{} {}: mutating".format(cmd_name, sub))
+                    return retval
+
+            retval = self._match_subcommand_lists(
+                "{} {}".format(cmd_name, sub), rest, nested_spec
+            )
+            return retval
+
+        retval = self._match_subcommand_lists(cmd_name, positional, spec)
+        return retval
+
+    def _match_subcommand_lists(self, label, positional, spec):
+        safe_subs = set(spec.get("safe_subcommands", []))
+        unsafe_subs = set(spec.get("unsafe_subcommands", []))
+        safe_patterns = spec.get("safe_subcommand_patterns", [])
+        unsafe_patterns = spec.get("unsafe_subcommand_patterns", [])
+
+        if not positional:
+            retval = (DECISION_UNKNOWN, "{}: no subcommand".format(label))
+            return retval
+
+        sub = positional[0]
+
+        if sub in safe_subs:
+            retval = (DECISION_SAFE, "{} {}: read-only".format(label, sub))
+            return retval
+        if sub in unsafe_subs:
+            retval = (DECISION_UNSAFE, "{} {}: mutating".format(label, sub))
+            return retval
+        for pat in safe_patterns:
+            if fnmatch(sub, pat):
+                retval = (DECISION_SAFE, "{} {}: matches safe pattern {}".format(label, sub, pat))
+                return retval
+        for pat in unsafe_patterns:
+            if fnmatch(sub, pat):
+                retval = (DECISION_UNSAFE, "{} {}: matches unsafe pattern {}".format(label, sub, pat))
+                return retval
+
+        retval = (DECISION_UNKNOWN, "{} {}: no rule".format(label, sub))
+        return retval
+
+    def classify_delegate_to_argument(self, cmd_name, cmd_args, spec, _depth):
+        skip_first_positional = spec.get("_skip_first_positional", False)
+
+        i = 0
+        while i < len(cmd_args):
+            tok = cmd_args[i]
+            if tok.startswith("--"):
+                if "=" in tok:
+                    i += 1
+                    continue
+                if i + 1 < len(cmd_args) and not cmd_args[i + 1].startswith("-"):
+                    i += 2
+                    continue
+                i += 1
+                continue
+            if tok.startswith("-") and len(tok) > 1:
+                if len(tok) > 2 and not tok[2].isalpha():
+                    # Inline value like -n5 or -I{}
+                    i += 1
+                    continue
+                if i + 1 < len(cmd_args) and not cmd_args[i + 1].startswith("-"):
+                    i += 2
+                    continue
+                i += 1
+                continue
+            if cmd_name == "env" and ASSIGNMENT_RE.match(tok) and "=" in tok:
+                i += 1
+                continue
+            if skip_first_positional:
+                skip_first_positional = False
+                i += 1
+                continue
+            break
+
+        if i >= len(cmd_args):
+            retval = (DECISION_UNKNOWN, "{}: no wrapped command".format(cmd_name))
+            return retval
+
+        wrapped_tokens = cmd_args[i:]
+        d, r = self.classify_tokens(wrapped_tokens, _depth=_depth + 1)
+        retval = (d, "{} wraps: {}".format(cmd_name, r))
+        return retval
+
+    def classify_aws(self, cmd_args, spec):
+        service, operation, trailing = parse_aws_positionals(cmd_args)
+        if service is None:
+            retval = (DECISION_UNKNOWN, "aws: no service")
+            return retval
+        if operation is None:
+            retval = (DECISION_UNKNOWN, "aws {}: no operation".format(service))
+            return retval
+
+        service_overrides = spec.get("service_overrides", {})
+        per_service = service_overrides.get(service, {})
+
+        safe_subs = set(per_service.get("safe_subcommands", []))
+        unsafe_subs = set(per_service.get("unsafe_subcommands", []))
+        if operation in safe_subs:
+            retval = (DECISION_SAFE, "aws {} {}: read-only".format(service, operation))
+            return retval
+        if operation in unsafe_subs:
+            retval = (DECISION_UNSAFE, "aws {} {}: mutating".format(service, operation))
+            return retval
+
+        extra_safe = per_service.get("extra_safe_patterns", [])
+        for pat in extra_safe:
+            if fnmatch(operation, pat):
+                retval = (DECISION_SAFE, "aws {} {}: service override safe".format(service, operation))
+                return retval
+
+        svc_safe_patterns = per_service.get("safe_operation_patterns", [])
+        svc_unsafe_patterns = per_service.get("unsafe_operation_patterns", [])
+        for pat in svc_safe_patterns:
+            if fnmatch(operation, pat):
+                retval = (DECISION_SAFE, "aws {} {}: service-safe pattern".format(service, operation))
+                return retval
+        for pat in svc_unsafe_patterns:
+            if fnmatch(operation, pat):
+                retval = (DECISION_UNSAFE, "aws {} {}: service-unsafe pattern".format(service, operation))
+                return retval
+
+        for pat in spec.get("safe_operation_patterns", []):
+            if fnmatch(operation, pat):
+                retval = (DECISION_SAFE, "aws {} {}: global read-only".format(service, operation))
+                return retval
+        for pat in spec.get("unsafe_operation_patterns", []):
+            if fnmatch(operation, pat):
+                retval = (DECISION_UNSAFE, "aws {} {}: global mutating".format(service, operation))
+                return retval
+
+        retval = (DECISION_UNKNOWN, "aws {} {}: unclassified".format(service, operation))
+        return retval
+
+    def classify_verb_cli(self, cmd_args, spec, label):
+        """For gcloud / az CLIs - they typically use 'verb' subcommands like
+        `list`, `describe`, `create`, `delete`. Without detailed rules we
+        keep this permissive on known read verbs and unsafe on known write
+        verbs; otherwise unknown."""
+        positional = self._skip_flags(cmd_args)
+        if len(positional) < 2:
+            retval = (DECISION_UNKNOWN, "{}: too few positionals".format(label))
+            return retval
+
+        verb = positional[-1]
+        safe_verbs = {"list", "describe", "get", "show", "export", "version", "help"}
+        unsafe_verbs = {
+            "create", "delete", "update", "replace", "set", "add", "remove",
+            "deploy", "run", "execute", "exec", "ssh",
+            "enable", "disable", "reset", "rollback", "promote", "restart",
+            "scale", "resize",
+        }
+        if verb in safe_verbs:
+            retval = (DECISION_SAFE, "{} {}: read verb".format(label, verb))
+            return retval
+        if verb in unsafe_verbs:
+            retval = (DECISION_UNSAFE, "{} {}: write verb".format(label, verb))
+            return retval
+        retval = (DECISION_UNKNOWN, "{} {}: unknown verb".format(label, verb))
+        return retval
+
+    @staticmethod
+    def _skip_flags(cmd_args):
+        """Return only positional (non-flag) tokens from cmd_args, skipping
+        flag-values heuristically."""
+        positional = []
+        i = 0
+        while i < len(cmd_args):
+            tok = cmd_args[i]
+            if tok.startswith("--"):
+                if "=" in tok:
+                    i += 1
+                    continue
+                if i + 1 < len(cmd_args) and not cmd_args[i + 1].startswith("-"):
+                    i += 2
+                    continue
+                i += 1
+                continue
+            if tok.startswith("-") and len(tok) > 1:
+                if len(tok) > 2 and not tok[2].isalpha():
+                    i += 1
+                    continue
+                if i + 1 < len(cmd_args) and not cmd_args[i + 1].startswith("-"):
+                    i += 2
+                    continue
+                i += 1
+                continue
+            positional.append(tok)
+            i += 1
+        retval = positional
+        return retval
+
+
+def classify_command(command, rules, python_analyzer_factory=None):
+    """Module-level convenience wrapper."""
+    classifier = ShellClassifier(rules, python_analyzer_factory=python_analyzer_factory)
+    retval = classifier.classify(command)
+    return retval
+
+
+def run_cli():
+    """CLI: read a shell command from argv and print its classification."""
+    import sys
+
+    if len(sys.argv) < 2:
+        print("Usage: shell_classifier.py '<shell command>'", file=sys.stderr)
+        sys.exit(1)
+
+    command = sys.argv[1]
+    yolt_dir = Path(__file__).resolve().parent.parent
+    rules = load_shell_rules(
+        rules_dir=yolt_dir / "rules",
+        user_overrides_path=Path.home() / ".claude" / "yolt" / "shell.json",
+    )
+
+    # Lazy-import the python analyzer for --c / script delegation
+    try:
+        sys.path.insert(0, str(Path(__file__).resolve().parent))
+        from yolt_analyzer import SafetyAnalyzer, load_rules as load_py_rules
+        py_rules = load_py_rules(
+            rules_dir=yolt_dir / "rules",
+            user_overrides_path=Path.home() / ".claude" / "yolt" / "rules.json",
+        )
+
+        def _factory():
+            retval = SafetyAnalyzer(py_rules)
+            return retval
+        factory = _factory
+    except ImportError:
+        factory = None
+
+    decision, reason = classify_command(command, rules, python_analyzer_factory=factory)
+    output = {"decision": decision, "reason": reason}
+    print(json.dumps(output, indent=2))
+    sys.exit(0 if decision == DECISION_SAFE else 1)
+
+
+if __name__ == "__main__":
+    run_cli()

--- a/hooks/shell_classifier.py
+++ b/hooks/shell_classifier.py
@@ -136,6 +136,110 @@ def match_allow_patterns(command, patterns):
     return retval
 
 
+_PYTHON_HEREDOC_RE = re.compile(
+    r"^\s*python3?\s+(?:-\s+)?<<-?\s*['\"]?(\w+)['\"]?\s*\n",
+    re.MULTILINE,
+)
+
+
+def _extract_python_heredoc(command):
+    """If `command` begins with a `python3 <<EOF ... EOF` (or
+    `python3 - <<'EOF'` ...) heredoc, return the script body. Otherwise
+    return None.
+
+    Mirrors yolt_analyzer.extract_heredoc_script but accepts the `-`
+    stdin form and is hosted in shell_classifier so the classifier can
+    handle the case standalone too (the hook entry point delegates to
+    the python analyzer directly, but the CLI scan path doesn't)."""
+    m = _PYTHON_HEREDOC_RE.match(command)
+    if not m:
+        retval = None
+        return retval
+    delimiter = m.group(1)
+    body_start = m.end()
+    closing_pattern = re.compile(
+        r"^\s*" + re.escape(delimiter) + r"\s*$", re.MULTILINE
+    )
+    closing = closing_pattern.search(command, body_start)
+    if not closing:
+        retval = None
+        return retval
+    retval = command[body_start:closing.start()]
+    return retval
+
+
+def preprocess_shell_source(command):
+    """Strip shell line-continuations (`\\` immediately before a newline)
+    and `#` line comments outside of quotes. This brings multi-line
+    `aws ... \\\\\n  --foo \\\\\n  --bar` invocations and trailing
+    `# explanatory comment` notes into the same shape as the single-line
+    forms the rest of the classifier already handles.
+
+    Quoting rules:
+      - Inside single quotes, nothing is interpreted - the chars pass
+        through unchanged.
+      - Inside double quotes, `\\<LF>` is still consumed (POSIX) but
+        `#` is literal. Only continuations are stripped there.
+      - Outside quotes, both transformations apply.
+    """
+    chars = []
+    i = 0
+    in_single = False
+    in_double = False
+    n = len(command)
+    while i < n:
+        c = command[i]
+        if in_single:
+            chars.append(c)
+            if c == "'":
+                in_single = False
+            i += 1
+            continue
+        if in_double:
+            if c == "\\" and i + 1 < n and command[i + 1] == "\n":
+                # Line continuation inside double quotes - drop both chars.
+                i += 2
+                continue
+            chars.append(c)
+            if c == '"' and (i == 0 or command[i - 1] != "\\"):
+                in_double = False
+            i += 1
+            continue
+        if c == "'":
+            in_single = True
+            chars.append(c)
+            i += 1
+            continue
+        if c == '"':
+            in_double = True
+            chars.append(c)
+            i += 1
+            continue
+        if c == "\\" and i + 1 < n and command[i + 1] == "\n":
+            # POSIX line continuation: `\<LF>` is removed entirely. The
+            # preceding character (usually a space) is what separates
+            # tokens; if there isn't one, the writer intended fusion.
+            i += 2
+            continue
+        if c == "#":
+            # `#` only starts a comment at the start of a word (BOL or
+            # preceded by whitespace). `echo a#b` is a literal `a#b`.
+            at_word_start = (
+                len(chars) == 0 or chars[-1] in (" ", "\t", "\n", ";", "&", "|")
+            )
+            if at_word_start:
+                # Skip until next newline (or end of input).
+                j = command.find("\n", i)
+                if j < 0:
+                    break
+                i = j  # leave the newline; outer loop appends it
+                continue
+        chars.append(c)
+        i += 1
+    retval = "".join(chars)
+    return retval
+
+
 def extract_substitutions(command):
     """Extract $(...) and `...` command substitutions, replacing each with a
     placeholder and returning the inner command strings in order.
@@ -325,6 +429,14 @@ def split_top_level(command):
             i += 1
             continue
         if c == "&":
+            # Skip FD-duplication forms like `2>&1`, `>&2`, `<&3`, where
+            # the `&` is glued to a preceding `>` or `<`. Treating those
+            # as a background-job separator would split mid-redirection.
+            buf = "".join(current)
+            if buf and buf[-1] in (">", "<"):
+                current.append(c)
+                i += 1
+                continue
             flush()
             i += 1
             continue
@@ -567,6 +679,17 @@ class ShellClassifier:
             retval = (DECISION_SAFE, "empty")
             return retval
 
+        # python3 heredocs (`python3 <<EOF ... EOF`, `python3 - <<'EOF'`)
+        # have to be intercepted before any shell decomposition - the body
+        # contains arbitrary code with newlines that the segment splitter
+        # would shred into nonsense.
+        heredoc = _extract_python_heredoc(command)
+        if heredoc is not None:
+            retval = self.classify_python_source(heredoc, "python3 <<heredoc")
+            return retval
+
+        command = preprocess_shell_source(command)
+
         stripped, subs = extract_substitutions(command)
 
         decisions = []
@@ -783,7 +906,8 @@ class ShellClassifier:
         return retval
 
     def classify_subcommand(self, cmd_name, cmd_args, spec, _depth):
-        positional = self._skip_flags(cmd_args)
+        valueless = set(spec.get("valueless_flags", []))
+        positional = self._skip_flags(cmd_args, valueless_flags=valueless)
         if not positional:
             retval = (DECISION_UNKNOWN, "{}: no subcommand".format(cmd_name))
             return retval
@@ -968,9 +1092,16 @@ class ShellClassifier:
         return retval
 
     @staticmethod
-    def _skip_flags(cmd_args):
+    def _skip_flags(cmd_args, valueless_flags=None):
         """Return only positional (non-flag) tokens from cmd_args, skipping
-        flag-values heuristically."""
+        flag-values heuristically.
+
+        `valueless_flags` is an optional set of long flags known not to
+        consume a value. Without this hint the walker assumes any
+        long-flag whose successor doesn't start with `-` is a flag/value
+        pair, which gets `git --no-pager log` wrong (`log` isn't the
+        value of `--no-pager`)."""
+        valueless_flags = valueless_flags or set()
         positional = []
         i = 0
         while i < len(cmd_args):
@@ -979,12 +1110,18 @@ class ShellClassifier:
                 if "=" in tok:
                     i += 1
                     continue
+                if tok in valueless_flags:
+                    i += 1
+                    continue
                 if i + 1 < len(cmd_args) and not cmd_args[i + 1].startswith("-"):
                     i += 2
                     continue
                 i += 1
                 continue
             if tok.startswith("-") and len(tok) > 1:
+                if tok in valueless_flags:
+                    i += 1
+                    continue
                 if len(tok) > 2 and not tok[2].isalpha():
                     i += 1
                     continue

--- a/hooks/yolt_analyzer.py
+++ b/hooks/yolt_analyzer.py
@@ -270,33 +270,42 @@ def make_hook_response(decision, reason=None):
     return output
 
 
-def run_hook():
-    """Run as a Claude Code PreToolUse hook."""
-    try:
-        hook_input = json.load(sys.stdin)
-    except (json.JSONDecodeError, EOFError):
-        sys.exit(0)
+def _emit_python_analyzer_decision(result):
+    """Emit the Claude Code hook response for a Python analyzer result."""
+    if result["safe"]:
+        reason = "YOLT: Script analyzed - safe (imports: {})".format(
+            ", ".join(result["imports"]) if result["imports"] else "none"
+        )
+        response = make_hook_response("allow", reason)
+        print(json.dumps(response))
+        return
+    lines = ["YOLT: Destructive operations detected:"]
+    for finding in result["findings"]:
+        line_info = "  Line {}: {} ({})".format(
+            finding["line"], finding["call"], finding["category"]
+        )
+        source_line = finding.get("source_line", "")
+        if source_line:
+            line_info += "\n    > {}".format(source_line)
+        lines.append(line_info)
+    reason = "\n".join(lines)
+    response = make_hook_response("ask", reason)
+    print(json.dumps(response))
 
-    tool_name = hook_input.get("tool_name", "")
-    if tool_name != "Bash":
-        sys.exit(0)
 
-    command = hook_input.get("tool_input", {}).get("command", "")
-    if not command.lstrip().startswith("python3"):
-        sys.exit(0)
-
+def _run_python_only_hook(command):
+    """Legacy path - analyzes python3 invocations without the shell classifier.
+    Kept as a fallback when the shell classifier isn't importable."""
     source_type, source = extract_script_from_command(command)
     if source_type is None:
-        # Can't determine what script to analyze - ask user
         response = make_hook_response("ask", "YOLT: Could not extract script to analyze")
         print(json.dumps(response))
-        sys.exit(0)
+        return
 
     if source_type == "file":
         script_path = source
         if not os.path.isfile(script_path):
-            # File doesn't exist yet - let it fail naturally
-            sys.exit(0)
+            return
         with open(script_path, "r") as f:
             source_code = f.read()
     else:
@@ -310,28 +319,91 @@ def run_hook():
 
     analyzer = SafetyAnalyzer(rules)
     result = analyzer.analyze(source_code)
+    _emit_python_analyzer_decision(result)
 
-    if result["safe"]:
-        reason = "YOLT: Script analyzed - safe (imports: {})".format(
-            ", ".join(result["imports"]) if result["imports"] else "none"
+
+def run_hook():
+    """Run as a Claude Code PreToolUse hook.
+
+    Flow:
+      1. Validate this is a Bash invocation.
+      2. Decompose the command via shell_classifier (handles compound forms,
+         substitutions, wrappers, interpreters). The classifier delegates
+         python3 inline / script analysis to SafetyAnalyzer.
+      3. Map classifier decision -> hook response:
+           safe    -> permissionDecision: allow
+           unsafe  -> permissionDecision: ask (with explanation)
+           unknown -> exit silently, let Claude Code apply its default.
+    """
+    try:
+        hook_input = json.load(sys.stdin)
+    except (json.JSONDecodeError, EOFError):
+        sys.exit(0)
+
+    tool_name = hook_input.get("tool_name", "")
+    if tool_name != "Bash":
+        sys.exit(0)
+
+    command = hook_input.get("tool_input", {}).get("command", "")
+    if not command.strip():
+        sys.exit(0)
+
+    yolt_dir = Path(__file__).resolve().parent.parent
+    py_rules = load_rules(
+        rules_dir=yolt_dir / "rules",
+        user_overrides_path=Path.home() / ".claude" / "yolt" / "rules.json",
+    )
+
+    # Heredoc python3 invocations get handled directly - the heredoc body
+    # has embedded newlines that the shell decomposer would otherwise split
+    # into nonsense segments.
+    if command.lstrip().startswith("python3") and "<<" in command:
+        heredoc_source = extract_heredoc_script(command.lstrip())
+        if heredoc_source is not None:
+            analyzer = SafetyAnalyzer(py_rules)
+            result = analyzer.analyze(heredoc_source)
+            _emit_python_analyzer_decision(result)
+            sys.exit(0)
+
+    try:
+        hooks_dir = Path(__file__).resolve().parent
+        if str(hooks_dir) not in sys.path:
+            sys.path.insert(0, str(hooks_dir))
+        from shell_classifier import (
+            ShellClassifier, load_shell_rules,
+            DECISION_SAFE, DECISION_UNSAFE,
         )
-        response = make_hook_response("allow", reason)
+    except ImportError:
+        # Fallback: behave like the pre-shell-classifier version for python3
+        if not command.lstrip().startswith("python3"):
+            sys.exit(0)
+        _run_python_only_hook(command)
+        sys.exit(0)
+
+    shell_rules = load_shell_rules(
+        rules_dir=yolt_dir / "rules",
+        user_overrides_path=Path.home() / ".claude" / "yolt" / "shell.json",
+    )
+
+    def _python_factory():
+        retval = SafetyAnalyzer(py_rules)
+        return retval
+
+    classifier = ShellClassifier(shell_rules, python_analyzer_factory=_python_factory)
+    decision, reason = classifier.classify(command)
+
+    if decision == DECISION_SAFE:
+        response = make_hook_response("allow", "YOLT: {}".format(reason))
         print(json.dumps(response))
         sys.exit(0)
-    else:
-        lines = ["YOLT: Destructive operations detected:"]
-        for finding in result["findings"]:
-            line_info = "  Line {}: {} ({})".format(
-                finding["line"], finding["call"], finding["category"]
-            )
-            source_line = finding.get("source_line", "")
-            if source_line:
-                line_info += "\n    > {}".format(source_line)
-            lines.append(line_info)
-        reason = "\n".join(lines)
-        response = make_hook_response("ask", reason)
+    if decision == DECISION_UNSAFE:
+        response = make_hook_response(
+            "ask", "YOLT: Mutating command detected:\n  {}".format(reason)
+        )
         print(json.dumps(response))
         sys.exit(0)
+    # decision == DECISION_UNKNOWN: let Claude Code handle it
+    sys.exit(0)
 
 
 def run_cli():

--- a/hooks/yolt_analyzer.py
+++ b/hooks/yolt_analyzer.py
@@ -370,7 +370,7 @@ def run_hook():
         if str(hooks_dir) not in sys.path:
             sys.path.insert(0, str(hooks_dir))
         from shell_classifier import (
-            ShellClassifier, load_shell_rules,
+            ShellClassifier, load_shell_rules, load_allow_patterns,
             DECISION_SAFE, DECISION_UNSAFE,
         )
     except ImportError:
@@ -385,11 +385,27 @@ def run_hook():
         user_overrides_path=Path.home() / ".claude" / "yolt" / "shell.json",
     )
 
+    # The user's settings.json `permissions.allow` Bash() entries become a
+    # secondary upgrade pass: any decomposed atom that the rule classifier
+    # would call `unknown` is upgraded to `safe` if its segment matches one
+    # of the user's allow patterns. Unsafe is never weakened.
+    cwd_str = hook_input.get("cwd") or os.getcwd()
+    cwd = Path(cwd_str)
+    allow_patterns = load_allow_patterns([
+        Path.home() / ".claude" / "settings.json",
+        cwd / ".claude" / "settings.json",
+        cwd / ".claude" / "settings.local.json",
+    ])
+
     def _python_factory():
         retval = SafetyAnalyzer(py_rules)
         return retval
 
-    classifier = ShellClassifier(shell_rules, python_analyzer_factory=_python_factory)
+    classifier = ShellClassifier(
+        shell_rules,
+        python_analyzer_factory=_python_factory,
+        allow_patterns=allow_patterns,
+    )
     decision, reason = classifier.classify(command)
 
     if decision == DECISION_SAFE:

--- a/rules/shell.json
+++ b/rules/shell.json
@@ -1,0 +1,420 @@
+{
+  "_meta": {
+    "version": "0.1.0",
+    "description": "YOLT shell command classification rules. Used to decide whether the *full* invocation of a Bash command is read-only (auto-allow) or mutating (ask)."
+  },
+
+  "shell_builtins_safe": [
+    "echo", "printf", "pwd", "true", "false",
+    "test", "[", "[[",
+    "cd", "pushd", "popd", "dirs",
+    "type", "command", "hash",
+    "alias", "unalias",
+    "history", "fc",
+    "jobs", "wait",
+    "let", "read"
+  ],
+
+  "shell_keywords": [
+    "if", "then", "else", "elif", "fi",
+    "for", "while", "until", "do", "done",
+    "case", "esac", "in", "select",
+    "function", "time", "coproc",
+    "!", "{", "}", "(", ")"
+  ],
+
+  "interpreters": {
+    "python3": {"inline_flag": "-c", "delegate": "python", "read_script_file": true},
+    "python":  {"inline_flag": "-c", "delegate": "python", "read_script_file": true},
+    "bash":    {"inline_flag": "-c", "delegate": "bash",   "read_script_file": false},
+    "sh":      {"inline_flag": "-c", "delegate": "bash",   "read_script_file": false},
+    "zsh":     {"inline_flag": "-c", "delegate": "bash",   "read_script_file": false},
+    "node":    {"inline_flag": "-e", "delegate": "unknown","read_script_file": false},
+    "bun":     {"inline_flag": "-e", "delegate": "unknown","read_script_file": false},
+    "ruby":    {"inline_flag": "-e", "delegate": "unknown","read_script_file": false},
+    "perl":    {"inline_flag": "-e", "delegate": "unknown","read_script_file": false}
+  },
+
+  "commands": {
+    "ls":       {"default": "safe"},
+    "cat":      {"default": "safe"},
+    "head":     {"default": "safe"},
+    "tail":     {"default": "safe"},
+    "less":     {"default": "safe"},
+    "more":     {"default": "safe"},
+    "wc":       {"default": "safe"},
+    "file":     {"default": "safe"},
+    "stat":     {"default": "safe"},
+    "basename": {"default": "safe"},
+    "dirname":  {"default": "safe"},
+    "realpath": {"default": "safe"},
+    "readlink": {"default": "safe"},
+    "which":    {"default": "safe"},
+    "whereis":  {"default": "safe"},
+    "env":      {"default": "safe"},
+    "printenv": {"default": "safe"},
+    "date":     {"default": "safe"},
+    "cal":      {"default": "safe"},
+    "uname":    {"default": "safe"},
+    "hostname": {"default": "safe"},
+    "id":       {"default": "safe"},
+    "whoami":   {"default": "safe"},
+    "who":      {"default": "safe"},
+    "uptime":   {"default": "safe"},
+    "tty":      {"default": "safe"},
+    "locale":   {"default": "safe"},
+    "groups":   {"default": "safe"},
+    "ps":       {"default": "safe"},
+    "top":      {"default": "safe"},
+    "htop":     {"default": "safe"},
+    "df":       {"default": "safe"},
+    "du":       {"default": "safe"},
+    "free":     {"default": "safe"},
+    "lsof":     {"default": "safe"},
+    "netstat":  {"default": "safe"},
+    "ss":       {"default": "safe"},
+    "dig":      {"default": "safe"},
+    "nslookup": {"default": "safe"},
+    "host":     {"default": "safe"},
+    "ping":     {"default": "safe"},
+
+    "grep":     {"default": "safe"},
+    "rg":       {"default": "safe"},
+    "ag":       {"default": "safe"},
+    "ack":      {"default": "safe"},
+    "sort":     {"default": "safe"},
+    "uniq":     {"default": "safe"},
+    "cut":      {"default": "safe"},
+    "tr":       {"default": "safe"},
+    "paste":    {"default": "safe"},
+    "join":     {"default": "safe"},
+    "comm":     {"default": "safe"},
+    "column":   {"default": "safe"},
+    "expand":   {"default": "safe"},
+    "unexpand": {"default": "safe"},
+    "fold":     {"default": "safe"},
+    "fmt":      {"default": "safe"},
+    "nl":       {"default": "safe"},
+    "od":       {"default": "safe"},
+    "hexdump":  {"default": "safe"},
+    "xxd":      {"default": "safe"},
+    "diff":     {"default": "safe"},
+    "cmp":      {"default": "safe"},
+    "jq":       {"default": "safe"},
+    "yq":       {"default": "safe"},
+    "awk":      {
+      "default": "safe",
+      "_note": "awk is safe unless given `-i inplace` (GNU) or the program calls system()/print > file. Pure text filtering is safe."
+    },
+    "sed": {
+      "default": "safe",
+      "unsafe_flag_any_value": ["-i", "--in-place"],
+      "_note": "sed without -i just outputs to stdout. -i rewrites files in place."
+    },
+
+    "md5":      {"default": "safe"},
+    "md5sum":   {"default": "safe"},
+    "shasum":   {"default": "safe"},
+    "sha1sum":  {"default": "safe"},
+    "sha256sum":{"default": "safe"},
+    "sha512sum":{"default": "safe"},
+    "openssl":  {"default": "ask", "_note": "openssl can generate keys and sign things. Too many subcommands to enumerate safely; punt to prompt."},
+
+    "tee": {
+      "default": "unsafe",
+      "_note": "tee writes to one or more files. Always mutating."
+    },
+    "rm":     {"default": "unsafe"},
+    "rmdir":  {"default": "unsafe"},
+    "mv":     {"default": "unsafe"},
+    "cp":     {"default": "unsafe"},
+    "ln":     {"default": "unsafe"},
+    "touch":  {"default": "unsafe"},
+    "mkdir":  {"default": "unsafe"},
+    "chmod":  {"default": "unsafe"},
+    "chown":  {"default": "unsafe"},
+    "chgrp":  {"default": "unsafe"},
+    "install":{"default": "unsafe"},
+    "dd":     {"default": "unsafe"},
+    "shred":  {"default": "unsafe"},
+    "sudo":   {"default": "unsafe"},
+    "su":     {"default": "unsafe"},
+    "doas":   {"default": "unsafe"},
+    "eval":   {"default": "unsafe"},
+    "source": {"default": "unsafe"},
+    ".":      {"default": "unsafe"},
+    "exec":   {"default": "unsafe"},
+    "trap":   {"default": "unsafe"},
+    "kill":   {"default": "unsafe"},
+    "killall":{"default": "unsafe"},
+    "pkill":  {"default": "unsafe"},
+
+    "find": {
+      "default": "safe",
+      "unsafe_flag_any_value": ["-delete"],
+      "unsafe_flags_without_value": ["-delete"],
+      "unsafe_flag_value_prefix": {"-exec": "*", "-execdir": "*", "-ok": "*", "-okdir": "*"},
+      "_note": "find is read-only until you add -delete, -exec, -execdir, -ok, or -okdir."
+    },
+    "xargs": {
+      "default": "delegate_to_argument",
+      "_note": "xargs runs a command. The command after its flags is the real work; classify that."
+    },
+    "parallel": {
+      "default": "delegate_to_argument",
+      "_note": "GNU parallel runs its argument command."
+    },
+    "time":    {"default": "delegate_to_argument"},
+    "nohup":   {"default": "delegate_to_argument"},
+    "nice":    {"default": "delegate_to_argument"},
+    "ionice":  {"default": "delegate_to_argument"},
+    "timeout": {"default": "delegate_to_argument", "_skip_first_positional": true},
+    "env":     {"default": "delegate_to_argument", "_note": "'env FOO=bar cmd args' runs cmd. Skip VAR=val tokens until we reach the actual command."},
+    "watch":   {"default": "delegate_to_argument"},
+
+    "gh": {
+      "default": "subcommand",
+      "safe_subcommands": [
+        "auth", "browse", "help",
+        "search", "status", "version"
+      ],
+      "nested_subcommand": {
+        "api": {
+          "default": "safe",
+          "unsafe_flag_values": {
+            "-X": ["POST", "PUT", "PATCH", "DELETE"],
+            "--method": ["POST", "PUT", "PATCH", "DELETE"]
+          },
+          "unsafe_flag_any_value": ["-F", "--field", "-f", "--raw-field"],
+          "unsafe_flag_value_prefix": {"--input": "*"},
+          "_note": "gh api defaults to GET. Body-carrying methods and --field/-F/-f imply POST."
+        },
+        "issue":       {"safe_subcommands": ["view", "list", "status"], "unsafe_subcommands": ["create", "close", "reopen", "comment", "edit", "delete", "transfer", "pin", "unpin", "lock", "unlock", "develop"]},
+        "pr":          {"safe_subcommands": ["view", "list", "status", "diff", "checks", "checkout"], "unsafe_subcommands": ["create", "close", "reopen", "comment", "edit", "merge", "ready", "review", "update-branch"]},
+        "release":     {"safe_subcommands": ["view", "list", "download"], "unsafe_subcommands": ["create", "delete", "edit", "upload"]},
+        "repo":        {"safe_subcommands": ["view", "list", "clone"], "unsafe_subcommands": ["create", "delete", "fork", "archive", "rename", "edit", "deploy-key", "sync"]},
+        "run":         {"safe_subcommands": ["list", "view", "watch"], "unsafe_subcommands": ["cancel", "delete", "rerun"]},
+        "workflow":    {"safe_subcommands": ["list", "view"], "unsafe_subcommands": ["disable", "enable", "run"]},
+        "gist":        {"safe_subcommands": ["view", "list"], "unsafe_subcommands": ["create", "delete", "edit", "clone"]},
+        "label":       {"safe_subcommands": ["list"], "unsafe_subcommands": ["create", "delete", "edit", "clone"]},
+        "cache":       {"safe_subcommands": ["list"], "unsafe_subcommands": ["delete"]},
+        "secret":      {"safe_subcommands": ["list"], "unsafe_subcommands": ["set", "delete"]},
+        "variable":    {"safe_subcommands": ["list"], "unsafe_subcommands": ["set", "delete"]},
+        "ssh-key":     {"safe_subcommands": ["list"], "unsafe_subcommands": ["add", "delete"]},
+        "gpg-key":     {"safe_subcommands": ["list"], "unsafe_subcommands": ["add", "delete"]},
+        "codespace":   {"safe_subcommands": ["list", "view", "logs", "ports"], "unsafe_subcommands": ["create", "delete", "edit", "stop", "rebuild", "ssh"]},
+        "config":      {"safe_subcommands": ["get", "list"], "unsafe_subcommands": ["set", "clear-cache"]}
+      }
+    },
+
+    "curl": {
+      "default": "safe",
+      "unsafe_flag_values": {
+        "-X": ["POST", "PUT", "PATCH", "DELETE"],
+        "--request": ["POST", "PUT", "PATCH", "DELETE"]
+      },
+      "unsafe_flag_any_value": [
+        "-d", "--data", "--data-raw", "--data-binary", "--data-urlencode",
+        "-F", "--form", "--form-string",
+        "-T", "--upload-file"
+      ],
+      "_note": "curl defaults to GET. Presence of body flags (-d, --data, -F, -T) or -X with a body method implies mutation."
+    },
+    "wget": {
+      "default": "safe",
+      "unsafe_flag_any_value": ["--post-data", "--post-file", "--method"],
+      "_note": "wget defaults to GET. --post-data / --post-file imply POST."
+    },
+    "http":  {"default": "ask", "_note": "httpie CLI: full classification is non-trivial. Punt."},
+    "https": {"default": "ask"},
+
+    "git": {
+      "default": "subcommand",
+      "safe_subcommands": [
+        "log", "status", "diff", "show", "blame",
+        "branch", "tag",
+        "rev-parse", "rev-list", "describe", "name-rev",
+        "reflog",
+        "ls-files", "ls-tree", "ls-remote",
+        "cat-file", "show-ref", "show-branch",
+        "grep", "shortlog",
+        "bisect",
+        "worktree",
+        "config",
+        "remote", "fetch",
+        "stash",
+        "help", "version"
+      ],
+      "unsafe_subcommands": [
+        "add", "rm", "mv",
+        "commit", "commit-tree",
+        "push", "pull",
+        "merge", "rebase", "cherry-pick", "revert", "am",
+        "reset", "restore", "checkout", "switch",
+        "clean",
+        "tag",
+        "apply", "format-patch",
+        "clone",
+        "init",
+        "gc", "prune", "repack",
+        "update-ref", "update-index",
+        "notes", "filter-branch", "filter-repo",
+        "submodule"
+      ],
+      "_note": "Some subcommands overlap (tag both lists). Safe list is checked first, so 'git tag' is safe (listing); 'git tag v1' still passes safe, which is slightly permissive. Acceptable trade-off."
+    },
+
+    "docker": {
+      "default": "subcommand",
+      "safe_subcommands": [
+        "ps", "images", "image", "container",
+        "inspect", "logs", "stats", "top", "port",
+        "diff", "history", "info", "version", "events",
+        "system", "volume", "network", "context", "search"
+      ],
+      "unsafe_subcommands": [
+        "run", "exec", "kill", "stop", "start", "restart",
+        "rm", "rmi", "prune",
+        "build", "buildx", "push", "pull", "load", "save",
+        "create", "commit", "cp", "tag", "update",
+        "pause", "unpause",
+        "login", "logout",
+        "compose", "swarm", "service", "stack"
+      ],
+      "_note": "Some top-level names (image, container, volume, network, system) have destructive sub-subcommands (prune, rm). We list them as safe because their default 'ls'/'inspect' verbs dominate usage; we'd need nested-subcommand rules for full fidelity."
+    },
+
+    "kubectl": {
+      "default": "subcommand",
+      "safe_subcommands": [
+        "get", "describe", "logs", "explain",
+        "top", "cluster-info", "version",
+        "api-resources", "api-versions",
+        "config",
+        "auth",
+        "diff",
+        "events",
+        "wait"
+      ],
+      "unsafe_subcommands": [
+        "apply", "create", "replace", "patch", "edit",
+        "delete",
+        "exec", "attach", "port-forward", "proxy", "run",
+        "rollout", "scale", "autoscale",
+        "label", "annotate",
+        "cordon", "uncordon", "drain", "taint",
+        "cp"
+      ]
+    },
+
+    "helm": {
+      "default": "subcommand",
+      "safe_subcommands": [
+        "get", "list", "ls", "status", "history",
+        "show", "search", "inspect", "lint", "template",
+        "env", "version", "repo"
+      ],
+      "unsafe_subcommands": [
+        "install", "upgrade", "uninstall", "delete",
+        "rollback", "test", "push", "pull", "package",
+        "dependency", "plugin", "registry", "create"
+      ]
+    },
+
+    "aws": {
+      "default": "aws_cli",
+      "_note": "Special-cased. AWS CLI operations are uniformly verb-prefixed: describe-*/list-*/get-*/head-* are read-only; create-*/delete-*/update-*/put-*/terminate-*/start-*/stop-*/run-* are mutating.",
+      "safe_operation_patterns": [
+        "describe-*", "list-*", "get-*", "head-*",
+        "lookup-*", "search-*", "batch-get-*",
+        "preview-*", "check-*", "test-*", "select-*",
+        "can-paginate", "wait", "help",
+        "ls", "cp_DISABLED"
+      ],
+      "unsafe_operation_patterns": [
+        "create-*", "delete-*", "put-*", "update-*", "modify-*",
+        "terminate-*", "stop-*", "start-*", "restart-*", "reboot-*",
+        "run-*", "execute-*", "invoke-*",
+        "attach-*", "detach-*",
+        "deregister-*", "register-*",
+        "disable-*", "enable-*",
+        "revoke-*", "grant-*", "authorize-*",
+        "tag-*", "untag-*",
+        "publish-*", "send-*",
+        "upload-*", "download-*",
+        "copy-*", "move-*", "restore-*",
+        "reset-*", "rollback-*", "cancel-*",
+        "accept-*", "reject-*", "decline-*",
+        "associate-*", "disassociate-*",
+        "add-*", "remove-*",
+        "set-*"
+      ],
+      "service_overrides": {
+        "s3": {
+          "safe_subcommands": ["ls"],
+          "unsafe_subcommands": ["cp", "mv", "rm", "sync", "mb", "rb", "presign", "website"]
+        },
+        "s3api": {
+          "safe_operation_patterns": ["head-*", "list-*", "get-*"],
+          "unsafe_operation_patterns": ["put-*", "delete-*", "copy-*", "create-*", "upload-*", "abort-*", "complete-*", "restore-*"]
+        },
+        "logs": {
+          "extra_safe_patterns": ["filter-log-events", "start-query", "get-query-results", "stop-query", "tail"],
+          "_note": "Logs service has some 'start-*' operations that are actually read-only queries (start-query). Explicit overrides."
+        }
+      }
+    },
+
+    "gcloud":   {"default": "gcloud_cli"},
+    "az":       {"default": "az_cli"},
+
+    "terraform": {
+      "default": "subcommand",
+      "safe_subcommands": [
+        "validate", "fmt", "plan", "show", "state",
+        "output", "version", "providers", "console",
+        "graph", "force-unlock_DISABLED", "workspace"
+      ],
+      "unsafe_subcommands": [
+        "apply", "destroy", "import", "init", "refresh",
+        "taint", "untaint"
+      ],
+      "nested_subcommand": {
+        "state": {
+          "safe_subcommands": ["list", "show", "pull"],
+          "unsafe_subcommands": ["mv", "rm", "replace-provider", "push"]
+        },
+        "workspace": {
+          "safe_subcommands": ["list", "show"],
+          "unsafe_subcommands": ["new", "select", "delete"]
+        }
+      }
+    },
+
+    "npm": {
+      "default": "subcommand",
+      "safe_subcommands": ["ls", "list", "view", "info", "show", "outdated", "search", "help", "root", "prefix", "config", "doctor", "ping", "version", "whoami"],
+      "unsafe_subcommands": ["install", "i", "uninstall", "un", "update", "up", "run", "run-script", "start", "test", "publish", "unpublish", "link", "unlink", "adduser", "login", "logout", "access", "deprecate", "dist-tag", "pack", "rebuild", "audit", "ci", "init", "edit", "exec", "x"]
+    },
+
+    "yarn": {"default": "ask", "_note": "yarn invokes scripts by default. Punt."},
+    "pnpm": {"default": "ask"},
+
+    "pip": {
+      "default": "subcommand",
+      "safe_subcommands": ["list", "show", "freeze", "check", "help", "config", "search", "index", "inspect"],
+      "unsafe_subcommands": ["install", "uninstall", "download", "wheel", "hash"]
+    },
+    "pip3": {
+      "default": "subcommand",
+      "safe_subcommands": ["list", "show", "freeze", "check", "help", "config", "search", "index", "inspect"],
+      "unsafe_subcommands": ["install", "uninstall", "download", "wheel", "hash"]
+    },
+
+    "brew": {
+      "default": "subcommand",
+      "safe_subcommands": ["list", "ls", "info", "abv", "search", "deps", "uses", "leaves", "outdated", "home", "config", "doctor", "help", "--version"],
+      "unsafe_subcommands": ["install", "uninstall", "remove", "rm", "upgrade", "update", "reinstall", "pin", "unpin", "cleanup", "tap", "untap", "link", "unlink"]
+    }
+  }
+}

--- a/rules/shell.json
+++ b/rules/shell.json
@@ -11,8 +11,10 @@
     "type", "command", "hash",
     "alias", "unalias",
     "history", "fc",
-    "jobs", "wait",
-    "let", "read"
+    "jobs", "wait", "sleep",
+    "let", "read",
+    "unset", "set",
+    ":"
   ],
 
   "shell_keywords": [
@@ -174,6 +176,10 @@
 
     "gh": {
       "default": "subcommand",
+      "valueless_flags": [
+        "--no-pager", "--paginate",
+        "--version", "--help"
+      ],
       "safe_subcommands": [
         "auth", "browse", "help",
         "search", "status", "version"
@@ -230,6 +236,13 @@
 
     "git": {
       "default": "subcommand",
+      "valueless_flags": [
+        "--no-pager", "--paginate", "--no-replace-objects",
+        "--bare", "--no-optional-locks",
+        "--literal-pathspecs", "--glob-pathspecs", "--noglob-pathspecs",
+        "--icase-pathspecs", "--no-advice",
+        "--version", "--help"
+      ],
       "safe_subcommands": [
         "log", "status", "diff", "show", "blame",
         "branch", "tag",

--- a/tests/test_shell_classifier.py
+++ b/tests/test_shell_classifier.py
@@ -1,0 +1,531 @@
+"""Unit tests for hooks/shell_classifier.py.
+
+Runs with stdlib unittest (no external dependencies, matching the project's
+zero-dependency design principle):
+
+    python3 -m unittest discover -v tests
+"""
+
+import json
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+HOOKS_DIR = REPO_ROOT / "hooks"
+sys.path.insert(0, str(HOOKS_DIR))
+
+from shell_classifier import (  # noqa: E402
+    DECISION_SAFE,
+    DECISION_UNKNOWN,
+    DECISION_UNSAFE,
+    ShellClassifier,
+    SUBSTITUTION_PLACEHOLDER,
+    aggregate_decisions,
+    check_unsafe_flags,
+    extract_substitutions,
+    load_shell_rules,
+    parse_aws_positionals,
+    split_top_level,
+    strip_leading_keywords_and_assignments,
+    strip_redirections,
+)
+from yolt_analyzer import SafetyAnalyzer, load_rules as load_py_rules  # noqa: E402
+
+
+def _make_classifier():
+    shell_rules = load_shell_rules(REPO_ROOT / "rules")
+    py_rules = load_py_rules(REPO_ROOT / "rules")
+
+    def _factory():
+        retval = SafetyAnalyzer(py_rules)
+        return retval
+
+    retval = ShellClassifier(shell_rules, python_analyzer_factory=_factory)
+    return retval
+
+
+# Keyword set mirroring rules/shell.json#shell_keywords, used by stripper tests.
+KEYWORDS = {
+    "if", "then", "else", "elif", "fi",
+    "for", "while", "until", "do", "done",
+    "case", "esac", "in", "select",
+    "function", "time", "coproc",
+    "!", "{", "}", "(", ")",
+}
+
+
+class TestExtractSubstitutions(unittest.TestCase):
+    def test_no_substitution(self):
+        out, subs = extract_substitutions("ls /tmp")
+        self.assertEqual(out, "ls /tmp")
+        self.assertEqual(subs, [])
+
+    def test_single_dollar_paren(self):
+        out, subs = extract_substitutions("echo $(date)")
+        self.assertIn(SUBSTITUTION_PLACEHOLDER, out)
+        self.assertEqual(subs, ["date"])
+
+    def test_backtick(self):
+        out, subs = extract_substitutions("echo `date`")
+        self.assertIn(SUBSTITUTION_PLACEHOLDER, out)
+        self.assertEqual(subs, ["date"])
+
+    def test_nested_substitution(self):
+        out, subs = extract_substitutions("echo $(foo $(bar))")
+        self.assertEqual(len(subs), 2)
+        self.assertIn("bar", subs)
+
+    def test_substitution_inside_double_quote_expanded(self):
+        out, subs = extract_substitutions('echo "prefix $(date) suffix"')
+        self.assertEqual(subs, ["date"])
+        self.assertIn(SUBSTITUTION_PLACEHOLDER, out)
+
+    def test_substitution_inside_single_quote_is_literal(self):
+        out, subs = extract_substitutions("echo 'literal $(date)'")
+        self.assertEqual(subs, [])
+        self.assertEqual(out, "echo 'literal $(date)'")
+
+    def test_unmatched_paren_passes_through(self):
+        out, subs = extract_substitutions("echo $(incomplete")
+        self.assertEqual(subs, [])
+        self.assertIn("$(incomplete", out)
+
+
+class TestSplitTopLevel(unittest.TestCase):
+    def test_semicolon(self):
+        self.assertEqual(split_top_level("ls; pwd"), ["ls", "pwd"])
+
+    def test_double_ampersand(self):
+        self.assertEqual(split_top_level("ls && pwd"), ["ls", "pwd"])
+
+    def test_double_pipe(self):
+        self.assertEqual(split_top_level("ls || pwd"), ["ls", "pwd"])
+
+    def test_single_pipe(self):
+        self.assertEqual(split_top_level("ls | grep foo"), ["ls", "grep foo"])
+
+    def test_newline_splits(self):
+        self.assertEqual(split_top_level("ls\npwd"), ["ls", "pwd"])
+
+    def test_background_ampersand(self):
+        self.assertEqual(split_top_level("ls & pwd"), ["ls", "pwd"])
+
+    def test_quoted_separators_not_split(self):
+        self.assertEqual(
+            split_top_level('echo "a && b" || pwd'),
+            ['echo "a && b"', "pwd"],
+        )
+
+    def test_single_quoted_separators_not_split(self):
+        self.assertEqual(
+            split_top_level("echo 'a; b; c' && pwd"),
+            ["echo 'a; b; c'", "pwd"],
+        )
+
+    def test_double_semicolon_collapses(self):
+        # Case-arm ;; produces an empty segment which is filtered out.
+        self.assertEqual(split_top_level("ls ;; pwd"), ["ls", "pwd"])
+
+
+class TestStripRedirections(unittest.TestCase):
+    def test_standalone_output_to_file_marked_as_write(self):
+        tokens, writes = strip_redirections(["ls", ">", "file.txt"])
+        self.assertEqual(tokens, ["ls"])
+        self.assertTrue(writes)
+
+    def test_standalone_output_to_dev_null_not_write(self):
+        tokens, writes = strip_redirections(["ls", ">", "/dev/null"])
+        self.assertEqual(tokens, ["ls"])
+        self.assertFalse(writes)
+
+    def test_attached_stderr_to_dev_null_not_write(self):
+        tokens, writes = strip_redirections(["aws", "describe", "2>/dev/null"])
+        self.assertEqual(tokens, ["aws", "describe"])
+        self.assertFalse(writes)
+
+    def test_attached_stderr_to_file_marked_as_write(self):
+        tokens, writes = strip_redirections(["aws", "describe", "2>/tmp/err.log"])
+        self.assertEqual(tokens, ["aws", "describe"])
+        self.assertTrue(writes)
+
+    def test_fd_duplicate_not_write(self):
+        tokens, writes = strip_redirections(["cmd", "2>&1"])
+        self.assertEqual(tokens, ["cmd"])
+        self.assertFalse(writes)
+
+    def test_stdin_redirection_not_write(self):
+        tokens, writes = strip_redirections(["cat", "<", "input.txt"])
+        self.assertEqual(tokens, ["cat"])
+        self.assertFalse(writes)
+
+    def test_append_to_file_marked_as_write(self):
+        tokens, writes = strip_redirections(["echo", "x", ">>", "/var/log/app.log"])
+        self.assertEqual(tokens, ["echo", "x"])
+        self.assertTrue(writes)
+
+    def test_amp_gt_all_to_file_marked_as_write(self):
+        tokens, writes = strip_redirections(["cmd", "&>/tmp/out.log"])
+        self.assertEqual(tokens, ["cmd"])
+        self.assertTrue(writes)
+
+
+class TestStripLeadingKeywords(unittest.TestCase):
+    def test_no_keywords(self):
+        tokens, wl = strip_leading_keywords_and_assignments(["ls", "/tmp"], KEYWORDS)
+        self.assertEqual(tokens, ["ls", "/tmp"])
+        self.assertFalse(wl)
+
+    def test_for_var_in_marks_word_list(self):
+        tokens, wl = strip_leading_keywords_and_assignments(
+            ["for", "x", "in", "a", "b", "c"], KEYWORDS
+        )
+        self.assertEqual(tokens, ["a", "b", "c"])
+        self.assertTrue(wl)
+
+    def test_for_var_implicit_consumes_two(self):
+        tokens, wl = strip_leading_keywords_and_assignments(["for", "x"], KEYWORDS)
+        self.assertEqual(tokens, [])
+
+    def test_case_word_in_strips_three(self):
+        tokens, wl = strip_leading_keywords_and_assignments(
+            ["case", "$x", "in"], KEYWORDS
+        )
+        self.assertEqual(tokens, [])
+
+    def test_case_pattern_arm_dropped(self):
+        tokens, wl = strip_leading_keywords_and_assignments(["a)", "ls"], KEYWORDS)
+        self.assertEqual(tokens, ["ls"])
+
+    def test_wildcard_pattern_arm_dropped(self):
+        tokens, wl = strip_leading_keywords_and_assignments(["*)", "ls"], KEYWORDS)
+        self.assertEqual(tokens, ["ls"])
+
+    def test_env_assignment_chain(self):
+        tokens, wl = strip_leading_keywords_and_assignments(
+            ["FOO=bar", "BAZ=qux", "ls"], KEYWORDS
+        )
+        self.assertEqual(tokens, ["ls"])
+
+    def test_if_then_stripped(self):
+        tokens, wl = strip_leading_keywords_and_assignments(["if", "ls"], KEYWORDS)
+        self.assertEqual(tokens, ["ls"])
+
+    def test_negation_drop(self):
+        tokens, wl = strip_leading_keywords_and_assignments(
+            ["!", "rm", "-rf"], KEYWORDS
+        )
+        self.assertEqual(tokens, ["rm", "-rf"])
+
+
+class TestCheckUnsafeFlags(unittest.TestCase):
+    def test_unsafe_flag_values_match(self):
+        spec = {"unsafe_flag_values": {"-X": ["POST", "DELETE"]}}
+        self.assertIsNotNone(check_unsafe_flags(["-X", "POST"], spec))
+
+    def test_unsafe_flag_values_match_case_insensitive(self):
+        spec = {"unsafe_flag_values": {"-X": ["POST"]}}
+        self.assertIsNotNone(check_unsafe_flags(["-X", "post"], spec))
+
+    def test_unsafe_flag_values_no_match_for_get(self):
+        spec = {"unsafe_flag_values": {"-X": ["POST"]}}
+        self.assertIsNone(check_unsafe_flags(["-X", "GET"], spec))
+
+    def test_unsafe_flag_any_value_catches_d(self):
+        spec = {"unsafe_flag_any_value": ["-d", "--data"]}
+        self.assertIsNotNone(check_unsafe_flags(["-d", "foo=bar"], spec))
+
+    def test_unsafe_flag_without_value(self):
+        spec = {"unsafe_flags_without_value": ["-delete"]}
+        self.assertIsNotNone(check_unsafe_flags(["-delete"], spec))
+
+    def test_inline_equals_flag_value(self):
+        spec = {"unsafe_flag_values": {"--method": ["POST"]}}
+        self.assertIsNotNone(check_unsafe_flags(["--method=POST"], spec))
+
+    def test_none_of_the_above(self):
+        spec = {"unsafe_flag_values": {"-X": ["POST"]}}
+        self.assertIsNone(check_unsafe_flags(["--foo", "bar"], spec))
+
+
+class TestParseAwsPositionals(unittest.TestCase):
+    def test_simple(self):
+        svc, op, _ = parse_aws_positionals(["ec2", "describe-instances"])
+        self.assertEqual((svc, op), ("ec2", "describe-instances"))
+
+    def test_profile_and_region_stripped(self):
+        svc, op, _ = parse_aws_positionals([
+            "--profile", "prod",
+            "--region", "us-east-1",
+            "ec2", "describe-instances",
+            "--no-cli-pager",
+        ])
+        self.assertEqual((svc, op), ("ec2", "describe-instances"))
+
+    def test_no_cli_pager_is_valueless(self):
+        svc, op, _ = parse_aws_positionals(["--no-cli-pager", "s3", "ls"])
+        self.assertEqual((svc, op), ("s3", "ls"))
+
+
+class TestAggregateDecisions(unittest.TestCase):
+    def test_empty(self):
+        d, _ = aggregate_decisions([])
+        self.assertEqual(d, DECISION_SAFE)
+
+    def test_all_safe(self):
+        d, _ = aggregate_decisions([(DECISION_SAFE, "a"), (DECISION_SAFE, "b")])
+        self.assertEqual(d, DECISION_SAFE)
+
+    def test_any_unsafe_wins(self):
+        d, _ = aggregate_decisions([(DECISION_SAFE, "a"), (DECISION_UNSAFE, "b")])
+        self.assertEqual(d, DECISION_UNSAFE)
+
+    def test_unknown_over_safe_but_not_over_unsafe(self):
+        d, _ = aggregate_decisions([(DECISION_SAFE, "a"), (DECISION_UNKNOWN, "b")])
+        self.assertEqual(d, DECISION_UNKNOWN)
+        d, _ = aggregate_decisions([
+            (DECISION_UNKNOWN, "a"),
+            (DECISION_UNSAFE, "b"),
+        ])
+        self.assertEqual(d, DECISION_UNSAFE)
+
+
+class TestClassifyScenarios(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.clf = _make_classifier()
+
+    def assertDecision(self, command, expected):
+        decision, reason = self.clf.classify(command)
+        self.assertEqual(
+            decision, expected,
+            "{!r}: got {}, reason={}".format(command, decision, reason),
+        )
+
+    # --- Safe cases ---
+    def test_ls_safe(self):
+        self.assertDecision("ls /tmp", DECISION_SAFE)
+
+    def test_aws_describe(self):
+        self.assertDecision("aws ec2 describe-instances", DECISION_SAFE)
+
+    def test_aws_describe_with_profile_flags(self):
+        self.assertDecision(
+            "aws --profile prod --region us-east-1 ec2 describe-instances --no-cli-pager",
+            DECISION_SAFE,
+        )
+
+    def test_aws_s3_ls(self):
+        self.assertDecision("aws s3 ls", DECISION_SAFE)
+
+    def test_aws_logs_start_query_is_service_override_safe(self):
+        self.assertDecision(
+            'aws logs start-query --log-group-name X --query-string "fields @timestamp"',
+            DECISION_SAFE,
+        )
+
+    def test_compound_for_loop_all_reads(self):
+        self.assertDecision(
+            'for svc in $(aws ecs list-services --cluster X); do '
+            'aws ecs describe-services --cluster X --services "$svc"; '
+            "done",
+            DECISION_SAFE,
+        )
+
+    def test_gh_api_default_get(self):
+        self.assertDecision("gh api /repos/x/y/issues", DECISION_SAFE)
+
+    def test_curl_default_get(self):
+        self.assertDecision("curl https://api.example.com/users", DECISION_SAFE)
+
+    def test_kubectl_get_pods(self):
+        self.assertDecision("kubectl get pods -A", DECISION_SAFE)
+
+    def test_python3_c_inline_safe(self):
+        self.assertDecision('python3 -c "print(1+1)"', DECISION_SAFE)
+
+    def test_bash_c_inline_safe(self):
+        self.assertDecision('bash -c "ls /tmp"', DECISION_SAFE)
+
+    def test_time_wrapper(self):
+        self.assertDecision("time aws ec2 describe-instances", DECISION_SAFE)
+
+    def test_xargs_wraps_cat(self):
+        self.assertDecision("echo foo | xargs cat", DECISION_SAFE)
+
+    def test_redirect_to_dev_null_is_safe(self):
+        self.assertDecision(
+            "aws ec2 describe-instances > /dev/null", DECISION_SAFE
+        )
+
+    def test_stderr_to_dev_null_piped_to_jq_is_safe(self):
+        self.assertDecision(
+            "aws ec2 describe-instances 2>/dev/null | jq .",
+            DECISION_SAFE,
+        )
+
+    def test_git_status(self):
+        self.assertDecision("git status", DECISION_SAFE)
+
+    def test_terraform_plan(self):
+        self.assertDecision("terraform plan", DECISION_SAFE)
+
+    def test_terraform_state_list_nested(self):
+        self.assertDecision("terraform state list", DECISION_SAFE)
+
+    def test_find_without_delete(self):
+        self.assertDecision("find . -name '*.py'", DECISION_SAFE)
+
+    def test_sed_without_inplace(self):
+        self.assertDecision("sed 's/a/b/' file.txt", DECISION_SAFE)
+
+    def test_double_bracket_test(self):
+        self.assertDecision("[[ -d /tmp ]] && ls /tmp", DECISION_SAFE)
+
+    def test_single_bracket_test(self):
+        self.assertDecision("[ -d /tmp ] && ls /tmp", DECISION_SAFE)
+
+    def test_command_group_safe(self):
+        self.assertDecision("{ ls /tmp; echo done; }", DECISION_SAFE)
+
+    def test_env_var_prefix_then_safe(self):
+        self.assertDecision("FOO=bar BAZ=qux aws s3 ls", DECISION_SAFE)
+
+    def test_case_all_reads(self):
+        self.assertDecision(
+            'case "$x" in a) ls ;; b) cat /etc/passwd ;; esac',
+            DECISION_SAFE,
+        )
+
+    def test_if_then_safe_body(self):
+        self.assertDecision(
+            "if aws ec2 describe-instances; then echo ok; fi",
+            DECISION_SAFE,
+        )
+
+    # --- Unsafe cases ---
+    def test_rm_unsafe(self):
+        self.assertDecision("rm -rf /tmp/foo", DECISION_UNSAFE)
+
+    def test_aws_terminate_unsafe(self):
+        self.assertDecision(
+            "aws ec2 terminate-instances --instance-ids i-abc",
+            DECISION_UNSAFE,
+        )
+
+    def test_aws_s3_rm_unsafe(self):
+        self.assertDecision("aws s3 rm s3://bucket/key", DECISION_UNSAFE)
+
+    def test_gh_api_post_unsafe(self):
+        self.assertDecision(
+            "gh api -X POST /repos/x/y/issues", DECISION_UNSAFE
+        )
+
+    def test_gh_api_field_unsafe(self):
+        self.assertDecision(
+            "gh api /repos/x/y/issues -f title=bug", DECISION_UNSAFE
+        )
+
+    def test_curl_post_unsafe(self):
+        self.assertDecision(
+            "curl -X POST https://api.example.com/users -d bar",
+            DECISION_UNSAFE,
+        )
+
+    def test_curl_data_flag_unsafe(self):
+        self.assertDecision(
+            "curl --data foo=bar https://api.example.com/users",
+            DECISION_UNSAFE,
+        )
+
+    def test_kubectl_exec_unsafe(self):
+        self.assertDecision(
+            "kubectl exec -it pod -- bash", DECISION_UNSAFE
+        )
+
+    def test_git_push_unsafe(self):
+        self.assertDecision("git push origin main", DECISION_UNSAFE)
+
+    def test_terraform_apply_unsafe(self):
+        self.assertDecision("terraform apply", DECISION_UNSAFE)
+
+    def test_terraform_state_rm_unsafe(self):
+        self.assertDecision("terraform state rm foo.bar", DECISION_UNSAFE)
+
+    def test_find_delete_unsafe(self):
+        self.assertDecision("find . -name '*.py' -delete", DECISION_UNSAFE)
+
+    def test_sed_inplace_unsafe(self):
+        self.assertDecision("sed -i 's/a/b/' file.txt", DECISION_UNSAFE)
+
+    def test_python3_c_os_system_unsafe(self):
+        self.assertDecision(
+            'python3 -c "import os; os.system(\\"rm -rf /\\")"',
+            DECISION_UNSAFE,
+        )
+
+    def test_bash_c_rm_unsafe(self):
+        self.assertDecision('bash -c "rm -rf /etc"', DECISION_UNSAFE)
+
+    def test_xargs_wraps_rm_unsafe(self):
+        self.assertDecision("echo foo | xargs rm", DECISION_UNSAFE)
+
+    def test_compound_with_rm_unsafe(self):
+        self.assertDecision("ls /tmp && rm -rf /etc", DECISION_UNSAFE)
+
+    def test_case_has_rm_unsafe(self):
+        self.assertDecision(
+            'case "$x" in a) ls ;; b) rm /tmp/foo ;; esac',
+            DECISION_UNSAFE,
+        )
+
+    def test_negated_rm_still_unsafe(self):
+        self.assertDecision("! rm -rf /tmp/foo", DECISION_UNSAFE)
+
+    # --- Unknown fall-throughs ---
+    def test_unknown_command_is_unknown(self):
+        self.assertDecision(
+            "somecommand_unknown --flag", DECISION_UNKNOWN
+        )
+
+    def test_redirect_write_to_file_is_unknown(self):
+        self.assertDecision(
+            "aws ec2 describe-instances > out.json", DECISION_UNKNOWN
+        )
+
+    def test_echo_to_system_file_is_unknown(self):
+        # `echo` alone is safe, but the classifier must not allow
+        # `echo x > /etc/profile` to ride on that classification.
+        self.assertDecision("echo x > /etc/profile", DECISION_UNKNOWN)
+
+
+class TestClassifierCLI(unittest.TestCase):
+    """The shell_classifier.py module is also runnable as a standalone CLI."""
+
+    def _run_cli(self, command):
+        script = REPO_ROOT / "hooks" / "shell_classifier.py"
+        result = subprocess.run(
+            [sys.executable, str(script), command],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        retval = json.loads(result.stdout)
+        return retval
+
+    def test_cli_reports_safe(self):
+        out = self._run_cli("ls /tmp")
+        self.assertEqual(out["decision"], "safe")
+
+    def test_cli_reports_unsafe(self):
+        out = self._run_cli("rm -rf /tmp/foo")
+        self.assertEqual(out["decision"], "unsafe")
+
+    def test_cli_reports_unknown(self):
+        out = self._run_cli("somecommand_unknown --flag")
+        self.assertEqual(out["decision"], "unknown")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_shell_classifier.py
+++ b/tests/test_shell_classifier.py
@@ -25,7 +25,9 @@ from shell_classifier import (  # noqa: E402
     aggregate_decisions,
     check_unsafe_flags,
     extract_substitutions,
+    load_allow_patterns,
     load_shell_rules,
+    match_allow_patterns,
     parse_aws_positionals,
     split_top_level,
     strip_leading_keywords_and_assignments,
@@ -498,6 +500,181 @@ class TestClassifyScenarios(unittest.TestCase):
         # `echo` alone is safe, but the classifier must not allow
         # `echo x > /etc/profile` to ride on that classification.
         self.assertDecision("echo x > /etc/profile", DECISION_UNKNOWN)
+
+
+class TestLoadAllowPatterns(unittest.TestCase):
+    """`load_allow_patterns` reads Claude Code settings.json files and
+    returns the unwrapped Bash() inner patterns from `permissions.allow`."""
+
+    def setUp(self):
+        import tempfile
+        self._tmp = tempfile.mkdtemp(prefix="yolt-allow-")
+        self.tmp = Path(self._tmp)
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self._tmp, ignore_errors=True)
+
+    def _write(self, name, data):
+        path = self.tmp / name
+        path.write_text(json.dumps(data))
+        retval = path
+        return retval
+
+    def test_extracts_bash_inner_patterns(self):
+        path = self._write("settings.json", {
+            "permissions": {
+                "allow": [
+                    "Bash(aws s3 ls*)",
+                    "Bash(env)",
+                    "Read",
+                    "mcp__github__get_file_contents",
+                ]
+            }
+        })
+        patterns = load_allow_patterns([path])
+        self.assertEqual(patterns, ["aws s3 ls*", "env"])
+
+    def test_missing_file_skipped(self):
+        patterns = load_allow_patterns([self.tmp / "does-not-exist.json"])
+        self.assertEqual(patterns, [])
+
+    def test_malformed_json_skipped(self):
+        path = self.tmp / "broken.json"
+        path.write_text("{not json")
+        patterns = load_allow_patterns([path])
+        self.assertEqual(patterns, [])
+
+    def test_dedupes_across_files(self):
+        a = self._write("a.json", {
+            "permissions": {"allow": ["Bash(env)", "Bash(ls*)"]}
+        })
+        b = self._write("b.json", {
+            "permissions": {"allow": ["Bash(ls*)", "Bash(cat*)"]}
+        })
+        patterns = load_allow_patterns([a, b])
+        self.assertEqual(patterns, ["env", "ls*", "cat*"])
+
+    def test_no_permissions_key(self):
+        path = self._write("nop.json", {"env": {"FOO": "bar"}})
+        patterns = load_allow_patterns([path])
+        self.assertEqual(patterns, [])
+
+    def test_empty_inner_pattern_skipped(self):
+        path = self._write("empty.json", {
+            "permissions": {"allow": ["Bash()", "Bash(  )", "Bash(env)"]}
+        })
+        patterns = load_allow_patterns([path])
+        self.assertEqual(patterns, ["env"])
+
+    def test_non_string_entries_skipped(self):
+        path = self._write("mixed.json", {
+            "permissions": {"allow": ["Bash(env)", 42, None, ["Bash(x)"]]}
+        })
+        patterns = load_allow_patterns([path])
+        self.assertEqual(patterns, ["env"])
+
+
+class TestMatchAllowPatterns(unittest.TestCase):
+    def test_no_patterns_returns_none(self):
+        self.assertIsNone(match_allow_patterns("aws s3 ls", []))
+
+    def test_exact_match(self):
+        self.assertEqual(match_allow_patterns("env", ["env"]), "env")
+
+    def test_glob_prefix_match(self):
+        self.assertEqual(
+            match_allow_patterns("aws s3 ls --recursive s3://b/", ["aws s3 ls*"]),
+            "aws s3 ls*",
+        )
+
+    def test_glob_with_internal_wildcard(self):
+        self.assertEqual(
+            match_allow_patterns("aws iam list-roles", ["aws * list*"]),
+            "aws * list*",
+        )
+
+    def test_no_match_returns_none(self):
+        self.assertIsNone(
+            match_allow_patterns("rm -rf /", ["aws *", "ls*"]),
+        )
+
+    def test_strips_whitespace(self):
+        self.assertEqual(
+            match_allow_patterns("  env  ", ["env"]),
+            "env",
+        )
+
+
+class TestClassifierAllowPatterns(unittest.TestCase):
+    """The classifier upgrades `unknown` segments to `safe` when they match
+    a user allow pattern, but never weakens `unsafe`."""
+
+    def _make(self, allow_patterns):
+        shell_rules = load_shell_rules(REPO_ROOT / "rules")
+        py_rules = load_py_rules(REPO_ROOT / "rules")
+
+        def _factory():
+            retval = SafetyAnalyzer(py_rules)
+            return retval
+
+        retval = ShellClassifier(
+            shell_rules,
+            python_analyzer_factory=_factory,
+            allow_patterns=allow_patterns,
+        )
+        return retval
+
+    def test_unknown_command_upgraded_to_safe(self):
+        classifier = self._make(["mycli *"])
+        decision, reason = classifier.classify("mycli foo --bar")
+        self.assertEqual(decision, DECISION_SAFE)
+        self.assertIn("mycli *", reason)
+
+    def test_unknown_aws_op_upgraded(self):
+        # An aws operation the rules don't know about, but the user trusts.
+        classifier = self._make(["aws * weird-op*"])
+        decision, _ = classifier.classify("aws ec2 weird-op --flag")
+        self.assertEqual(decision, DECISION_SAFE)
+
+    def test_unsafe_not_weakened_by_allowlist(self):
+        # Even a permissive `Bash(aws *)` does not turn `aws iam delete-user`
+        # into safe - YOLT keeps flagging mutating calls.
+        classifier = self._make(["aws *"])
+        decision, _ = classifier.classify("aws iam delete-user --user-name foo")
+        self.assertEqual(decision, DECISION_UNSAFE)
+
+    def test_unsafe_in_compound_not_weakened(self):
+        classifier = self._make(["aws *", "rm *"])
+        decision, _ = classifier.classify("aws s3 ls && rm -rf /etc")
+        self.assertEqual(decision, DECISION_UNSAFE)
+
+    def test_no_allowlist_match_stays_unknown(self):
+        classifier = self._make(["aws *"])
+        decision, _ = classifier.classify("somecommand_unknown")
+        self.assertEqual(decision, DECISION_UNKNOWN)
+
+    def test_decomposed_atoms_match_allowlist(self):
+        # Outer command would not match `Bash(aws s3 ls*)` because of the
+        # `for` wrapper - this is the case where YOLT's decomposition
+        # plus allowlist upgrade earns its keep.
+        classifier = self._make(["aws s3 ls*"])
+        decision, _ = classifier.classify(
+            "for b in foo bar; do aws s3 ls s3://$b/; done"
+        )
+        self.assertEqual(decision, DECISION_SAFE)
+
+    def test_writes_to_file_upgraded_when_allowlisted(self):
+        # `echo x > /etc/profile` is unknown by default (writes_to_file).
+        # If user has Bash(echo *), allowlist upgrades to safe.
+        classifier = self._make(["echo *"])
+        decision, _ = classifier.classify("echo x > /etc/profile")
+        self.assertEqual(decision, DECISION_SAFE)
+
+    def test_empty_allow_patterns_unchanged_behavior(self):
+        classifier = self._make([])
+        decision, _ = classifier.classify("somecommand_unknown")
+        self.assertEqual(decision, DECISION_UNKNOWN)
 
 
 class TestClassifierCLI(unittest.TestCase):

--- a/tests/test_shell_classifier.py
+++ b/tests/test_shell_classifier.py
@@ -29,6 +29,7 @@ from shell_classifier import (  # noqa: E402
     load_shell_rules,
     match_allow_patterns,
     parse_aws_positionals,
+    preprocess_shell_source,
     split_top_level,
     strip_leading_keywords_and_assignments,
     strip_redirections,
@@ -56,6 +57,180 @@ KEYWORDS = {
     "function", "time", "coproc",
     "!", "{", "}", "(", ")",
 }
+
+
+class TestPreprocessShellSource(unittest.TestCase):
+    def test_no_continuation_no_change(self):
+        self.assertEqual(
+            preprocess_shell_source("ls /tmp"),
+            "ls /tmp",
+        )
+
+    def test_backslash_newline_removed(self):
+        # POSIX: `\<LF>` is removed entirely. The space before `\` stays,
+        # so this collapses to one space + the next line's two leading
+        # spaces, totalling three.
+        self.assertEqual(
+            preprocess_shell_source("aws ec2 describe-instances \\\n  --foo"),
+            "aws ec2 describe-instances   --foo",
+        )
+
+    def test_continuation_inside_double_quotes(self):
+        # Inside double quotes the `\<LF>` is also removed; the space
+        # before the backslash stays.
+        out = preprocess_shell_source('echo "abc \\\ndef"')
+        self.assertEqual(out, 'echo "abc def"')
+
+    def test_continuation_inside_single_quotes_literal(self):
+        # Inside single quotes nothing is interpreted.
+        src = "echo 'abc \\\ndef'"
+        self.assertEqual(preprocess_shell_source(src), src)
+
+    def test_standalone_comment_dropped(self):
+        self.assertEqual(
+            preprocess_shell_source("# this is a comment\nls"),
+            "\nls",
+        )
+
+    def test_tail_comment_dropped(self):
+        self.assertEqual(
+            preprocess_shell_source("ls /tmp # explain"),
+            "ls /tmp ",
+        )
+
+    def test_hash_inside_double_quotes_literal(self):
+        self.assertEqual(
+            preprocess_shell_source('echo "#hashtag"'),
+            'echo "#hashtag"',
+        )
+
+    def test_hash_inside_single_quotes_literal(self):
+        self.assertEqual(
+            preprocess_shell_source("echo '#hashtag'"),
+            "echo '#hashtag'",
+        )
+
+    def test_hash_glued_to_word_not_comment(self):
+        # `a#b` is one token, not `a` + comment.
+        self.assertEqual(
+            preprocess_shell_source("echo a#b"),
+            "echo a#b",
+        )
+
+    def test_multiple_continuations(self):
+        cmd = "aws ec2 describe-instances \\\n  --foo bar \\\n  --baz"
+        # Same accounting as the single-continuation case for each
+        # `\<LF>` removed: trailing space + two leading spaces = three.
+        self.assertEqual(
+            preprocess_shell_source(cmd),
+            "aws ec2 describe-instances   --foo bar   --baz",
+        )
+
+
+class TestClassifierMultilineHandling(unittest.TestCase):
+    """Real-world transcript shapes: multi-line scripts with backslash
+    continuations and inline comments that the classifier has to bring
+    back into one logical command before splitting on top-level
+    operators."""
+
+    def setUp(self):
+        self.classifier = _make_classifier()
+
+    def assertDecision(self, cmd, expected):
+        d, _ = self.classifier.classify(cmd)
+        self.assertEqual(d, expected, msg="cmd={!r}".format(cmd))
+
+    def test_multi_line_aws_describe(self):
+        cmd = (
+            "aws cloudwatch get-metric-statistics \\\n"
+            "  --no-cli-pager \\\n"
+            '  --namespace "bidder/prod" \\\n'
+            '  --metric-name "app.render_b" \\\n'
+            "  --start-time 2026-05-01T00:00:00Z"
+        )
+        self.assertDecision(cmd, DECISION_SAFE)
+
+    def test_echo_header_then_aws_describe(self):
+        cmd = (
+            'echo "=== ECR images ==="\n'
+            "aws ec2 describe-instances --no-cli-pager"
+        )
+        self.assertDecision(cmd, DECISION_SAFE)
+
+    def test_inline_comment_dropped(self):
+        self.assertDecision("ls /tmp # show contents", DECISION_SAFE)
+
+    def test_standalone_comment_safe(self):
+        self.assertDecision("# nothing to do", DECISION_SAFE)
+
+
+class TestValuelessGlobalFlags(unittest.TestCase):
+    """Top-level CLI flags that don't take a value (`git --no-pager`,
+    ...) used to consume the subcommand as their value, hiding `log` /
+    `status` from the subcommand classifier."""
+
+    def setUp(self):
+        self.classifier = _make_classifier()
+
+    def assertDecision(self, cmd, expected):
+        d, _ = self.classifier.classify(cmd)
+        self.assertEqual(d, expected, msg="cmd={!r}".format(cmd))
+
+    def test_git_no_pager_log(self):
+        self.assertDecision("git --no-pager log --oneline", DECISION_SAFE)
+
+    def test_git_no_pager_status(self):
+        self.assertDecision("git --no-pager status", DECISION_SAFE)
+
+    def test_git_no_pager_diff(self):
+        self.assertDecision("git --no-pager diff main", DECISION_SAFE)
+
+    def test_git_no_pager_push_unsafe(self):
+        self.assertDecision("git --no-pager push origin main", DECISION_UNSAFE)
+
+    def test_git_dash_C_with_value(self):
+        # -C does take a value (working directory), so the heuristic
+        # should still consume it correctly.
+        self.assertDecision("git -C /tmp/repo log --oneline", DECISION_SAFE)
+
+    def test_gh_no_pager_run_list(self):
+        self.assertDecision("gh --no-pager run list --repo foo", DECISION_SAFE)
+
+    def test_gh_no_pager_pr_list(self):
+        self.assertDecision("gh --no-pager pr list", DECISION_SAFE)
+
+
+class TestPythonHeredocViaClassifier(unittest.TestCase):
+    """The classifier handles `python3 <<EOF ... EOF` heredocs by
+    delegating the body to the Python analyzer factory. In hook flow
+    yolt_analyzer.run_hook already routes heredocs early; this is the
+    standalone-classifier path used by the CLI scan."""
+
+    def setUp(self):
+        self.classifier = _make_classifier()
+
+    def test_safe_heredoc(self):
+        cmd = "python3 << 'EOF'\nimport json\nprint(json.dumps({'ok': True}))\nEOF"
+        d, r = self.classifier.classify(cmd)
+        self.assertEqual(d, DECISION_SAFE)
+
+    def test_destructive_heredoc(self):
+        cmd = "python3 << EOF\nimport os\nos.system('rm -rf /tmp/x')\nEOF"
+        d, r = self.classifier.classify(cmd)
+        self.assertEqual(d, DECISION_UNSAFE)
+
+    def test_python3_dash_stdin_form(self):
+        # `python3 - <<'EOF'` reads from stdin; same heredoc rules apply.
+        cmd = "python3 - <<'EOF'\nprint(1)\nEOF"
+        d, r = self.classifier.classify(cmd)
+        self.assertEqual(d, DECISION_SAFE)
+
+
+class TestUnsetBuiltin(unittest.TestCase):
+    def test_unset_is_safe(self):
+        c = _make_classifier()
+        d, _ = c.classify("unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY")
+        self.assertEqual(d, DECISION_SAFE)
 
 
 class TestExtractSubstitutions(unittest.TestCase):
@@ -129,6 +304,33 @@ class TestSplitTopLevel(unittest.TestCase):
     def test_double_semicolon_collapses(self):
         # Case-arm ;; produces an empty segment which is filtered out.
         self.assertEqual(split_top_level("ls ;; pwd"), ["ls", "pwd"])
+
+    def test_fd_dup_2_to_1_not_split(self):
+        # `2>&1` is a file-descriptor duplication, not a `2>` followed by
+        # the `&` background operator and a `1` segment.
+        self.assertEqual(
+            split_top_level("gh pr list 2>&1"),
+            ["gh pr list 2>&1"],
+        )
+
+    def test_fd_dup_followed_by_pipe_still_splits(self):
+        self.assertEqual(
+            split_top_level("aws ec2 describe-instances 2>&1 | head"),
+            ["aws ec2 describe-instances 2>&1", "head"],
+        )
+
+    def test_redirect_to_stderr_not_split(self):
+        # `>&2` is also FD duplication.
+        self.assertEqual(
+            split_top_level("echo hi >&2"),
+            ["echo hi >&2"],
+        )
+
+    def test_trailing_background_ampersand_still_splits(self):
+        self.assertEqual(
+            split_top_level("sleep 5 & pwd"),
+            ["sleep 5", "pwd"],
+        )
 
 
 class TestStripRedirections(unittest.TestCase):

--- a/tests/test_yolt_hook.py
+++ b/tests/test_yolt_hook.py
@@ -237,5 +237,50 @@ class TestHookEndToEnd(unittest.TestCase):
         self.assertIn("os.system", reason)
 
 
+class TestHookAllowlistDiscovery(unittest.TestCase):
+    """The hook reads the user's settings.json `permissions.allow` Bash()
+    entries and uses them as a secondary upgrade pass for unknown atoms.
+    Tests scope the lookup via the `cwd` field in the hook payload so
+    they don't depend on the real test runner's home directory."""
+
+    def setUp(self):
+        self._tmp = tempfile.mkdtemp(prefix="yolt-hook-cwd-")
+        self.cwd = Path(self._tmp)
+        (self.cwd / ".claude").mkdir()
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self._tmp, ignore_errors=True)
+
+    def _write_settings(self, allow):
+        path = self.cwd / ".claude" / "settings.json"
+        path.write_text(json.dumps({"permissions": {"allow": allow}}))
+
+    def _decision(self, command):
+        result = HookSubprocess.run({
+            "tool_name": "Bash",
+            "tool_input": {"command": command},
+            "cwd": str(self.cwd),
+        })
+        resp = HookSubprocess.response_of(result)
+        if resp is None:
+            retval = None
+            return retval
+        retval = resp["hookSpecificOutput"]["permissionDecision"]
+        return retval
+
+    def test_unknown_atom_upgraded_via_cwd_settings(self):
+        self._write_settings(["Bash(yolt_test_mycli *)"])
+        self.assertEqual(self._decision("yolt_test_mycli foo bar"), "allow")
+
+    def test_unknown_atom_without_match_stays_silent(self):
+        self._write_settings(["Bash(yolt_test_othertool *)"])
+        self.assertIsNone(self._decision("yolt_test_mycli foo bar"))
+
+    def test_allowlist_does_not_override_unsafe(self):
+        self._write_settings(["Bash(rm *)"])
+        self.assertEqual(self._decision("rm -rf /tmp/foo"), "ask")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_yolt_hook.py
+++ b/tests/test_yolt_hook.py
@@ -1,0 +1,241 @@
+"""End-to-end tests for the PreToolUse hook entry point.
+
+Invokes `python3 hooks/yolt_analyzer.py --hook` as a subprocess, feeding a
+simulated Claude Code hook payload on stdin, and asserts on the JSON
+response emitted on stdout.
+
+Runs with stdlib unittest only:
+
+    python3 -m unittest discover -v tests
+"""
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+HOOKS_DIR = REPO_ROOT / "hooks"
+sys.path.insert(0, str(HOOKS_DIR))
+
+from yolt_analyzer import (  # noqa: E402
+    extract_heredoc_script,
+    extract_script_from_command,
+)
+
+
+class TestHeredocExtraction(unittest.TestCase):
+    def test_simple_heredoc(self):
+        cmd = "python3 <<EOF\nprint(1)\nEOF\n"
+        self.assertEqual(extract_heredoc_script(cmd), "print(1)\n")
+
+    def test_single_quoted_delimiter(self):
+        cmd = "python3 <<'EOF'\nprint(1)\nEOF\n"
+        self.assertEqual(extract_heredoc_script(cmd), "print(1)\n")
+
+    def test_double_quoted_delimiter(self):
+        cmd = 'python3 <<"EOF"\nprint(1)\nEOF\n'
+        self.assertEqual(extract_heredoc_script(cmd), "print(1)\n")
+
+    def test_tab_strip_form(self):
+        cmd = "python3 <<-EOF\nprint(1)\nEOF\n"
+        self.assertEqual(extract_heredoc_script(cmd), "print(1)\n")
+
+    def test_no_heredoc(self):
+        self.assertIsNone(extract_heredoc_script("python3 script.py"))
+
+
+class TestExtractScriptFromCommand(unittest.TestCase):
+    def test_dash_c_inline(self):
+        kind, src = extract_script_from_command('python3 -c "print(1)"')
+        self.assertEqual((kind, src), ("inline", "print(1)"))
+
+    def test_heredoc_inline(self):
+        kind, src = extract_script_from_command(
+            "python3 <<EOF\nprint(1)\nEOF\n"
+        )
+        self.assertEqual(kind, "inline")
+        self.assertIn("print(1)", src)
+
+    def test_file_path(self):
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".py", delete=False
+        ) as f:
+            f.write("print(1)\n")
+            path = f.name
+        try:
+            kind, src = extract_script_from_command("python3 {}".format(path))
+            self.assertEqual((kind, src), ("file", path))
+        finally:
+            os.unlink(path)
+
+
+class HookSubprocess:
+    """Helper to invoke yolt_analyzer.py --hook and parse the response."""
+
+    @staticmethod
+    def run(payload):
+        result = subprocess.run(
+            [sys.executable, str(HOOKS_DIR / "yolt_analyzer.py"), "--hook"],
+            input=json.dumps(payload),
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        return result
+
+    @staticmethod
+    def run_bash(command):
+        retval = HookSubprocess.run({
+            "tool_name": "Bash",
+            "tool_input": {"command": command},
+        })
+        return retval
+
+    @staticmethod
+    def response_of(result):
+        """Parse the hook's JSON response, or return None for silent exits."""
+        stdout = result.stdout.strip()
+        if not stdout:
+            retval = None
+            return retval
+        last_line = stdout.splitlines()[-1]
+        retval = json.loads(last_line)
+        return retval
+
+
+class TestHookEndToEnd(unittest.TestCase):
+    def _decision(self, command):
+        result = HookSubprocess.run_bash(command)
+        resp = HookSubprocess.response_of(result)
+        if resp is None:
+            retval = None
+            return retval
+        retval = resp["hookSpecificOutput"]["permissionDecision"]
+        return retval
+
+    def test_safe_ls_returns_allow(self):
+        self.assertEqual(self._decision("ls /tmp"), "allow")
+
+    def test_aws_describe_returns_allow(self):
+        self.assertEqual(
+            self._decision("aws ec2 describe-instances"), "allow"
+        )
+
+    def test_unsafe_rm_returns_ask(self):
+        self.assertEqual(self._decision("rm -rf /tmp/foo"), "ask")
+
+    def test_gh_api_post_returns_ask(self):
+        self.assertEqual(
+            self._decision("gh api -X POST /repos/x/y/issues"), "ask"
+        )
+
+    def test_unknown_command_exits_silently(self):
+        # `None` means the hook produced no output; Claude Code then applies
+        # its default (prompt the user).
+        self.assertIsNone(self._decision("somecommand_unknown --flag"))
+
+    def test_redirect_to_system_file_exits_silently(self):
+        self.assertIsNone(self._decision("echo x > /etc/profile"))
+
+    def test_compound_aws_loop_returns_allow(self):
+        cmd = (
+            'for svc in $(aws ecs list-services --cluster X); do '
+            'aws ecs describe-services --cluster X --services "$svc"; '
+            "done"
+        )
+        self.assertEqual(self._decision(cmd), "allow")
+
+    def test_python3_dash_c_safe_returns_allow(self):
+        self.assertEqual(
+            self._decision('python3 -c "print(1+1)"'), "allow"
+        )
+
+    def test_python3_dash_c_destructive_returns_ask(self):
+        self.assertEqual(
+            self._decision(
+                'python3 -c "import os; os.system(\\"rm -rf /tmp/x\\")"'
+            ),
+            "ask",
+        )
+
+    def test_heredoc_safe_returns_allow(self):
+        cmd = 'python3 <<EOF\nimport os\nprint(os.listdir("/tmp"))\nEOF\n'
+        self.assertEqual(self._decision(cmd), "allow")
+
+    def test_heredoc_destructive_returns_ask(self):
+        cmd = 'python3 <<EOF\nimport os\nos.system("rm -rf /tmp/x")\nEOF\n'
+        self.assertEqual(self._decision(cmd), "ask")
+
+    def test_python3_script_file_safe_returns_allow(self):
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".py", delete=False
+        ) as f:
+            f.write("import json\nprint(json.dumps({'ok': True}))\n")
+            path = f.name
+        try:
+            self.assertEqual(
+                self._decision("python3 {}".format(path)), "allow"
+            )
+        finally:
+            os.unlink(path)
+
+    def test_python3_script_file_destructive_returns_ask(self):
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".py", delete=False
+        ) as f:
+            f.write("import os\nos.system('rm -rf /tmp/x')\n")
+            path = f.name
+        try:
+            self.assertEqual(
+                self._decision("python3 {}".format(path)), "ask"
+            )
+        finally:
+            os.unlink(path)
+
+    def test_non_bash_tool_exits_silently(self):
+        result = HookSubprocess.run({
+            "tool_name": "Read",
+            "tool_input": {"file_path": "/tmp/foo"},
+        })
+        self.assertEqual(result.stdout.strip(), "")
+        self.assertEqual(result.returncode, 0)
+
+    def test_empty_command_exits_silently(self):
+        result = HookSubprocess.run_bash("")
+        self.assertEqual(result.stdout.strip(), "")
+        self.assertEqual(result.returncode, 0)
+
+    def test_malformed_stdin_exits_silently(self):
+        result = subprocess.run(
+            [sys.executable, str(HOOKS_DIR / "yolt_analyzer.py"), "--hook"],
+            input="not valid json",
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        self.assertEqual(result.stdout.strip(), "")
+        self.assertEqual(result.returncode, 0)
+
+    def test_response_reason_includes_detail(self):
+        result = HookSubprocess.run_bash("rm -rf /tmp/foo")
+        resp = HookSubprocess.response_of(result)
+        self.assertIsNotNone(resp)
+        reason = resp["hookSpecificOutput"]["permissionDecisionReason"]
+        self.assertIn("rm", reason)
+
+    def test_heredoc_destructive_reason_includes_line_number(self):
+        cmd = 'python3 <<EOF\nimport os\nos.system("rm -rf /tmp/x")\nEOF\n'
+        result = HookSubprocess.run_bash(cmd)
+        resp = HookSubprocess.response_of(result)
+        self.assertIsNotNone(resp)
+        reason = resp["hookSpecificOutput"]["permissionDecisionReason"]
+        self.assertIn("Line 2", reason)
+        self.assertIn("os.system", reason)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #1.

## Summary

Closes the two gaps in Claude Code's built-in allowlist matcher that
issue #1 calls out:

1. **Dual-use wrappers and interpreters.** `python3 *`, `bash *`, `gh api *`,
   `curl *`, `kubectl exec *`, and friends can't be allowlisted with a
   wildcard without granting arbitrary execution, so benign read-only
   invocations prompt every time.
2. **Compound shell forms.** `for VAR in $(cmd); do ... done`, `cmd1 && cmd2`,
   `$(cmd1)`, `bash -c "cmd"`, `xargs cmd`, etc. match only the outer
   token, so loops and substitutions prompt even when every inner command
   is allowlisted individually.

## What's new

### `hooks/shell_classifier.py`

- Decomposes `$(...)` and backtick substitutions (respects quoting and
  handles nesting).
- Splits on top-level `;`, `&&`, `||`, `|`, `&`, newlines.
- Strips leading shell keywords (`for VAR in`, `while`, `if`, `case WORD in`,
  `do`, `done`, ...), `VAR=val` assignments, redirections.
- Classifies each simple command against `rules/shell.json`:
  - safe shell builtins (`echo`, `pwd`, `test`, `[`, `cd`, ...),
  - known tools with subcommands (`gh`, `kubectl`, `git`, `docker`,
    `terraform` with nested `state` / `workspace`, `npm`, `pip`, `brew`, ...),
  - AWS CLI with global `describe-*` / `list-*` / `get-*` / `head-*` allow
    and service-specific overrides for `s3` and `logs` (`start-query` is
    read-only despite the `start-` prefix),
  - dual-use tools with unsafe-flag rules: `gh api -X POST|PUT|PATCH|DELETE`,
    `gh api --field / -F / -f`, `curl -X POST|PUT|PATCH|DELETE`,
    `curl -d / --data / -T`, `find -delete / -exec`, `sed -i`,
  - interpreters: `python3 -c '...'` and `python3 script.py` delegate to
    the existing Python analyzer; `bash -c '...'` recurses into the shell
    classifier,
  - wrapper commands (`time`, `xargs`, `timeout`, `env VAR=val cmd`,
    `nohup`, `nice`, `watch`, `parallel`) re-classify whatever they wrap.
- Aggregates decisions with precedence `unsafe > unknown > safe`.
- Output redirection to anything other than `/dev/null` / `/dev/stdout` /
  `/dev/stderr` pins the decision to `unknown` so `echo x > /etc/profile`
  doesn't ride on `echo`'s safe classification.

### `hooks/yolt_analyzer.py`

- `run_hook` now dispatches every Bash invocation through the shell
  classifier (previously only `python3 ...` was analyzed).
- Heredoc `python3 <<EOF ... EOF` is intercepted before shell
  decomposition, since splitting on newlines would otherwise scatter the
  heredoc body.
- Fallback path keeps the old python3-only behavior if
  `shell_classifier.py` can't be imported.

### `rules/shell.json`

The default rule set. Rules are data, not code; the shapes are
`default: "safe" | "unsafe" | "subcommand" | "delegate_to_argument" | "aws_cli" | "gcloud_cli" | "az_cli"`,
with optional `unsafe_flag_values` / `unsafe_flag_any_value` /
`unsafe_flags_without_value` / `safe_subcommands` / `unsafe_subcommands`
/ `safe_subcommand_patterns` / `unsafe_subcommand_patterns` /
`nested_subcommand` keys.

### `examples/shell-overrides.json`

Example `~/.claude/yolt/shell.json` showing how to add a custom command,
extend safe patterns for a specific AWS service, and register a personal
safe builtin.

## Test plan

Manually verified (shell classifier CLI + hook stdin simulation):

- [x] `aws ec2 describe-instances` -> allow
- [x] `aws ec2 terminate-instances --instance-ids i-abc` -> ask
- [x] `aws --profile prod --region us-east-1 ec2 describe-instances --no-cli-pager` -> allow (flag-skipping)
- [x] `aws s3 ls` -> allow; `aws s3 rm s3://bucket/key` -> ask
- [x] `aws logs start-query --log-group-name X ...` -> allow (service override)
- [x] `gh api /repos/x/y/issues` -> allow
- [x] `gh api -X POST /repos/x/y/issues` -> ask
- [x] `curl https://api.example.com` -> allow; `curl -X POST ... -d ...` -> ask
- [x] `kubectl get pods` -> allow; `kubectl exec ... -- bash` -> ask
- [x] `terraform plan` / `terraform state list` -> allow; `terraform apply` / `terraform state rm` -> ask
- [x] `git status` -> allow; `git push origin main` -> ask
- [x] `find . -name '*.py'` -> allow; `find . -name '*.py' -delete` -> ask
- [x] `sed 's/a/b/' f` -> allow; `sed -i 's/a/b/' f` -> ask
- [x] `python3 -c "print(1+1)"` -> allow
- [x] `python3 -c "import os; os.system('rm -rf /')"` -> ask
- [x] `bash -c "ls /tmp"` -> allow; `bash -c "rm /etc/passwd"` -> ask
- [x] `for svc in $(aws ecs list-services --cluster X); do aws ecs describe-services --cluster X --services "$svc"; done` -> allow
- [x] `case "$x" in a) ls ;; b) rm /tmp/foo ;; esac` -> ask
- [x] `[[ -d /tmp ]] && ls /tmp` / `[ -d /tmp ] && ls /tmp` / `{ ls; echo done; }` / `! rm -rf /tmp/foo` -> correct
- [x] `echo foo | xargs rm` -> ask; `echo foo | xargs cat` -> allow
- [x] `time aws ec2 describe-instances` -> allow
- [x] `aws ec2 describe-instances > out.json` -> unknown; `... > /dev/null` -> allow
- [x] `python3 <<EOF\nimport os\nos.system("rm -rf /tmp/x")\nEOF` -> ask (heredoc)
- [x] `python3 script.py` with `os.system(...)` in file -> ask
- [x] Unknown command (`somecommand --flag`) -> silent exit, Claude Code falls through
