### PR TITLE
Fix marketplace.json source path

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "yolt",
-      "source": ".",
+      "source": "./",
       "description": "Static safety analyzer for Bash invocations - auto-allows read-only commands and prompts for mutating ones."
     }
   ]


### PR DESCRIPTION
## Summary
- Fix `source` field in marketplace.json from `"."` to `"./"` — relative plugin source paths must start with `./` per the Claude Code plugin schema
- Without this fix, `/plugin marketplace add voitta-ai/voitta-yolt` fails with "Invalid schema: plugins.0.source: Invalid input"

## Test plan
- [ ] Run `/plugin marketplace add voitta-ai/voitta-yolt` and verify no schema error
- [ ] Run `/plugin install yolt@voitta-yolt` and verify plugin installs

🤖 Generated with [Claude Code](https://claude.com/claude-code)