### PR TITLE
Add YOLT_LOG_FILE for dogfood / QA visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,32 @@ won't false-positive.
 User overrides merge with (and override) defaults per top-level key.
 Examples: `examples/user-overrides.json`, `examples/shell-overrides.json`.
 
+## Debug / dogfood log
+
+Set `YOLT_LOG_FILE` and the hook appends one JSON line per Bash
+invocation it examines, regardless of the eventual decision:
+
+```bash
+export YOLT_LOG_FILE="$HOME/.claude/yolt.log"
+# Open a Claude Code session that inherits this env var.
+tail -f "$YOLT_LOG_FILE"
+```
+
+Each record:
+
+```json
+{"ts": "2026-05-08T14:00:00.000+00:00", "decision": "safe", "reason": "ls: read-only", "command": "ls /tmp"}
+```
+
+`decision` is one of `safe`, `unsafe`, `unknown`, or `import-error` (when
+the tree-sitter dependency is missing). The `command` field is truncated
+to 500 characters. Logging failures are swallowed — the hook never
+breaks the session because of an unwritable log path.
+
+This is the cleanest way to QA YOLT against your own session: the
+Claude Code UI hides the hook's contribution when your `permissions.allow`
+already covers the command, but the log records every fire.
+
 ## CLI usage
 
 Analyze a Python script directly:

--- a/hooks/yolt_analyzer.py
+++ b/hooks/yolt_analyzer.py
@@ -8,6 +8,7 @@ Zero external dependencies - stdlib only.
 """
 
 import ast
+import datetime
 import json
 import os
 import sys
@@ -220,6 +221,35 @@ def make_hook_response(decision, reason=None):
     return output
 
 
+def _log_hook_decision(command, decision, reason):
+    """Append a JSON-line record of this hook fire to $YOLT_LOG_FILE if set.
+
+    Useful for dogfooding / QA: a user opens a fresh Claude Code session
+    with `YOLT_LOG_FILE=~/.claude/yolt.log` exported, runs commands as
+    normal, and tails the log to see exactly which decision YOLT made on
+    every Bash invocation — even when the user's `permissions.allow`
+    short-circuits the hook display in the Claude Code UI.
+
+    Failures (unwritable path, full disk) are swallowed: logging must
+    never break the hook. The Bash command is truncated to 500 chars to
+    avoid pathologically long lines.
+    """
+    log_path = os.environ.get("YOLT_LOG_FILE")
+    if not log_path:
+        return
+    try:
+        record = {
+            "ts": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+            "decision": decision,
+            "reason": reason,
+            "command": command[:500] if command else "",
+        }
+        with open(log_path, "a") as f:
+            f.write(json.dumps(record) + "\n")
+    except OSError:
+        pass
+
+
 def run_hook():
     """Run as a Claude Code PreToolUse hook.
 
@@ -237,6 +267,9 @@ def run_hook():
     If tree-sitter-bash is not importable on the host (broken install,
     unsupported platform), exit silently so Claude Code falls through to
     its default prompt rather than failing the hook.
+
+    When `YOLT_LOG_FILE` is set, every examined Bash invocation appends
+    a JSON-line record there — including the silent-fallthrough cases.
     """
     try:
         hook_input = json.load(sys.stdin)
@@ -266,9 +299,8 @@ def run_hook():
             DECISION_SAFE, DECISION_UNSAFE,
             load_allow_patterns, load_shell_rules,
         )
-    except ImportError:
-        # Most likely tree-sitter-bash isn't installed. Stay silent so
-        # Claude Code falls through to its default prompt.
+    except ImportError as e:
+        _log_hook_decision(command, "import-error", str(e))
         sys.exit(0)
 
     shell_rules = load_shell_rules(
@@ -293,6 +325,7 @@ def run_hook():
         allow_patterns=allow_patterns,
     )
     decision, reason = classifier.classify(command)
+    _log_hook_decision(command, decision, reason)
 
     if decision == DECISION_SAFE:
         response = make_hook_response("allow", "YOLT: {}".format(reason))

--- a/tests/test_yolt_hook.py
+++ b/tests/test_yolt_hook.py
@@ -232,5 +232,121 @@ class TestHookAllowlistDiscovery(unittest.TestCase):
         self.assertEqual(self._decision("rm -rf /tmp/foo"), "ask")
 
 
+class TestHookLogFile(unittest.TestCase):
+    """When YOLT_LOG_FILE is set, the hook appends a JSON-line record per
+    Bash invocation regardless of the eventual decision. Used for
+    dogfooding and QA visibility."""
+
+    def setUp(self):
+        self._tmp = tempfile.mkdtemp(prefix="yolt-log-")
+        self.tmp = Path(self._tmp)
+        self.log_path = self.tmp / "yolt.log"
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self._tmp, ignore_errors=True)
+
+    def _run_with_log(self, command):
+        env = dict(os.environ)
+        env["YOLT_LOG_FILE"] = str(self.log_path)
+        subprocess.run(
+            [sys.executable, str(HOOKS_DIR / "yolt_analyzer.py"), "--hook"],
+            input=json.dumps({
+                "tool_name": "Bash",
+                "tool_input": {"command": command},
+            }),
+            capture_output=True,
+            text=True,
+            timeout=30,
+            env=env,
+        )
+
+    def _records(self):
+        if not self.log_path.exists():
+            return []
+        retval = []
+        for line in self.log_path.read_text().splitlines():
+            line = line.strip()
+            if line:
+                retval.append(json.loads(line))
+        return retval
+
+    def test_logs_safe_decision(self):
+        self._run_with_log("ls /tmp")
+        recs = self._records()
+        self.assertEqual(len(recs), 1)
+        self.assertEqual(recs[0]["decision"], "safe")
+        self.assertEqual(recs[0]["command"], "ls /tmp")
+        self.assertIn("ts", recs[0])
+        self.assertIn("ls", recs[0]["reason"])
+
+    def test_logs_unsafe_decision(self):
+        self._run_with_log("rm -rf /tmp/foo")
+        recs = self._records()
+        self.assertEqual(len(recs), 1)
+        self.assertEqual(recs[0]["decision"], "unsafe")
+        self.assertEqual(recs[0]["command"], "rm -rf /tmp/foo")
+
+    def test_logs_unknown_decision(self):
+        self._run_with_log("somecommand_unknown_xyz --flag")
+        recs = self._records()
+        self.assertEqual(len(recs), 1)
+        self.assertEqual(recs[0]["decision"], "unknown")
+
+    def test_appends_across_invocations(self):
+        self._run_with_log("ls /tmp")
+        self._run_with_log("rm -rf /tmp/foo")
+        self._run_with_log("git status")
+        recs = self._records()
+        self.assertEqual(len(recs), 3)
+        decisions = [r["decision"] for r in recs]
+        self.assertEqual(decisions, ["safe", "unsafe", "safe"])
+
+    def test_long_command_is_truncated(self):
+        long_cmd = "echo " + ("x" * 1000)
+        self._run_with_log(long_cmd)
+        recs = self._records()
+        self.assertEqual(len(recs), 1)
+        self.assertLessEqual(len(recs[0]["command"]), 500)
+
+    def test_no_log_file_when_env_unset(self):
+        # Sanity: without YOLT_LOG_FILE the hook does not write to the
+        # path even if it would have existed.
+        env = dict(os.environ)
+        env.pop("YOLT_LOG_FILE", None)
+        subprocess.run(
+            [sys.executable, str(HOOKS_DIR / "yolt_analyzer.py"), "--hook"],
+            input=json.dumps({
+                "tool_name": "Bash",
+                "tool_input": {"command": "ls /tmp"},
+            }),
+            capture_output=True,
+            text=True,
+            timeout=30,
+            env=env,
+        )
+        self.assertFalse(self.log_path.exists())
+
+    def test_unwritable_log_path_does_not_break_hook(self):
+        # If the log path is unwritable, the hook must still emit its
+        # normal decision and exit cleanly. Logging is best-effort.
+        env = dict(os.environ)
+        env["YOLT_LOG_FILE"] = "/proc/cannot-write-here/yolt.log"
+        result = subprocess.run(
+            [sys.executable, str(HOOKS_DIR / "yolt_analyzer.py"), "--hook"],
+            input=json.dumps({
+                "tool_name": "Bash",
+                "tool_input": {"command": "ls /tmp"},
+            }),
+            capture_output=True,
+            text=True,
+            timeout=30,
+            env=env,
+        )
+        self.assertEqual(result.returncode, 0)
+        # Decision is still emitted on stdout.
+        self.assertIn("hookSpecificOutput", result.stdout)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

When `YOLT_LOG_FILE` is set, the `PreToolUse` hook appends a JSON-line record per Bash invocation it examines, regardless of the eventual decision.

```json
{"ts": "2026-05-08T14:00:00.000+00:00", "decision": "safe", "reason": "ls: read-only", "command": "ls /tmp"}
```

`decision` is one of `safe`, `unsafe`, `unknown`, or `import-error` (the last when `tree-sitter-bash` isn't importable on the host).

## Why

The Claude Code UI hides YOLT's contribution when the user's `permissions.allow` already covers a command — a static allow rule short-circuits `PreToolUse` hooks entirely. That means dogfood QA is stochastic: you can't tell whether YOLT fired and decided `safe`, or never fired at all.

The log is the ground truth. Open a Claude Code session with `YOLT_LOG_FILE` exported, `tail -f` the log in another terminal, run commands as normal, see exactly what YOLT decided on each invocation.

## Behavior

- The `command` field is truncated to 500 characters to bound line length.
- Logging failures are swallowed — unwritable path, full disk, etc. never break the hook.
- When the tree-sitter dependency is missing, the log records `decision: "import-error"` so a broken install is visible even though the hook still exits silently and Claude Code falls through to its default prompt.
- When `YOLT_LOG_FILE` is unset, no log file is created (no behavior change for existing users).

## Tests

7 new tests in `TestHookLogFile`:

- `test_logs_safe_decision`
- `test_logs_unsafe_decision`
- `test_logs_unknown_decision`
- `test_appends_across_invocations`
- `test_long_command_is_truncated`
- `test_no_log_file_when_env_unset`
- `test_unwritable_log_path_does_not_break_hook`

Full suite: 139 tests, all green.

## Verifying locally

```bash
git fetch origin gg/yolt-log
git checkout gg/yolt-log
python3 -m unittest discover -v tests

# Smoke against the hook itself:
LOG=/tmp/yolt-smoke.log
YOLT_LOG_FILE="$LOG" python3 hooks/yolt_analyzer.py --hook \
  <<<'{"tool_name":"Bash","tool_input":{"command":"diff <(ls /a) <(rm -rf /a)"}}' >/dev/null
cat "$LOG"
```

Expected: a single record with `decision: "unsafe"` and `reason: "rm: mutating"` — proving process-substitution destructive-inner classification flows through to the log.

## Test plan

- [x] All 139 unit tests pass.
- [x] Manual smoke against the hook subprocess produces the expected records.
- [ ] Dogfood in a fresh Claude Code session with `YOLT_LOG_FILE` exported. (User-facing; this PR enables that workflow.)
