### PR TITLE
Default YOLT_LOG_FILE to ~/.claude/yolt.log

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,29 +266,32 @@ Examples: `examples/user-overrides.json`, `examples/shell-overrides.json`.
 
 ## Debug / dogfood log
 
-Set `YOLT_LOG_FILE` and the hook appends one JSON line per Bash
-invocation it examines, regardless of the eventual decision:
-
-```bash
-export YOLT_LOG_FILE="$HOME/.claude/yolt.log"
-# Open a Claude Code session that inherits this env var.
-tail -f "$YOLT_LOG_FILE"
-```
-
-Each record:
+YOLT logs every examined Bash invocation by default to
+`~/.claude/yolt.log`. Each line is a JSON record:
 
 ```json
 {"ts": "2026-05-08T14:00:00.000+00:00", "decision": "safe", "reason": "ls: read-only", "command": "ls /tmp"}
 ```
 
-`decision` is one of `safe`, `unsafe`, `unknown`, or `import-error` (when
-the tree-sitter dependency is missing). The `command` field is truncated
-to 500 characters. Logging failures are swallowed — the hook never
-breaks the session because of an unwritable log path.
+`decision` is one of `safe`, `unsafe`, `unknown`, or `import-error` (the
+last when the tree-sitter dependency is missing). The `command` field is
+truncated to 500 characters. Logging failures are swallowed — the hook
+never breaks the session because of an unwritable log path.
+
+```bash
+tail -f ~/.claude/yolt.log
+```
 
 This is the cleanest way to QA YOLT against your own session: the
 Claude Code UI hides the hook's contribution when your `permissions.allow`
 already covers the command, but the log records every fire.
+
+To override the log location, set `YOLT_LOG_FILE` to an absolute path.
+To opt out entirely, set `YOLT_LOG_FILE=""` (empty string).
+
+> The log grows unbounded. There is no rotation today — if the file
+> gets uncomfortable, `truncate -s 0 ~/.claude/yolt.log` or rotate it
+> with your tool of choice.
 
 ## CLI usage
 

--- a/hooks/yolt_analyzer.py
+++ b/hooks/yolt_analyzer.py
@@ -221,23 +221,43 @@ def make_hook_response(decision, reason=None):
     return output
 
 
+DEFAULT_LOG_PATH = Path.home() / ".claude" / "yolt.log"
+
+
+def _resolve_log_path():
+    """Resolve the log destination.
+
+    - `YOLT_LOG_FILE` unset -> default to ~/.claude/yolt.log (always-on
+      so plugin install gives users a usable log out of the box).
+    - `YOLT_LOG_FILE` set to an empty string -> opt out, no logging.
+    - Otherwise -> the path the user specified.
+    """
+    env_value = os.environ.get("YOLT_LOG_FILE")
+    if env_value is None:
+        return DEFAULT_LOG_PATH
+    if env_value == "":
+        return None
+    return Path(env_value)
+
+
 def _log_hook_decision(command, decision, reason):
-    """Append a JSON-line record of this hook fire to $YOLT_LOG_FILE if set.
+    """Append a JSON-line record of this hook fire to the resolved log
+    path. Logs by default to `~/.claude/yolt.log`; the user can override
+    with `YOLT_LOG_FILE=<path>` or opt out with `YOLT_LOG_FILE=""`.
 
-    Useful for dogfooding / QA: a user opens a fresh Claude Code session
-    with `YOLT_LOG_FILE=~/.claude/yolt.log` exported, runs commands as
-    normal, and tails the log to see exactly which decision YOLT made on
-    every Bash invocation — even when the user's `permissions.allow`
-    short-circuits the hook display in the Claude Code UI.
+    Useful for dogfooding / QA: tail the log to see exactly which
+    decision YOLT made on every Bash invocation — including the silent
+    unknown-fallthrough cases that the Claude Code UI hides.
 
-    Failures (unwritable path, full disk) are swallowed: logging must
-    never break the hook. The Bash command is truncated to 500 chars to
+    Failures (unwritable path, full disk, ...) are swallowed: logging
+    must never break the hook. The command is truncated to 500 chars to
     avoid pathologically long lines.
     """
-    log_path = os.environ.get("YOLT_LOG_FILE")
-    if not log_path:
+    log_path = _resolve_log_path()
+    if log_path is None:
         return
     try:
+        log_path.parent.mkdir(parents=True, exist_ok=True)
         record = {
             "ts": datetime.datetime.now(datetime.timezone.utc).isoformat(),
             "decision": decision,

--- a/tests/test_yolt_hook.py
+++ b/tests/test_yolt_hook.py
@@ -309,11 +309,15 @@ class TestHookLogFile(unittest.TestCase):
         self.assertEqual(len(recs), 1)
         self.assertLessEqual(len(recs[0]["command"]), 500)
 
-    def test_no_log_file_when_env_unset(self):
-        # Sanity: without YOLT_LOG_FILE the hook does not write to the
-        # path even if it would have existed.
+    def test_default_log_path_used_when_env_unset(self):
+        # When YOLT_LOG_FILE is unset, the hook writes to the default
+        # path (~/.claude/yolt.log via $HOME). Redirect HOME so we can
+        # observe the default-path write without polluting the real one.
+        fake_home = self.tmp / "fake-home"
+        fake_home.mkdir()
         env = dict(os.environ)
         env.pop("YOLT_LOG_FILE", None)
+        env["HOME"] = str(fake_home)
         subprocess.run(
             [sys.executable, str(HOOKS_DIR / "yolt_analyzer.py"), "--hook"],
             input=json.dumps({
@@ -325,6 +329,33 @@ class TestHookLogFile(unittest.TestCase):
             timeout=30,
             env=env,
         )
+        default_log = fake_home / ".claude" / "yolt.log"
+        self.assertTrue(default_log.exists(), "default log path was not written")
+        line = default_log.read_text().strip()
+        record = json.loads(line)
+        self.assertEqual(record["decision"], "safe")
+        self.assertEqual(record["command"], "ls /tmp")
+
+    def test_empty_string_opts_out_of_logging(self):
+        # YOLT_LOG_FILE="" means the user explicitly opted out — no
+        # log file, default or otherwise.
+        fake_home = self.tmp / "fake-home"
+        fake_home.mkdir()
+        env = dict(os.environ)
+        env["YOLT_LOG_FILE"] = ""
+        env["HOME"] = str(fake_home)
+        subprocess.run(
+            [sys.executable, str(HOOKS_DIR / "yolt_analyzer.py"), "--hook"],
+            input=json.dumps({
+                "tool_name": "Bash",
+                "tool_input": {"command": "ls /tmp"},
+            }),
+            capture_output=True,
+            text=True,
+            timeout=30,
+            env=env,
+        )
+        self.assertFalse((fake_home / ".claude" / "yolt.log").exists())
         self.assertFalse(self.log_path.exists())
 
     def test_unwritable_log_path_does_not_break_hook(self):


### PR DESCRIPTION
## Summary

Default `YOLT_LOG_FILE` to `~/.claude/yolt.log` so plugin install gives users a usable log out of the box without first having to know to export the env var.

## Behavior

| `YOLT_LOG_FILE` | Result |
| --- | --- |
| unset | logs to `~/.claude/yolt.log` (default) |
| `<path>` | logs to the path the user specified |
| `""` | opt out, no log file written |

Parent directory is created on demand. Logging failures stay swallowed — the hook never breaks the session because of an unwritable log path.

## Why

After PR #6 the user had to know to `export YOLT_LOG_FILE` before opening a Claude Code session. With YOLT shipping as a plugin, the right experience is: install the plugin, the log is just there. The next dogfooder reads `tail -f ~/.claude/yolt.log` in the README and is one command away from ground truth.

The empty-string opt-out is intentional: a deliberate way to silence YOLT's logging without uninstalling the plugin.

## Tests

8 tests in `TestHookLogFile`, including the new ones:

- `test_default_log_path_used_when_env_unset` — redirects `HOME` so the test can observe the default-path write without polluting the real `~/.claude/`.
- `test_empty_string_opts_out_of_logging` — verifies the opt-out keyword.

Full suite: 140 tests, all green.

## Note for users

Log grows unbounded. There is no rotation today. If the file gets uncomfortable, `truncate -s 0 ~/.claude/yolt.log` or rotate with the tool of choice. Documented in README.
