### PR TITLE
Bootstrap tree-sitter deps in pre-tool-use.sh on first run

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,11 +217,25 @@ Two pure-Python deps via wheels:
 - [`tree-sitter`](https://pypi.org/project/tree-sitter/) — parser runtime.
 - [`tree-sitter-bash`](https://pypi.org/project/tree-sitter-bash/) — bash grammar.
 
-Install with `pip install -r requirements.txt`. The plugin install path
-expects them on the same Python that runs `hooks/pre-tool-use.sh`. If
-either is missing, the hook exits silently and Claude Code falls through
-to its default prompt — YOLT does not break the user's session on a
-broken install.
+`hooks/pre-tool-use.sh` bootstraps these on first run: probes the import,
+and if missing, runs `pip install --user -r requirements.txt` (falling
+back to `--break-system-packages` for PEP 668 environments). A marker
+under `~/.cache/yolt/deps-installed-<sha>` records success and is keyed
+to the `requirements.txt` content hash, so a dep bump triggers re-bootstrap.
+Subsequent hook fires skip the import probe entirely.
+
+If the bootstrap fails (no network, locked-down pip, exotic Python
+distribution), the hook exits silently and Claude Code falls through to
+its default prompt — YOLT does not break the user's session on a broken
+install. The failure is recorded in `~/.claude/yolt.log` as
+`decision: "import-error"`; the user can fix manually with
+`pip install -r requirements.txt` and the next hook fire picks it up.
+
+To force re-bootstrap (after a venv switch or manual uninstall):
+
+```bash
+rm ~/.cache/yolt/deps-installed-*
+```
 
 ## What the grammar classifier handles
 

--- a/hooks/pre-tool-use.sh
+++ b/hooks/pre-tool-use.sh
@@ -1,5 +1,75 @@
 #!/bin/bash
-# YOLT (You Only Live Twice) - PreToolUse hook for Claude Code
-# Delegates to yolt_analyzer.py for Python script safety analysis
+# YOLT (You Only Live Twice) - PreToolUse hook for Claude Code.
+#
+# Two responsibilities:
+#   1. Bootstrap the two grammar deps (tree-sitter, tree-sitter-bash) on
+#      first run, so plugin install gives users a working hook out of
+#      the box without a separate `pip install` step. The bootstrap runs
+#      once per requirements.txt content hash, marker lives under
+#      $HOME/.cache/yolt/ so it survives plugin reinstalls.
+#   2. Exec the Python analyzer to actually classify the command.
+#
+# The bootstrap is best-effort: if it fails (pip locked down, no network,
+# unsupported platform), the analyzer is still invoked. yolt_analyzer.py
+# records the ImportError in $YOLT_LOG_FILE so the user can see why YOLT
+# silently no-ops.
+set -u
+
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+YOLT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+REQS="$YOLT_ROOT/requirements.txt"
+
+bootstrap_deps() {
+    # Marker is keyed to requirements.txt content so a dep bump triggers
+    # re-bootstrap. Once set, subsequent hook fires skip even the import
+    # probe — bash file-exists test only, ~ms.
+    local cache_dir="$HOME/.cache/yolt"
+    local sha
+    if command -v shasum >/dev/null 2>&1; then
+        sha="$(shasum -a 256 "$REQS" 2>/dev/null | awk '{print substr($1,1,12)}')"
+    elif command -v sha256sum >/dev/null 2>&1; then
+        sha="$(sha256sum "$REQS" 2>/dev/null | awk '{print substr($1,1,12)}')"
+    else
+        sha="nohash"
+    fi
+    local marker="$cache_dir/deps-installed-$sha"
+
+    # Hot path: marker exists, trust it. If the user removed the package
+    # since the marker was set (venv switch, manual uninstall), the
+    # analyzer will ImportError and log import-error to YOLT_LOG_FILE —
+    # the user can delete the marker to force re-bootstrap.
+    if [[ -f "$marker" ]]; then
+        return 0
+    fi
+
+    mkdir -p "$cache_dir" 2>/dev/null
+
+    # Already importable from a previous manual install? Record marker,
+    # done. Costs one python3 startup the first time, never again.
+    if python3 -c "import tree_sitter, tree_sitter_bash" 2>/dev/null; then
+        touch "$marker"
+        return 0
+    fi
+
+    # Try `--user` first (works on most setups). Fall back to
+    # `--break-system-packages` for PEP 668 environments (recent Debian,
+    # Homebrew Python on macOS). All output discarded; pip is noisy.
+    if python3 -m pip install --quiet --user --disable-pip-version-check \
+            -r "$REQS" >/dev/null 2>&1; then
+        touch "$marker"
+        return 0
+    fi
+    if python3 -m pip install --quiet --user --disable-pip-version-check \
+            --break-system-packages -r "$REQS" >/dev/null 2>&1; then
+        touch "$marker"
+        return 0
+    fi
+
+    # Bootstrap failed. Don't mark; retry next time. Hook still execs
+    # the analyzer below, which logs ImportError to YOLT_LOG_FILE.
+    return 1
+}
+
+bootstrap_deps || true
+
 exec python3 "$SCRIPT_DIR/yolt_analyzer.py" --hook

--- a/tests/test_yolt_hook.py
+++ b/tests/test_yolt_hook.py
@@ -232,6 +232,65 @@ class TestHookAllowlistDiscovery(unittest.TestCase):
         self.assertEqual(self._decision("rm -rf /tmp/foo"), "ask")
 
 
+class TestBootstrapShell(unittest.TestCase):
+    """The shell wrapper `pre-tool-use.sh` bootstraps tree-sitter deps on
+    first run, then execs the Python analyzer. These tests exercise the
+    bash bootstrap path without actually running pip — we point HOME at a
+    fresh temp dir and verify that a marker appears after a successful
+    run (deps are already importable in the test process), and that
+    subsequent invocations skip the import probe entirely."""
+
+    def setUp(self):
+        self._tmp = tempfile.mkdtemp(prefix="yolt-bootstrap-")
+        self.tmp = Path(self._tmp)
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self._tmp, ignore_errors=True)
+
+    def _run(self, command, env_overrides=None):
+        env = dict(os.environ)
+        env["HOME"] = str(self.tmp)
+        env["YOLT_LOG_FILE"] = ""  # opt out of log noise for this class
+        if env_overrides:
+            env.update(env_overrides)
+        return subprocess.run(
+            [str(HOOKS_DIR / "pre-tool-use.sh")],
+            input=json.dumps({
+                "tool_name": "Bash",
+                "tool_input": {"command": command},
+            }),
+            capture_output=True,
+            text=True,
+            timeout=60,
+            env=env,
+        )
+
+    def test_first_run_creates_marker(self):
+        result = self._run("ls /tmp")
+        self.assertEqual(result.returncode, 0)
+        cache = self.tmp / ".cache" / "yolt"
+        markers = list(cache.glob("deps-installed-*"))
+        self.assertEqual(len(markers), 1, "expected one marker file under {}".format(cache))
+
+    def test_subsequent_run_keeps_same_marker(self):
+        self._run("ls /tmp")
+        self._run("ls /tmp")
+        markers = list((self.tmp / ".cache" / "yolt").glob("deps-installed-*"))
+        self.assertEqual(len(markers), 1)
+
+    def test_hook_still_emits_decision_through_bootstrap(self):
+        # Sanity: the bootstrap wrapper transparently passes through to
+        # the analyzer's stdout.
+        result = self._run("rm -rf /tmp/yolt-bootstrap-fake")
+        self.assertEqual(result.returncode, 0)
+        last = [l for l in result.stdout.splitlines() if l.strip()][-1]
+        parsed = json.loads(last)
+        self.assertEqual(
+            parsed["hookSpecificOutput"]["permissionDecision"], "ask",
+        )
+
+
 class TestHookLogFile(unittest.TestCase):
     """When YOLT_LOG_FILE is set, the hook appends a JSON-line record per
     Bash invocation regardless of the eventual decision. Used for


### PR DESCRIPTION
## Summary

Make plugin install one-click for new users. `hooks/pre-tool-use.sh` now bootstraps `tree-sitter` and `tree-sitter-bash` on first run, instead of leaving the hook to silently no-op on systems where those deps aren't already in the Python the hook invokes.

## Why

Before this PR, `/plugin install yolt@voitta-yolt` succeeded but YOLT did nothing on most fresh systems. The Python analyzer caught the ImportError and exited 0 silently (correct — never break the session), but users who didn't read the log just assumed YOLT wasn't working. Friction documented in `HANDOFF.md` and `.handoffs/2026-05-08-yolt-rewrite-qa-self.md` as the top priority follow-up.

## Behavior

```
On every hook fire:

  1. Compute marker path = ~/.cache/yolt/deps-installed-<sha12 of requirements.txt>
  2. If marker exists -> done. Exec analyzer. (Fast path: bash file-exists test.)
  3. Else probe `python3 -c "import tree_sitter, tree_sitter_bash"`.
  4. If importable -> touch marker. Exec analyzer.
  5. Else try `pip install --user -r requirements.txt`. On success -> touch marker.
  6. Else retry with `--break-system-packages` (PEP 668 envs).
  7. If all fail -> don't mark. Exec analyzer anyway; it logs "import-error".
```

The marker is keyed to the requirements.txt content hash, so a future dep bump invalidates the marker and triggers re-bootstrap automatically.

## What happens when bootstrap fails

The hook never breaks the session. `pre-tool-use.sh` still execs `yolt_analyzer.py`, which catches the ImportError and exits silently with `decision: "import-error"` recorded in `~/.claude/yolt.log`. Users can fix manually with `pip install -r requirements.txt`; next hook fire picks it up.

To force re-bootstrap after a venv switch or manual package uninstall:

```bash
rm ~/.cache/yolt/deps-installed-*
```

## Tests

3 new `TestBootstrapShell` cases:

- `test_first_run_creates_marker` — `HOME` pointed at temp dir; one marker appears after a single hook fire.
- `test_subsequent_run_keeps_same_marker` — second fire reuses the marker rather than creating a second.
- `test_hook_still_emits_decision_through_bootstrap` — sanity that the bootstrap wrapper passes through analyzer output cleanly.

Full suite: 149 passing.

## Verifying locally

```bash
git fetch origin gg/bootstrap-pip
git checkout gg/bootstrap-pip
python3 -m unittest discover -v tests

# Simulate a fresh user: remove the marker and watch bootstrap probe.
rm -f ~/.cache/yolt/deps-installed-*
echo '{"tool_name":"Bash","tool_input":{"command":"ls /tmp"}}' | hooks/pre-tool-use.sh
ls ~/.cache/yolt/
```

## Test plan

- [x] Existing deps already installed → marker appears, no pip call, decision emitted.
- [ ] Fresh system without deps → pip install runs once, marker appears, subsequent hooks fast-path.
- [ ] PEP 668 system (recent Debian / Homebrew Python) → `--user` fails, `--break-system-packages` succeeds.
- [ ] No network / locked-down pip → `decision: "import-error"` in log, hook still silently passes through to Claude Code default.

The last three need real-world environments to validate; this is a follow-up for QA after merge.
