### PR TITLE
Rotate YOLT log at 5MB (YOLT_LOG_MAX_BYTES override)

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,9 +352,10 @@ already covers the command, but the log records every fire.
 To override the log location, set `YOLT_LOG_FILE` to an absolute path.
 To opt out entirely, set `YOLT_LOG_FILE=""` (empty string).
 
-> The log grows unbounded. There is no rotation today — if the file
-> gets uncomfortable, `truncate -s 0 ~/.claude/yolt.log` or rotate it
-> with your tool of choice.
+YOLT rotates the log when it grows past 5 MB by renaming it to
+`<log>.old`, clobbering any previous `.old`. One generation is
+preserved. `YOLT_LOG_MAX_BYTES` overrides the threshold; set
+`YOLT_LOG_MAX_BYTES=0` to disable rotation.
 
 ## CLI usage
 

--- a/hooks/yolt_analyzer.py
+++ b/hooks/yolt_analyzer.py
@@ -222,6 +222,7 @@ def make_hook_response(decision, reason=None):
 
 
 DEFAULT_LOG_PATH = Path.home() / ".claude" / "yolt.log"
+DEFAULT_LOG_MAX_BYTES = 5 * 1024 * 1024  # 5 MB
 
 
 def _resolve_log_path():
@@ -240,6 +241,41 @@ def _resolve_log_path():
     return Path(env_value)
 
 
+def _resolve_log_max_bytes():
+    """Maximum log size before rotation. Defaults to 5MB. `YOLT_LOG_MAX_BYTES`
+    overrides; set to 0 to disable rotation entirely."""
+    raw = os.environ.get("YOLT_LOG_MAX_BYTES")
+    if raw is None:
+        return DEFAULT_LOG_MAX_BYTES
+    try:
+        return max(0, int(raw))
+    except ValueError:
+        return DEFAULT_LOG_MAX_BYTES
+
+
+def _maybe_rotate_log(log_path, max_bytes):
+    """Single-generation rotation. If `log_path` exceeds `max_bytes`,
+    rename it to `<log_path>.old` (clobbering any existing .old), so
+    the next write starts a fresh file. One previous generation kept.
+
+    No-op if `max_bytes` is 0 (rotation disabled), if the file doesn't
+    exist, or if the rename fails for any reason — rotation is
+    best-effort and must never break the hook."""
+    if max_bytes <= 0:
+        return
+    try:
+        size = log_path.stat().st_size
+    except OSError:
+        return
+    if size < max_bytes:
+        return
+    try:
+        old = log_path.with_suffix(log_path.suffix + ".old")
+        os.replace(log_path, old)
+    except OSError:
+        pass
+
+
 def _log_hook_decision(command, decision, reason):
     """Append a JSON-line record of this hook fire to the resolved log
     path. Logs by default to `~/.claude/yolt.log`; the user can override
@@ -248,6 +284,10 @@ def _log_hook_decision(command, decision, reason):
     Useful for dogfooding / QA: tail the log to see exactly which
     decision YOLT made on every Bash invocation — including the silent
     unknown-fallthrough cases that the Claude Code UI hides.
+
+    Rotates the log when it grows past `YOLT_LOG_MAX_BYTES` (default
+    5MB) by renaming it to `<log>.old` — one previous generation
+    preserved. Set `YOLT_LOG_MAX_BYTES=0` to disable.
 
     Failures (unwritable path, full disk, ...) are swallowed: logging
     must never break the hook. The command is truncated to 500 chars to
@@ -258,6 +298,7 @@ def _log_hook_decision(command, decision, reason):
         return
     try:
         log_path.parent.mkdir(parents=True, exist_ok=True)
+        _maybe_rotate_log(log_path, _resolve_log_max_bytes())
         record = {
             "ts": datetime.datetime.now(datetime.timezone.utc).isoformat(),
             "decision": decision,

--- a/tests/test_yolt_hook.py
+++ b/tests/test_yolt_hook.py
@@ -417,6 +417,79 @@ class TestHookLogFile(unittest.TestCase):
         self.assertFalse((fake_home / ".claude" / "yolt.log").exists())
         self.assertFalse(self.log_path.exists())
 
+    def test_log_rotates_when_size_exceeds_max(self):
+        # Set the rotation threshold tiny (200 bytes) so a single fire
+        # plus a pre-existing log overflows it. Verify the old log is
+        # preserved as `<log>.old` and the new write goes to a fresh
+        # `<log>`.
+        self.log_path.parent.mkdir(parents=True, exist_ok=True)
+        self.log_path.write_text("x" * 500 + "\n")
+        env = dict(os.environ)
+        env["YOLT_LOG_FILE"] = str(self.log_path)
+        env["YOLT_LOG_MAX_BYTES"] = "200"
+        subprocess.run(
+            [sys.executable, str(HOOKS_DIR / "yolt_analyzer.py"), "--hook"],
+            input=json.dumps({
+                "tool_name": "Bash",
+                "tool_input": {"command": "ls /tmp"},
+            }),
+            capture_output=True,
+            text=True,
+            timeout=30,
+            env=env,
+        )
+        old_path = self.log_path.with_suffix(self.log_path.suffix + ".old")
+        self.assertTrue(old_path.exists(), "rotated .old log was not created")
+        self.assertIn("xxx", old_path.read_text())
+        new_records = self._records()
+        self.assertEqual(len(new_records), 1)
+        self.assertEqual(new_records[0]["decision"], "safe")
+
+    def test_log_does_not_rotate_below_threshold(self):
+        self.log_path.parent.mkdir(parents=True, exist_ok=True)
+        self.log_path.write_text("small\n")
+        env = dict(os.environ)
+        env["YOLT_LOG_FILE"] = str(self.log_path)
+        env["YOLT_LOG_MAX_BYTES"] = "10000"
+        subprocess.run(
+            [sys.executable, str(HOOKS_DIR / "yolt_analyzer.py"), "--hook"],
+            input=json.dumps({
+                "tool_name": "Bash",
+                "tool_input": {"command": "ls /tmp"},
+            }),
+            capture_output=True,
+            text=True,
+            timeout=30,
+            env=env,
+        )
+        old_path = self.log_path.with_suffix(self.log_path.suffix + ".old")
+        self.assertFalse(old_path.exists(), "log rotated below threshold")
+        # Pre-existing line + the new record both present.
+        contents = self.log_path.read_text()
+        self.assertIn("small", contents)
+        self.assertIn('"decision": "safe"', contents)
+
+    def test_log_rotation_disabled_when_max_bytes_zero(self):
+        self.log_path.parent.mkdir(parents=True, exist_ok=True)
+        big = "x" * 10_000 + "\n"
+        self.log_path.write_text(big)
+        env = dict(os.environ)
+        env["YOLT_LOG_FILE"] = str(self.log_path)
+        env["YOLT_LOG_MAX_BYTES"] = "0"  # disable
+        subprocess.run(
+            [sys.executable, str(HOOKS_DIR / "yolt_analyzer.py"), "--hook"],
+            input=json.dumps({
+                "tool_name": "Bash",
+                "tool_input": {"command": "ls /tmp"},
+            }),
+            capture_output=True,
+            text=True,
+            timeout=30,
+            env=env,
+        )
+        old_path = self.log_path.with_suffix(self.log_path.suffix + ".old")
+        self.assertFalse(old_path.exists(), "log rotated despite max_bytes=0")
+
     def test_unwritable_log_path_does_not_break_hook(self):
         # If the log path is unwritable, the hook must still emit its
         # normal decision and exit cleanly. Logging is best-effort.


### PR DESCRIPTION
## Summary

Rotate the YOLT log when it grows past 5 MB. Rename current log to `<log>.old`, clobber any prior `.old`, next write starts fresh. One previous generation preserved.

## Why

The log grows unbounded otherwise — one JSON record per Bash invocation, no upper bound on session length. The `HANDOFF.md` follow-up queue called this out. With this PR, `~/.claude/yolt.log` stays bounded automatically; nobody has to remember `truncate -s 0`.

## Behavior

| `YOLT_LOG_MAX_BYTES` | Result |
| --- | --- |
| unset | rotate at 5 MB (default) |
| `<N>` | rotate at `N` bytes |
| `0` | rotation disabled |
| invalid (non-int) | rotate at 5 MB (default) |

Rotation happens at write time. If the file is at or above the threshold, `os.replace(log, log.old)` then proceed with the new write. Single generation kept on disk: `<log>` (current) and `<log>.old` (previous full cycle).

Rotation failures (rename across filesystems, permission denied) are swallowed. Rotation is best-effort; the hook never breaks the session.

## Tests

3 new cases in `TestHookLogFile`:

- `test_log_rotates_when_size_exceeds_max` — preexisting 500-byte log + 200-byte threshold + a new fire ⇒ `.old` appears, new `.log` has one fresh record.
- `test_log_does_not_rotate_below_threshold` — threshold well above current size ⇒ no `.old` created, append continues normally.
- `test_log_rotation_disabled_when_max_bytes_zero` — pre-existing 10KB log + `YOLT_LOG_MAX_BYTES=0` ⇒ no rotation.

Full suite: 152 passing.

## Verifying locally

```bash
git fetch origin gg/log-rotation
git checkout gg/log-rotation
python3 -m unittest discover -v tests

# Manual smoke:
YOLT_LOG_FILE=/tmp/yolt-rotate-demo.log YOLT_LOG_MAX_BYTES=500 \
  python3 hooks/yolt_analyzer.py --hook \
  <<<'{"tool_name":"Bash","tool_input":{"command":"ls /tmp"}}'
# fire a few more times, watch /tmp/yolt-rotate-demo.log + .old appear
ls -la /tmp/yolt-rotate-demo.log*
```
