### PR TITLE
First-class python3 -m <module> rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,8 @@ Example decisions (see `rules/shell.json` for the full rule set):
 | `sed 's/a/b/' f` / `sed -i 's/a/b/' f`                       | allow / ask |
 | `python3 -c "print(1+1)"`                                    | allow    |
 | `python3 -c "import os; os.system('rm -rf /')"`              | ask      |
+| `python3 -m json.tool` / `python3 -m http.server`            | allow / ask |
+| `python3 -m pip list` / `python3 -m pip install requests`    | allow / ask |
 | `bash -c "ls /tmp"` / `bash -c "rm /etc/passwd"`             | allow / ask |
 | `for svc in $(aws ecs list-services --cluster X); do aws ecs describe-services --cluster X --services "$svc"; done` | allow |
 | `echo foo \| xargs rm` / `echo foo \| xargs cat`             | ask / allow |

--- a/hooks/rule_classifier.py
+++ b/hooks/rule_classifier.py
@@ -241,6 +241,7 @@ class RuleClassifier:
     def classify_interpreter(self, name, cmd_args, _depth):
         spec = self.interpreters[name]
         inline_flag = spec.get("inline_flag")
+        module_flag = spec.get("module_flag")
         delegate = spec.get("delegate", "unknown")
         read_script_file = spec.get("read_script_file", False)
 
@@ -262,6 +263,18 @@ class RuleClassifier:
                 return (d, "{} -c -> {}".format(name, r))
             return (DECISION_UNKNOWN, "cannot analyze inline {}".format(delegate))
 
+        # `python3 -m <module> [args...]` — classify by module name. The
+        # module-rule data lives in `interpreters.<name>.{safe,unsafe}_modules`
+        # plus `nested_modules` for cases like `pip` where the subcommand
+        # decides (install/uninstall = unsafe, list/show/freeze = safe).
+        if module_flag and module_flag in cmd_args:
+            idx = cmd_args.index(module_flag)
+            if idx + 1 < len(cmd_args):
+                module = cmd_args[idx + 1]
+                module_args = cmd_args[idx + 2:]
+                return self._classify_module(name, module, module_args, spec)
+            return (DECISION_UNKNOWN, "{} {}: no module".format(name, module_flag))
+
         if read_script_file and delegate == "python":
             for arg in cmd_args:
                 if arg.startswith("-"):
@@ -276,6 +289,59 @@ class RuleClassifier:
                 break
 
         return (DECISION_UNKNOWN, "{} invocation not analyzable".format(name))
+
+    def _classify_module(self, name, module, module_args, spec):
+        safe_modules = set(spec.get("safe_modules", []))
+        unsafe_modules = set(spec.get("unsafe_modules", []))
+        nested = spec.get("nested_modules", {})
+
+        if module in safe_modules:
+            return (DECISION_SAFE, "{} -m {}: read-only".format(name, module))
+        if module in unsafe_modules:
+            return (DECISION_UNSAFE, "{} -m {}: mutating".format(name, module))
+
+        if module in nested:
+            return self._classify_nested_module(
+                name, module, module_args, nested[module]
+            )
+
+        for pat in spec.get("safe_module_patterns", []):
+            if fnmatch(module, pat):
+                return (DECISION_SAFE,
+                        "{} -m {}: matches safe pattern".format(name, module))
+        for pat in spec.get("unsafe_module_patterns", []):
+            if fnmatch(module, pat):
+                return (DECISION_UNSAFE,
+                        "{} -m {}: matches unsafe pattern".format(name, module))
+
+        return (DECISION_UNKNOWN, "{} -m {}: no rule".format(name, module))
+
+    def _classify_nested_module(self, name, module, args, mod_spec):
+        safe_subs = set(mod_spec.get("safe_subcommands", []))
+        unsafe_subs = set(mod_spec.get("unsafe_subcommands", []))
+
+        sub = None
+        for a in args:
+            if not a.startswith("-"):
+                sub = a
+                break
+
+        label = "{} -m {}".format(name, module)
+
+        if sub is None:
+            default = mod_spec.get("default")
+            if default == "safe":
+                return (DECISION_SAFE, "{}: read-only".format(label))
+            if default == "unsafe":
+                return (DECISION_UNSAFE, "{}: mutating".format(label))
+            return (DECISION_UNKNOWN, "{}: no subcommand".format(label))
+
+        if sub in safe_subs:
+            return (DECISION_SAFE, "{} {}: read-only".format(label, sub))
+        if sub in unsafe_subs:
+            return (DECISION_UNSAFE, "{} {}: mutating".format(label, sub))
+
+        return (DECISION_UNKNOWN, "{} {}: no rule".format(label, sub))
 
     def classify_python_source(self, source, description):
         if self.python_analyzer_factory is None:

--- a/rules/shell.json
+++ b/rules/shell.json
@@ -40,8 +40,54 @@
   ],
 
   "interpreters": {
-    "python3": {"inline_flag": "-c", "delegate": "python", "read_script_file": true},
-    "python":  {"inline_flag": "-c", "delegate": "python", "read_script_file": true},
+    "python3": {
+      "inline_flag": "-c",
+      "module_flag": "-m",
+      "delegate": "python",
+      "read_script_file": true,
+      "safe_modules": [
+        "json.tool",
+        "tokenize", "dis", "ast", "py_compile", "tabnanny",
+        "this", "antigravity",
+        "calendar", "uuid", "secrets",
+        "site", "sysconfig", "platform",
+        "pdb",
+        "timeit", "cProfile", "profile",
+        "doctest",
+        "base64", "binhex"
+      ],
+      "unsafe_modules": [
+        "http.server",
+        "SimpleHTTPServer",
+        "smtpd",
+        "webbrowser",
+        "compileall",
+        "venv",
+        "ensurepip",
+        "zipfile"
+      ],
+      "nested_modules": {
+        "pip": {
+          "safe_subcommands": [
+            "list", "show", "freeze", "help", "search", "check",
+            "config", "debug", "inspect", "index", "hash", "completion"
+          ],
+          "unsafe_subcommands": [
+            "install", "uninstall", "download", "wheel"
+          ]
+        },
+        "unittest": {
+          "safe_subcommands": ["discover"],
+          "default": "safe"
+        }
+      }
+    },
+    "python":  {
+      "inline_flag": "-c",
+      "module_flag": "-m",
+      "delegate": "python",
+      "read_script_file": true
+    },
     "bash":    {"inline_flag": "-c", "delegate": "bash",   "read_script_file": false},
     "sh":      {"inline_flag": "-c", "delegate": "bash",   "read_script_file": false},
     "zsh":     {"inline_flag": "-c", "delegate": "bash",   "read_script_file": false},

--- a/tests/test_grammar_classifier.py
+++ b/tests/test_grammar_classifier.py
@@ -452,6 +452,60 @@ class TestGrammarSpecific(unittest.TestCase):
         )
 
 
+class TestPython3DashM(unittest.TestCase):
+    """`python3 -m <module>` classification via interpreters.python3
+    safe_modules / unsafe_modules / nested_modules rule data."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.clf = _make_classifier()
+
+    def assertDecision(self, cmd, expected):
+        d, r = self.clf.classify(cmd)
+        self.assertEqual(d, expected, msg="cmd={!r}, reason={}".format(cmd, r))
+
+    def test_safe_module_json_tool(self):
+        self.assertDecision("python3 -m json.tool < /tmp/foo.json", DECISION_SAFE)
+
+    def test_safe_module_dis(self):
+        self.assertDecision("python3 -m dis script.py", DECISION_SAFE)
+
+    def test_unsafe_module_http_server(self):
+        # Opens a listener; treat as side-effecting.
+        self.assertDecision("python3 -m http.server 8000", DECISION_UNSAFE)
+
+    def test_unsafe_module_venv(self):
+        self.assertDecision("python3 -m venv .venv", DECISION_UNSAFE)
+
+    def test_unsafe_module_compileall(self):
+        self.assertDecision("python3 -m compileall .", DECISION_UNSAFE)
+
+    def test_unsafe_module_webbrowser(self):
+        self.assertDecision(
+            "python3 -m webbrowser https://example.com",
+            DECISION_UNSAFE,
+        )
+
+    def test_nested_pip_list_safe(self):
+        self.assertDecision("python3 -m pip list", DECISION_SAFE)
+
+    def test_nested_pip_show_safe(self):
+        self.assertDecision("python3 -m pip show requests", DECISION_SAFE)
+
+    def test_nested_pip_install_unsafe(self):
+        self.assertDecision("python3 -m pip install requests", DECISION_UNSAFE)
+
+    def test_nested_pip_uninstall_unsafe(self):
+        self.assertDecision("python3 -m pip uninstall -y requests", DECISION_UNSAFE)
+
+    def test_nested_unittest_discover_safe(self):
+        self.assertDecision("python3 -m unittest discover tests", DECISION_SAFE)
+
+    def test_nested_unittest_default_safe_when_no_subcommand(self):
+        # unittest spec has "default": "safe" so bare invocation is fine.
+        self.assertDecision("python3 -m unittest", DECISION_SAFE)
+
+
 class TestSafeWriteTargets(unittest.TestCase):
     """Custom safe-write-target lists from `rules.safe_write_targets`."""
 


### PR DESCRIPTION
## Summary

`python3 -m <module>` was previously falling through to `unknown` with reason `"python3 invocation not analyzable"`, requiring the user's allowlist to upgrade it. Add module-aware classification driven by rule data in `rules/shell.json`.

## Behavior

| Command | Before | After |
| --- | --- | --- |
| `python3 -m json.tool` | unknown | safe |
| `python3 -m dis script.py` | unknown | safe |
| `python3 -m http.server 8000` | unknown | unsafe (opens listener) |
| `python3 -m venv .venv` | unknown | unsafe (creates dir) |
| `python3 -m compileall .` | unknown | unsafe (writes .pyc) |
| `python3 -m webbrowser https://x` | unknown | unsafe (side effect) |
| `python3 -m pip list` | unknown | safe |
| `python3 -m pip install requests` | unknown | unsafe |
| `python3 -m unittest discover tests` | unknown | safe |
| `python3 -m some_random_mod` | unknown | unknown (unchanged) |

## Rule schema additions

Under `interpreters.python3` in `rules/shell.json`:

```json
{
  "inline_flag": "-c",
  "module_flag": "-m",                             // NEW
  "delegate": "python",
  "read_script_file": true,
  "safe_modules": ["json.tool", "dis", "tokenize", ...],     // NEW
  "unsafe_modules": ["http.server", "venv", "compileall", ...], // NEW
  "safe_module_patterns": ["fnmatch globs"],       // NEW
  "unsafe_module_patterns": ["fnmatch globs"],     // NEW
  "nested_modules": {                              // NEW
    "pip": {
      "safe_subcommands": ["list", "show", "freeze", "help", ...],
      "unsafe_subcommands": ["install", "uninstall", "download", "wheel"]
    },
    "unittest": {
      "safe_subcommands": ["discover"],
      "default": "safe"
    }
  }
}
```

The nested-module shape mirrors the existing `commands.<cmd>.nested_subcommand` schema, so it'll feel familiar to anyone who's added a rule before.

## Implementation

- `rule_classifier.RuleClassifier.classify_interpreter` now checks `spec.module_flag` (`-m`) in addition to `inline_flag` (`-c`). On match, dispatches to `_classify_module`.
- `_classify_module` checks `safe_modules` / `unsafe_modules` sets, then `nested_modules`, then `safe_module_patterns` / `unsafe_module_patterns`, then falls through to `unknown`.
- `_classify_nested_module` finds the first positional arg as the subcommand and looks it up against the nested spec. Supports a `"default"` field for modules where the bare invocation is meaningful (e.g. `python3 -m unittest`).

## Tests

12 new cases under `TestPython3DashM` covering safe / unsafe leaf modules plus pip and unittest nested forms. Total: 164 passing.

## Verifying locally

```bash
git fetch origin gg/python-dash-m
git checkout gg/python-dash-m
python3 -m unittest discover -v tests

# Manual smoke:
python3 hooks/grammar_classifier.py 'python3 -m pip install requests'
# => {"decision": "unsafe", "reason": "python3 -m pip install: mutating"}
```
