### PR TITLE
Add SQL CLI classifier: sqlite3, psql, mysql, mariadb, duckdb

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
 - [User allowlist as a secondary upgrade pass](#user-allowlist-as-a-secondary-upgrade-pass)
 - [Dependencies](#dependencies)
 - [What the grammar classifier handles](#what-the-grammar-classifier-handles)
+- [SQL CLIs](#sql-clis)
 - [Python rules (interpreter delegate)](#python-rules-interpreter-delegate)
 - [Custom rules](#custom-rules)
   - [Python rules — `~/.claude/yolt/rules.json`](#python-rules---claudeyoltrulesjson)
@@ -280,6 +281,39 @@ Example decisions (see `rules/shell.json` for the full rule set):
 | `cat file > /tmp/out`                                        | allow (`/tmp/*` is on the safe-write list) |
 | `cat file > /etc/profile`                                    | unknown (writes to a system path) |
 | `aws ec2 describe-instances > /dev/null`                     | allow    |
+| `sqlite3 db.sqlite "SELECT * FROM t"`                        | allow    |
+| `sqlite3 db.sqlite "DROP TABLE t"`                           | ask      |
+| `sqlite3 db.sqlite ".tables"` / `... ".import f.csv t"`      | allow / ask |
+| `psql -c "SELECT now()" mydb` / `psql -c "DELETE FROM t" mydb` | allow / ask |
+| `mysql -e "SHOW DATABASES" mydb` / `mysql -e "DROP TABLE t" mydb` | allow / ask |
+
+## SQL CLIs
+
+`sqlite3`, `psql`, `mysql`, `mariadb`, and `duckdb` are classified via
+the `sql_cli` default. The argv walker pulls the SQL string out
+(positional for sqlite3/duckdb, `-c` / `--command` for psql, `-e` /
+`--execute` for mysql/mariadb) and runs a conservative scan:
+
+1. Strip line comments (`-- ...`), block comments (`/* ... */`), and
+   string/identifier literals (`'...'`, `"..."`, `` `...` ``).
+2. If any of `INSERT / UPDATE / DELETE / DROP / CREATE / ALTER /
+   TRUNCATE / REPLACE / MERGE / GRANT / REVOKE / VACUUM / REINDEX /
+   ATTACH / DETACH / COPY / LOAD / IMPORT / LOCK / CALL / EXEC /
+   SET / RESET / BEGIN / COMMIT / ROLLBACK / ...` survives → `unsafe`.
+3. Otherwise, if the first remaining keyword is `SELECT / WITH /
+   EXPLAIN / SHOW / DESCRIBE / DESC / VALUES / TABLE` → `safe`.
+4. `PRAGMA` is `safe` for reads, `unsafe` if it contains `=`
+   (sqlite assignment form).
+5. Anything else → `unknown` (Claude Code's default prompt fires).
+
+SQL fed via file (`psql -f queries.sql`, `mysql < queries.sql`) is
+opaque to a static checker and stays `unknown`. Bare `sqlite3 db.sqlite`
+also stays `unknown` because it opens an interactive shell.
+
+sqlite3 dot-commands (`.tables`, `.schema`, `.import`, `.read`, ...)
+are classified separately by name — `.tables` / `.schema` / `.headers`
+are safe; `.import` / `.load` / `.read` / `.shell` / `.backup` are
+unsafe.
 
 ## Python rules (interpreter delegate)
 

--- a/examples/demo.sh
+++ b/examples/demo.sh
@@ -68,6 +68,18 @@ commands=(
   'aws ec2 describe-instances > /dev/null'
   'aws ec2 describe-instances 2>/dev/null | jq .'
 
+  # Safe: SQL CLIs reading
+  'sqlite3 /tmp/db.sqlite "SELECT * FROM foo"'
+  'sqlite3 /tmp/db.sqlite ".tables"'
+  'psql -c "SELECT now()" mydb'
+  'mysql -e "SHOW DATABASES" mydb'
+
+  # Unsafe: SQL CLIs mutating
+  'sqlite3 /tmp/db.sqlite "DROP TABLE foo"'
+  'sqlite3 /tmp/db.sqlite ".import foo.csv mytable"'
+  'psql -c "DELETE FROM users WHERE id = 1" mydb'
+  'mysql -e "TRUNCATE TABLE foo" mydb'
+
   # Unsafe: direct mutation
   'rm -rf /tmp/foo'
   'sed -i "s/a/b/" file.txt'

--- a/hooks/rule_classifier.py
+++ b/hooks/rule_classifier.py
@@ -39,6 +39,189 @@ ASSIGNMENT_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
 BASH_PATTERN_RE = re.compile(r"^Bash\((.*)\)$")
 
 
+# --- SQL safety detection (used by sql_cli default) ---
+#
+# Conservative scan: strip string literals and comments, then look for
+# mutating keywords anywhere. If none, classify by the first remaining
+# keyword. This treats `EXPLAIN DELETE FROM t` as unsafe (the DELETE
+# keyword is still present even though it would not execute); we accept
+# that false-positive to keep the rule simple.
+
+SQL_MUTATING_KEYWORDS = frozenset({
+    "INSERT", "UPDATE", "DELETE", "DROP", "CREATE", "ALTER",
+    "TRUNCATE", "REPLACE", "MERGE", "GRANT", "REVOKE",
+    "VACUUM", "REINDEX", "ATTACH", "DETACH",
+    "COMMIT", "ROLLBACK", "BEGIN", "SAVEPOINT", "RELEASE",
+    "CALL", "EXEC", "EXECUTE",
+    "COPY", "LOAD", "IMPORT",
+    "LOCK", "UNLOCK",
+    "SET", "RESET",
+})
+
+SQL_SAFE_FIRST_KEYWORDS = frozenset({
+    "SELECT", "WITH", "EXPLAIN", "SHOW", "DESCRIBE", "DESC",
+    "VALUES", "TABLE",
+})
+
+# Strip comments and string/identifier literals before keyword scanning.
+# Order in the regex matters — line comments are matched before block
+# comments to keep nested `/*` inside `-- ...` from leaking through.
+_SQL_STRIP_RE = re.compile(
+    r"""
+    --[^\n]*               # -- line comment
+    | /\*.*?\*/            # /* block comment */
+    | '(?:[^']|'')*'       # 'single' quoted string ('' is escape)
+    | \"(?:[^\"]|\"\")*\"  # "double" quoted ident/string
+    | `[^`]*`              # `backtick` ident (MySQL)
+    """,
+    re.DOTALL | re.VERBOSE,
+)
+
+_SQL_WORD_RE = re.compile(r"\b([A-Za-z_][A-Za-z0-9_]*)\b")
+
+# sqlite3 has a separate "dot-command" namespace (.tables, .schema, ...)
+# that runs inside the CLI but isn't SQL. Most read state; a few load
+# or write files.
+SQLITE_DOT_SAFE = frozenset({
+    ".tables", ".schema", ".databases", ".indexes", ".indices",
+    ".show", ".help", ".headers", ".mode", ".width", ".print",
+    ".timer", ".eqp", ".changes", ".dbinfo", ".dbconfig",
+    ".fullschema", ".scanstats", ".limit", ".nullvalue",
+    ".separator", ".prompt", ".excel", ".version", ".lint",
+    ".stats", ".explain", ".binary", ".filectrl",
+})
+SQLITE_DOT_UNSAFE = frozenset({
+    ".import", ".load", ".save", ".backup", ".restore",
+    ".system", ".shell", ".read", ".cd", ".open", ".dump",
+    ".archive", ".clone", ".log", ".recover",
+})
+
+
+def classify_sql_text(cmd_name, sql):
+    """Return (decision, reason) for a single SQL string passed to a
+    SQL CLI. Handles sqlite3 dot-commands too — they're not SQL but they
+    arrive through the same channel (positional / -cmd / -e)."""
+    sql = sql.strip()
+    if not sql:
+        retval = (DECISION_SAFE, "{}: empty SQL".format(cmd_name))
+        return retval
+
+    if cmd_name == "sqlite3" and sql.startswith("."):
+        first_line = sql.split("\n", 1)[0].strip()
+        dot_tokens = first_line.split()
+        dot = dot_tokens[0] if dot_tokens else ""
+        if dot in SQLITE_DOT_SAFE:
+            retval = (DECISION_SAFE,
+                      "sqlite3 dot-cmd {}: read-only".format(dot))
+            return retval
+        if dot in SQLITE_DOT_UNSAFE:
+            retval = (DECISION_UNSAFE,
+                      "sqlite3 dot-cmd {}: mutating".format(dot))
+            return retval
+        retval = (DECISION_UNKNOWN,
+                  "sqlite3 dot-cmd {}: no rule".format(dot))
+        return retval
+
+    stripped = _SQL_STRIP_RE.sub(" ", sql).upper()
+
+    first_word = None
+    for m in _SQL_WORD_RE.finditer(stripped):
+        word = m.group(1)
+        if first_word is None:
+            first_word = word
+        if word in SQL_MUTATING_KEYWORDS:
+            retval = (DECISION_UNSAFE,
+                      "{}: SQL contains mutating keyword {}".format(cmd_name, word))
+            return retval
+
+    if first_word == "PRAGMA":
+        if "=" in stripped:
+            retval = (DECISION_UNSAFE,
+                      "{}: PRAGMA assignment".format(cmd_name))
+            return retval
+        retval = (DECISION_SAFE, "{}: PRAGMA read".format(cmd_name))
+        return retval
+
+    if first_word in SQL_SAFE_FIRST_KEYWORDS:
+        retval = (DECISION_SAFE,
+                  "{}: read-only SQL ({})".format(cmd_name, first_word))
+        return retval
+
+    if first_word is None:
+        retval = (DECISION_SAFE, "{}: no SQL keywords".format(cmd_name))
+        return retval
+
+    retval = (DECISION_UNKNOWN,
+              "{}: unclassified SQL ({})".format(cmd_name, first_word))
+    return retval
+
+
+def parse_sql_cli_argv(cmd_args, spec):
+    """Walk argv for a SQL CLI, returning (sql_strings, sql_from_file).
+    `spec` carries: sql_flags (list), valueless_flags (list),
+    sql_file_flags (list), sql_positional_index (int or None)."""
+    sql_flags = set(spec.get("sql_flags", []))
+    sql_file_flags = set(spec.get("sql_file_flags", []))
+    valueless = set(spec.get("valueless_flags", []))
+    sql_positional_index = spec.get("sql_positional_index")
+
+    sqls = []
+    positionals = []
+    file_input = False
+
+    i = 0
+    while i < len(cmd_args):
+        tok = cmd_args[i]
+
+        if tok.startswith("--") and "=" in tok:
+            flag, _, value = tok.partition("=")
+            if flag in sql_flags:
+                sqls.append(value)
+            elif flag in sql_file_flags:
+                file_input = True
+            i += 1
+            continue
+
+        if tok in sql_flags:
+            if i + 1 < len(cmd_args):
+                sqls.append(cmd_args[i + 1])
+                i += 2
+                continue
+            i += 1
+            continue
+
+        if tok in sql_file_flags:
+            file_input = True
+            if i + 1 < len(cmd_args) and not cmd_args[i + 1].startswith("-"):
+                i += 2
+                continue
+            i += 1
+            continue
+
+        if tok in valueless:
+            i += 1
+            continue
+
+        if tok.startswith("-") and len(tok) > 1:
+            if i + 1 < len(cmd_args) and not cmd_args[i + 1].startswith("-"):
+                i += 2
+                continue
+            i += 1
+            continue
+
+        positionals.append(tok)
+        i += 1
+
+    if (
+        sql_positional_index is not None
+        and sql_positional_index < len(positionals)
+    ):
+        sqls.append(positionals[sql_positional_index])
+
+    retval = (sqls, file_input)
+    return retval
+
+
 def load_shell_rules(rules_dir, user_overrides_path=None):
     """Load shell rules from rules_dir/shell.json plus optional overrides.
     Overrides merge per top-level key, one level deep."""
@@ -378,6 +561,8 @@ class RuleClassifier:
             return self.classify_verb_cli(cmd_args, spec, label="gcloud")
         if default == "az_cli":
             return self.classify_verb_cli(cmd_args, spec, label="az")
+        if default == "sql_cli":
+            return self.classify_sql_cli(cmd_name, cmd_args, spec)
 
         return (DECISION_UNKNOWN, "{}: unknown default '{}'".format(cmd_name, default))
 
@@ -503,6 +688,17 @@ class RuleClassifier:
                 return (DECISION_UNSAFE, "aws {} {}: global mutating".format(service, operation))
 
         return (DECISION_UNKNOWN, "aws {} {}: unclassified".format(service, operation))
+
+    def classify_sql_cli(self, cmd_name, cmd_args, spec):
+        sqls, file_input = parse_sql_cli_argv(cmd_args, spec)
+        if file_input:
+            return (DECISION_UNKNOWN,
+                    "{}: SQL from file (opaque)".format(cmd_name))
+        if not sqls:
+            return (DECISION_UNKNOWN,
+                    "{}: no inline SQL (interactive or stdin)".format(cmd_name))
+        decisions = [classify_sql_text(cmd_name, s) for s in sqls]
+        return aggregate_decisions(decisions)
 
     def classify_verb_cli(self, cmd_args, spec, label):
         positional = self._skip_flags(cmd_args)

--- a/rules/shell.json
+++ b/rules/shell.json
@@ -488,6 +488,78 @@
       "default": "subcommand",
       "safe_subcommands": ["list", "ls", "info", "abv", "search", "deps", "uses", "leaves", "outdated", "home", "config", "doctor", "help", "--version"],
       "unsafe_subcommands": ["install", "uninstall", "remove", "rm", "upgrade", "update", "reinstall", "pin", "unpin", "cleanup", "tap", "untap", "link", "unlink"]
+    },
+
+    "sqlite3": {
+      "default": "sql_cli",
+      "sql_flags": ["-cmd"],
+      "sql_positional_index": 1,
+      "valueless_flags": [
+        "-batch", "-bail", "-csv", "-echo", "-fullschema",
+        "-header", "-noheader", "-help", "-html", "-interactive",
+        "-line", "-list", "-nofollow", "-quote", "-readonly",
+        "-stats", "-table", "-tabs", "-version", "-zip", "-A",
+        "-markdown", "-box", "-json", "-safe"
+      ],
+      "_note": "sqlite3 DB [SQL] — second positional is the SQL string. Dot-commands (.tables, .schema, .import, ...) come through the same channel and are classified separately."
+    },
+    "psql": {
+      "default": "sql_cli",
+      "sql_flags": ["-c", "--command"],
+      "sql_file_flags": ["-f", "--file"],
+      "valueless_flags": [
+        "-l", "--list", "-?", "-V", "--version", "-X", "--no-psqlrc",
+        "-1", "--single-transaction", "-A", "--no-align",
+        "-e", "--echo-queries", "-E", "--echo-hidden",
+        "-H", "--html", "-n", "--no-readline",
+        "-q", "--quiet", "-s", "--single-step", "-S", "--single-line",
+        "-t", "--tuples-only", "-w", "--no-password", "-W", "--password",
+        "-x", "--expanded", "-z", "--field-separator-zero",
+        "-0", "--record-separator-zero", "-a", "--echo-all",
+        "-b", "--echo-errors"
+      ],
+      "_note": "psql -c 'SQL' / -f file.sql. Bare positionals are dbname/username, not SQL."
+    },
+    "mysql": {
+      "default": "sql_cli",
+      "sql_flags": ["-e", "--execute"],
+      "valueless_flags": [
+        "-?", "--help", "-V", "--version",
+        "-A", "--no-auto-rehash",
+        "-B", "--batch", "-C", "--compress",
+        "-E", "--vertical", "-f", "--force",
+        "-N", "--skip-column-names", "-s", "--silent",
+        "-t", "--table", "-v", "--verbose",
+        "-w", "--wait", "-X", "--xml",
+        "--column-names", "--auto-rehash", "--auto-vertical-output",
+        "--show-warnings", "--no-defaults", "--no-beep"
+      ],
+      "_note": "mysql -e 'SQL'. Bare positional is the database name."
+    },
+    "mariadb": {
+      "default": "sql_cli",
+      "sql_flags": ["-e", "--execute"],
+      "valueless_flags": [
+        "-?", "--help", "-V", "--version",
+        "-A", "--no-auto-rehash",
+        "-B", "--batch", "-C", "--compress",
+        "-E", "--vertical", "-f", "--force",
+        "-N", "--skip-column-names", "-s", "--silent",
+        "-t", "--table", "-v", "--verbose",
+        "-w", "--wait", "-X", "--xml",
+        "--column-names", "--auto-rehash"
+      ]
+    },
+    "duckdb": {
+      "default": "sql_cli",
+      "sql_flags": ["-c", "-cmd"],
+      "sql_positional_index": 1,
+      "valueless_flags": [
+        "-readonly", "-batch", "-csv", "-echo", "-header", "-noheader",
+        "-html", "-interactive", "-json", "-line", "-list", "-markdown",
+        "-quote", "-table", "-version", "-help"
+      ],
+      "_note": "duckdb CLI mirrors sqlite3 surface: DB [SQL], plus -c/-cmd flags."
     }
   }
 }

--- a/tests/test_grammar_classifier.py
+++ b/tests/test_grammar_classifier.py
@@ -587,6 +587,140 @@ class TestClassifierAllowPatterns(unittest.TestCase):
         self.assertEqual(d, DECISION_UNKNOWN)
 
 
+class TestSqlCli(unittest.TestCase):
+    """SQL clients: sqlite3 / psql / mysql / mariadb / duckdb. The argv
+    walker extracts SQL and the SQL keyword scan decides safe vs unsafe."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.clf = _make_classifier()
+
+    def assertDecision(self, cmd, expected):
+        d, r = self.clf.classify(cmd)
+        self.assertEqual(d, expected, msg="cmd={!r}, reason={}".format(cmd, r))
+
+    # sqlite3 positional SQL
+    def test_sqlite3_select_safe(self):
+        self.assertDecision(
+            'sqlite3 /tmp/db.sqlite "SELECT * FROM foo"',
+            DECISION_SAFE,
+        )
+
+    def test_sqlite3_multiline_select_safe(self):
+        cmd = (
+            'sqlite3 /Users/x/voitta.db "SELECT sync_status,\n'
+            "COALESCE(sync_error,'none') AS err, "
+            "(SELECT count(*) FROM llm_tldr_indexed_files WHERE\n"
+            "folder_path='vrag-test-4') AS tldr_rows "
+            "FROM folder_sync_sources WHERE folder_path='vrag-test-4';\""
+        )
+        self.assertDecision(cmd, DECISION_SAFE)
+
+    def test_sqlite3_drop_unsafe(self):
+        self.assertDecision(
+            "sqlite3 /tmp/db.sqlite 'DROP TABLE foo'",
+            DECISION_UNSAFE,
+        )
+
+    def test_sqlite3_insert_unsafe(self):
+        self.assertDecision(
+            "sqlite3 /tmp/db.sqlite 'INSERT INTO foo VALUES (1)'",
+            DECISION_UNSAFE,
+        )
+
+    def test_sqlite3_interactive_is_unknown(self):
+        # Bare invocation drops the user into a REPL — no SQL to analyze.
+        self.assertDecision("sqlite3 /tmp/db.sqlite", DECISION_UNKNOWN)
+
+    def test_sqlite3_dot_tables_safe(self):
+        self.assertDecision(
+            "sqlite3 /tmp/db.sqlite '.tables'",
+            DECISION_SAFE,
+        )
+
+    def test_sqlite3_dot_import_unsafe(self):
+        self.assertDecision(
+            "sqlite3 /tmp/db.sqlite '.import foo.csv mytable'",
+            DECISION_UNSAFE,
+        )
+
+    def test_sqlite3_cmd_flag(self):
+        self.assertDecision(
+            'sqlite3 -cmd "SELECT 1" /tmp/db.sqlite',
+            DECISION_SAFE,
+        )
+
+    def test_sqlite3_readonly_flag_does_not_eat_positional(self):
+        # -readonly is valueless; it must not consume /tmp/db.sqlite.
+        self.assertDecision(
+            'sqlite3 -readonly /tmp/db.sqlite "SELECT 1"',
+            DECISION_SAFE,
+        )
+
+    # psql -c
+    def test_psql_dash_c_select_safe(self):
+        self.assertDecision(
+            'psql -c "SELECT 1" mydb',
+            DECISION_SAFE,
+        )
+
+    def test_psql_dash_c_delete_unsafe(self):
+        self.assertDecision(
+            'psql -c "DELETE FROM users WHERE id = 1" mydb',
+            DECISION_UNSAFE,
+        )
+
+    def test_psql_command_long_form(self):
+        self.assertDecision(
+            'psql --command "SELECT now()" mydb',
+            DECISION_SAFE,
+        )
+
+    def test_psql_dash_f_file_is_unknown(self):
+        # File contents are opaque to a static checker.
+        self.assertDecision(
+            "psql -f queries.sql mydb",
+            DECISION_UNKNOWN,
+        )
+
+    def test_psql_bare_dbname_is_unknown(self):
+        self.assertDecision("psql mydb", DECISION_UNKNOWN)
+
+    # mysql -e
+    def test_mysql_dash_e_select_safe(self):
+        self.assertDecision(
+            'mysql -e "SELECT VERSION()" mydb',
+            DECISION_SAFE,
+        )
+
+    def test_mysql_dash_e_drop_unsafe(self):
+        self.assertDecision(
+            'mysql -e "DROP TABLE foo" mydb',
+            DECISION_UNSAFE,
+        )
+
+    def test_mysql_execute_equals_form(self):
+        self.assertDecision(
+            'mysql --execute=SHOW DATABASES',
+            DECISION_SAFE,
+        )
+
+    # SQL injected via $(...) substitution — placeholders preserve safety.
+    def test_sqlite3_with_substitution_in_select(self):
+        self.assertDecision(
+            'sqlite3 /tmp/db "SELECT * FROM t WHERE id = $(echo 1)"',
+            DECISION_SAFE,
+        )
+
+    # Compound: SELECT then mutating substitution.
+    def test_sqlite3_with_destructive_substitution(self):
+        # The outer SQL is SELECT (safe), but the substitution runs `rm`.
+        self.assertDecision(
+            'sqlite3 /tmp/db "SELECT $(rm -rf /tmp/x)"',
+            DECISION_UNSAFE,
+        )
+
+
 class TestClassifierCLI(unittest.TestCase):
     """grammar_classifier.py is also runnable as a standalone CLI."""
 

--- a/tests/test_rule_classifier.py
+++ b/tests/test_rule_classifier.py
@@ -25,9 +25,11 @@ from rule_classifier import (  # noqa: E402
     DECISION_UNSAFE,
     aggregate_decisions,
     check_unsafe_flags,
+    classify_sql_text,
     load_allow_patterns,
     match_allow_patterns,
     parse_aws_positionals,
+    parse_sql_cli_argv,
 )
 
 
@@ -188,6 +190,206 @@ class TestMatchAllowPatterns(unittest.TestCase):
 
     def test_strips_whitespace(self):
         self.assertEqual(match_allow_patterns("  env  ", ["env"]), "env")
+
+
+class TestClassifySqlText(unittest.TestCase):
+    def test_simple_select_safe(self):
+        d, _ = classify_sql_text("sqlite3", "SELECT * FROM foo")
+        self.assertEqual(d, DECISION_SAFE)
+
+    def test_select_with_subquery_safe(self):
+        sql = (
+            "SELECT sync_status, COALESCE(sync_error,'none') AS err, "
+            "(SELECT count(*) FROM t WHERE path='x') AS n "
+            "FROM s WHERE path='x';"
+        )
+        d, _ = classify_sql_text("sqlite3", sql)
+        self.assertEqual(d, DECISION_SAFE)
+
+    def test_with_cte_select_safe(self):
+        d, _ = classify_sql_text(
+            "psql",
+            "WITH t AS (SELECT 1) SELECT * FROM t",
+        )
+        self.assertEqual(d, DECISION_SAFE)
+
+    def test_insert_unsafe(self):
+        d, _ = classify_sql_text("psql", "INSERT INTO t VALUES (1)")
+        self.assertEqual(d, DECISION_UNSAFE)
+
+    def test_update_unsafe(self):
+        d, _ = classify_sql_text("mysql", "UPDATE t SET x = 1 WHERE id = 2")
+        self.assertEqual(d, DECISION_UNSAFE)
+
+    def test_delete_unsafe(self):
+        d, _ = classify_sql_text("psql", "DELETE FROM t WHERE id = 1")
+        self.assertEqual(d, DECISION_UNSAFE)
+
+    def test_drop_unsafe(self):
+        d, _ = classify_sql_text("sqlite3", "DROP TABLE foo")
+        self.assertEqual(d, DECISION_UNSAFE)
+
+    def test_create_unsafe(self):
+        d, _ = classify_sql_text("psql", "CREATE TABLE t (id int)")
+        self.assertEqual(d, DECISION_UNSAFE)
+
+    def test_alter_unsafe(self):
+        d, _ = classify_sql_text("psql", "ALTER TABLE t ADD COLUMN x int")
+        self.assertEqual(d, DECISION_UNSAFE)
+
+    def test_truncate_unsafe(self):
+        d, _ = classify_sql_text("mysql", "TRUNCATE TABLE t")
+        self.assertEqual(d, DECISION_UNSAFE)
+
+    def test_with_cte_delete_unsafe(self):
+        # CTE with mutating tail.
+        d, _ = classify_sql_text(
+            "psql",
+            "WITH t AS (SELECT id FROM s) DELETE FROM s WHERE id IN (SELECT id FROM t)",
+        )
+        self.assertEqual(d, DECISION_UNSAFE)
+
+    def test_delete_in_string_literal_safe(self):
+        # The string literal is stripped before scanning.
+        d, _ = classify_sql_text(
+            "psql",
+            "SELECT name FROM users WHERE label = 'DELETE FROM users'",
+        )
+        self.assertEqual(d, DECISION_SAFE)
+
+    def test_delete_in_line_comment_does_not_flag(self):
+        d, _ = classify_sql_text(
+            "psql",
+            "SELECT 1 -- DELETE FROM x\nFROM dual",
+        )
+        self.assertEqual(d, DECISION_SAFE)
+
+    def test_delete_in_block_comment_does_not_flag(self):
+        d, _ = classify_sql_text(
+            "psql",
+            "SELECT 1 /* DELETE FROM x */ FROM dual",
+        )
+        self.assertEqual(d, DECISION_SAFE)
+
+    def test_multiple_statements_one_unsafe(self):
+        d, _ = classify_sql_text(
+            "psql",
+            "SELECT 1; INSERT INTO t VALUES (1); SELECT 2;",
+        )
+        self.assertEqual(d, DECISION_UNSAFE)
+
+    def test_explain_safe(self):
+        d, _ = classify_sql_text("psql", "EXPLAIN SELECT * FROM t")
+        self.assertEqual(d, DECISION_SAFE)
+
+    def test_show_safe(self):
+        d, _ = classify_sql_text("mysql", "SHOW TABLES")
+        self.assertEqual(d, DECISION_SAFE)
+
+    def test_describe_safe(self):
+        d, _ = classify_sql_text("mysql", "DESCRIBE foo")
+        self.assertEqual(d, DECISION_SAFE)
+
+    def test_pragma_read_safe(self):
+        d, _ = classify_sql_text("sqlite3", "PRAGMA table_info(foo)")
+        self.assertEqual(d, DECISION_SAFE)
+
+    def test_pragma_assignment_unsafe(self):
+        d, _ = classify_sql_text("sqlite3", "PRAGMA journal_mode = WAL")
+        self.assertEqual(d, DECISION_UNSAFE)
+
+    def test_unknown_first_keyword(self):
+        d, _ = classify_sql_text("psql", "BANANA FROM t")
+        self.assertEqual(d, DECISION_UNKNOWN)
+
+    def test_empty_sql_safe(self):
+        d, _ = classify_sql_text("sqlite3", "")
+        self.assertEqual(d, DECISION_SAFE)
+
+    def test_sqlite_dot_tables_safe(self):
+        d, _ = classify_sql_text("sqlite3", ".tables")
+        self.assertEqual(d, DECISION_SAFE)
+
+    def test_sqlite_dot_schema_safe(self):
+        d, _ = classify_sql_text("sqlite3", ".schema foo")
+        self.assertEqual(d, DECISION_SAFE)
+
+    def test_sqlite_dot_import_unsafe(self):
+        d, _ = classify_sql_text("sqlite3", ".import foo.csv mytable")
+        self.assertEqual(d, DECISION_UNSAFE)
+
+    def test_sqlite_dot_unknown_falls_through(self):
+        d, _ = classify_sql_text("sqlite3", ".weirdcmd foo")
+        self.assertEqual(d, DECISION_UNKNOWN)
+
+    def test_select_with_single_quote_escape(self):
+        # 'don''t' is a single-quoted string containing an escaped quote.
+        d, _ = classify_sql_text(
+            "psql",
+            "SELECT 'don''t' FROM dual",
+        )
+        self.assertEqual(d, DECISION_SAFE)
+
+
+class TestParseSqlCliArgv(unittest.TestCase):
+    def test_sqlite3_positional_sql(self):
+        spec = {"sql_positional_index": 1}
+        sqls, file_in = parse_sql_cli_argv(
+            ["/path/db.sqlite", "SELECT 1"], spec,
+        )
+        self.assertEqual(sqls, ["SELECT 1"])
+        self.assertFalse(file_in)
+
+    def test_sqlite3_interactive_no_sql(self):
+        spec = {"sql_positional_index": 1}
+        sqls, _ = parse_sql_cli_argv(["/path/db.sqlite"], spec)
+        self.assertEqual(sqls, [])
+
+    def test_psql_dash_c_flag(self):
+        spec = {"sql_flags": ["-c", "--command"]}
+        sqls, _ = parse_sql_cli_argv(
+            ["-c", "SELECT 1", "mydb"], spec,
+        )
+        self.assertEqual(sqls, ["SELECT 1"])
+
+    def test_mysql_dash_e_flag(self):
+        spec = {"sql_flags": ["-e", "--execute"]}
+        sqls, _ = parse_sql_cli_argv(
+            ["-e", "SHOW TABLES", "mydb"], spec,
+        )
+        self.assertEqual(sqls, ["SHOW TABLES"])
+
+    def test_long_flag_with_equals(self):
+        spec = {"sql_flags": ["-e", "--execute"]}
+        sqls, _ = parse_sql_cli_argv(
+            ["--execute=SELECT 1"], spec,
+        )
+        self.assertEqual(sqls, ["SELECT 1"])
+
+    def test_file_input_flag(self):
+        spec = {"sql_file_flags": ["-f", "--file"]}
+        _, file_in = parse_sql_cli_argv(["-f", "queries.sql"], spec)
+        self.assertTrue(file_in)
+
+    def test_valueless_flag_does_not_consume_positional(self):
+        spec = {
+            "sql_positional_index": 1,
+            "valueless_flags": ["-batch"],
+        }
+        sqls, _ = parse_sql_cli_argv(
+            ["-batch", "/path/db", "SELECT 1"], spec,
+        )
+        self.assertEqual(sqls, ["SELECT 1"])
+
+    def test_short_flag_with_value_consumes_next(self):
+        # `-cmd CMD` form (sqlite3): no `--`, takes a value.
+        spec = {"sql_flags": ["-cmd"], "sql_positional_index": 1}
+        sqls, _ = parse_sql_cli_argv(
+            ["-cmd", "SELECT 1", "/path/db"], spec,
+        )
+        # `-cmd` captured as SQL flag; remaining positional[0] is the DB,
+        # no positional[1].
+        self.assertEqual(sqls, ["SELECT 1"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Adds a new `sql_cli` default in `rules/shell.json` so YOLT can auto-allow read-only SQL invocations (e.g. `sqlite3 db 'SELECT ...'`, `psql -c 'SELECT ...'`, `mysql -e 'SHOW TABLES'`) without prompting, and route mutating SQL to the `ask` path.

- `parse_sql_cli_argv` pulls SQL out of argv: positional for `sqlite3` / `duckdb`, `-c` / `--command` for `psql`, `-e` / `--execute` for `mysql` / `mariadb`. Per-CLI valueless flag lists keep flag parsing from eating positionals.
- `classify_sql_text` strips line comments (`-- ...`), block comments (`/* ... */`), and string / identifier literals (`'...'`, `"..."`, `` `...` ``). Then it scans for mutating keywords anywhere (`INSERT`, `UPDATE`, `DELETE`, `DROP`, `CREATE`, `ALTER`, `TRUNCATE`, `REPLACE`, `MERGE`, `GRANT`, `REVOKE`, `VACUUM`, `REINDEX`, `ATTACH`, `DETACH`, `COMMIT`, `ROLLBACK`, `BEGIN`, `COPY`, `LOAD`, `IMPORT`, `LOCK`, `CALL`, `EXEC`, `SET`, `RESET`, ...) and classifies by first keyword for safe (`SELECT`, `WITH`, `EXPLAIN`, `SHOW`, `DESCRIBE`, `VALUES`, `TABLE`).
- `PRAGMA`: safe for reads, unsafe on assignment (`PRAGMA journal_mode = WAL`).
- sqlite3 dot-commands have their own list — `.tables` / `.schema` / `.headers` safe; `.import` / `.load` / `.read` / `.shell` / `.backup` unsafe; unknown dot-commands fall through.
- File input (`psql -f`, `mysql <`) stays `unknown` (opaque to static checker). Bare `sqlite3 db` stays `unknown` (opens REPL).

## Test plan

- [x] `python3 -m unittest discover -v tests` — 218/218 pass (50 new SQL tests).
- [x] `./examples/demo.sh` — SQL examples land on expected decisions.
- [x] Hand-run on real command: `sqlite3 voitta.db "SELECT sync_status, COALESCE(...) ... FROM folder_sync_sources WHERE folder_path='vrag-test-4'"` → `safe`.
- [x] `psql -c 'DELETE FROM users' mydb` → `unsafe`.
- [x] `mysql -e 'SELECT VERSION()' mydb` → `safe`.
