### PR TITLE
Honor unsafe_flag_value_prefix in shell rule evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,10 +410,13 @@ YOLT logs every examined Bash invocation by default to
 {"ts": "2026-05-08T14:00:00.000+00:00", "decision": "safe", "reason": "ls: read-only", "command": "ls /tmp"}
 ```
 
-`decision` is one of `safe`, `unsafe`, `unknown`, or `import-error` (the
-last when the tree-sitter dependency is missing). The `command` field is
-truncated to 500 characters. Logging failures are swallowed — the hook
-never breaks the session because of an unwritable log path.
+`decision` is one of `safe`, `unsafe`, `unknown`, `import-error` (the
+tree-sitter dependency is missing), or `rules-validation-error` (the
+bundled or user-override `shell.json` failed schema validation; the
+`reason` field carries the list of offending keys / defaults so the
+user can fix the override). The `command` field is truncated to 500
+characters. Logging failures are swallowed — the hook never breaks the
+session because of an unwritable log path.
 
 ```bash
 tail -f ~/.claude/yolt.log

--- a/hooks/rule_classifier.py
+++ b/hooks/rule_classifier.py
@@ -308,10 +308,26 @@ def aggregate_decisions(decisions):
 
 def check_unsafe_flags(cmd_args, spec):
     """Check whether cmd_args contains a flag combination the command spec
-    declares unsafe. Returns a human-readable description, or None."""
+    declares unsafe. Returns a human-readable description, or None.
+
+    Recognized fields on `spec`:
+
+    - `unsafe_flags_without_value`: list of flags that are unsafe by their
+      presence alone (`find -delete`).
+    - `unsafe_flag_values`: dict flag -> list of values. Match is
+      case-insensitive equality against the value (`curl -X POST`).
+    - `unsafe_flag_any_value`: list of flags unsafe whenever they appear,
+      regardless of value (`curl -d ...`).
+    - `unsafe_flag_value_prefix`: dict flag -> fnmatch glob pattern.
+      The flag carries a value (inline `--flag=value` or split
+      `--flag value`); the value is matched against the glob
+      (`find -exec rm`, `gh api --input body.json`). `"*"` matches any
+      value.
+    """
     unsafe_flag_values = spec.get("unsafe_flag_values", {})
     unsafe_flag_any_value = set(spec.get("unsafe_flag_any_value", []))
     unsafe_flags_without_value = set(spec.get("unsafe_flags_without_value", []))
+    unsafe_flag_value_prefix = spec.get("unsafe_flag_value_prefix", {})
 
     i = 0
     while i < len(cmd_args):
@@ -335,12 +351,162 @@ def check_unsafe_flags(cmd_args, spec):
                     if value_upper == unsafe_val.upper():
                         return "{} {}".format(flag, value)
 
+        if flag in unsafe_flag_value_prefix:
+            value = inline_value
+            if value is None and i + 1 < len(cmd_args):
+                value = cmd_args[i + 1]
+            if value is not None:
+                pat = unsafe_flag_value_prefix[flag]
+                if fnmatch(value, pat):
+                    return "{} {}".format(flag, value)
+
         if flag in unsafe_flag_any_value:
             return flag
 
         i += 1
 
     return None
+
+
+_ALLOWED_DEFAULTS = frozenset({
+    "safe", "unsafe", "ask", "unknown",
+    "subcommand", "delegate_to_argument",
+    "aws_cli", "gcloud_cli", "az_cli", "sql_cli",
+})
+
+_ALLOWED_TOP_LEVEL_KEYS = frozenset({
+    "_meta", "_safe_write_targets_note",
+    "shell_builtins_safe", "shell_keywords",
+    "safe_write_targets",
+    "commands", "interpreters",
+})
+
+_ALLOWED_COMMAND_KEYS = frozenset({
+    "default", "_note", "_skip_first_positional",
+    "unsafe_flag_values", "unsafe_flag_any_value",
+    "unsafe_flags_without_value", "unsafe_flag_value_prefix",
+    "valueless_flags",
+    "safe_subcommands", "unsafe_subcommands",
+    "safe_subcommand_patterns", "unsafe_subcommand_patterns",
+    "nested_subcommand",
+    "service_overrides",
+    "safe_operation_patterns", "unsafe_operation_patterns",
+    "sql_flags", "sql_file_flags", "sql_positional_index",
+})
+
+_ALLOWED_SERVICE_OVERRIDE_KEYS = frozenset({
+    "_note",
+    "safe_subcommands", "unsafe_subcommands",
+    "safe_operation_patterns", "unsafe_operation_patterns",
+    "extra_safe_patterns",
+})
+
+_ALLOWED_INTERPRETER_KEYS = frozenset({
+    "inline_flag", "module_flag", "delegate", "read_script_file",
+    "safe_modules", "unsafe_modules",
+    "safe_module_patterns", "unsafe_module_patterns",
+    "nested_modules",
+})
+
+_ALLOWED_NESTED_MODULE_KEYS = frozenset({
+    "default",
+    "safe_subcommands", "unsafe_subcommands",
+    "safe_subcommand_patterns", "unsafe_subcommand_patterns",
+})
+
+
+def validate_shell_rules(rules):
+    """Schema-check a loaded shell.json. Returns a list of error strings —
+    empty list means the data only uses keys / defaults the classifier
+    actually evaluates. Catches drift where the rule file references a
+    field the implementation silently ignores."""
+    errors = []
+
+    for key in rules:
+        if key not in _ALLOWED_TOP_LEVEL_KEYS:
+            errors.append("top-level: unknown key '{}'".format(key))
+
+    commands = rules.get("commands", {})
+    if not isinstance(commands, dict):
+        errors.append("commands: must be a dict")
+        commands = {}
+
+    for name, spec in commands.items():
+        if not isinstance(spec, dict):
+            errors.append("commands.{}: must be a dict".format(name))
+            continue
+        _validate_command_spec("commands.{}".format(name), spec, errors)
+
+    interpreters = rules.get("interpreters", {})
+    if not isinstance(interpreters, dict):
+        errors.append("interpreters: must be a dict")
+        interpreters = {}
+
+    for name, spec in interpreters.items():
+        if not isinstance(spec, dict):
+            errors.append("interpreters.{}: must be a dict".format(name))
+            continue
+        for key in spec:
+            if key not in _ALLOWED_INTERPRETER_KEYS:
+                errors.append(
+                    "interpreters.{}: unknown key '{}'".format(name, key)
+                )
+        nested = spec.get("nested_modules", {})
+        if isinstance(nested, dict):
+            for mod, mod_spec in nested.items():
+                if not isinstance(mod_spec, dict):
+                    errors.append(
+                        "interpreters.{}.nested_modules.{}: must be a dict"
+                        .format(name, mod)
+                    )
+                    continue
+                for key in mod_spec:
+                    if key not in _ALLOWED_NESTED_MODULE_KEYS:
+                        errors.append(
+                            "interpreters.{}.nested_modules.{}: unknown key '{}'"
+                            .format(name, mod, key)
+                        )
+
+    return errors
+
+
+def _validate_command_spec(path, spec, errors):
+    for key in spec:
+        if key not in _ALLOWED_COMMAND_KEYS:
+            errors.append("{}: unknown key '{}'".format(path, key))
+
+    default = spec.get("default")
+    if default is not None and default not in _ALLOWED_DEFAULTS:
+        errors.append("{}: unknown default '{}'".format(path, default))
+
+    nested = spec.get("nested_subcommand", {})
+    if isinstance(nested, dict):
+        for sub, sub_spec in nested.items():
+            if not isinstance(sub_spec, dict):
+                errors.append(
+                    "{}.nested_subcommand.{}: must be a dict".format(path, sub)
+                )
+                continue
+            _validate_command_spec(
+                "{}.nested_subcommand.{}".format(path, sub),
+                sub_spec,
+                errors,
+            )
+
+    overrides = spec.get("service_overrides", {})
+    if isinstance(overrides, dict):
+        for svc, svc_spec in overrides.items():
+            if not isinstance(svc_spec, dict):
+                errors.append(
+                    "{}.service_overrides.{}: must be a dict".format(path, svc)
+                )
+                continue
+            for key in svc_spec:
+                if key not in _ALLOWED_SERVICE_OVERRIDE_KEYS:
+                    errors.append(
+                        "{}.service_overrides.{}: unknown key '{}'"
+                        .format(path, svc, key)
+                    )
 
 
 def parse_aws_positionals(cmd_args):

--- a/hooks/rule_classifier.py
+++ b/hooks/rule_classifier.py
@@ -222,9 +222,16 @@ def parse_sql_cli_argv(cmd_args, spec):
     return retval
 
 
-def load_shell_rules(rules_dir, user_overrides_path=None):
+def load_shell_rules(rules_dir, user_overrides_path=None, validate=True):
     """Load shell rules from rules_dir/shell.json plus optional overrides.
-    Overrides merge per top-level key, one level deep."""
+    Overrides merge per top-level key, one level deep.
+
+    By default the merged result is schema-checked via `validate_shell_rules`
+    and a `ShellRulesValidationError` is raised on drift, so malformed rule
+    data (including user overrides under `~/.claude/yolt/shell.json`) fails
+    at load time rather than degrading silently to `unknown` at classify
+    time. Pass `validate=False` to skip — useful for tests that construct
+    intentionally-malformed rule fixtures."""
     rules = {}
 
     default_path = Path(rules_dir) / "shell.json"
@@ -241,7 +248,27 @@ def load_shell_rules(rules_dir, user_overrides_path=None):
             else:
                 rules[key] = value
 
+    if validate:
+        errors = validate_shell_rules(rules)
+        if errors:
+            raise ShellRulesValidationError(default_path, user_overrides_path, errors)
+
     return rules
+
+
+class ShellRulesValidationError(ValueError):
+    """Raised when shell rule data references keys or defaults the
+    classifier does not implement. Carries the source paths and the full
+    list of error strings so callers can log them verbatim."""
+
+    def __init__(self, default_path, user_overrides_path, errors):
+        self.default_path = default_path
+        self.user_overrides_path = user_overrides_path
+        self.errors = list(errors)
+        message = "shell rules failed validation ({} error(s)): {}".format(
+            len(self.errors), "; ".join(self.errors),
+        )
+        super().__init__(message)
 
 
 def load_allow_patterns(settings_paths):
@@ -414,6 +441,11 @@ _ALLOWED_NESTED_MODULE_KEYS = frozenset({
     "safe_subcommand_patterns", "unsafe_subcommand_patterns",
 })
 
+# `_classify_nested_module` only resolves "safe" and "unsafe"; any other
+# value silently degrades to `unknown` at classify time, which is exactly
+# the drift this validator exists to catch.
+_ALLOWED_NESTED_MODULE_DEFAULTS = frozenset({"safe", "unsafe"})
+
 
 def validate_shell_rules(rules):
     """Schema-check a loaded shell.json. Returns a list of error strings —
@@ -466,6 +498,15 @@ def validate_shell_rules(rules):
                             "interpreters.{}.nested_modules.{}: unknown key '{}'"
                             .format(name, mod, key)
                         )
+                mod_default = mod_spec.get("default")
+                if (
+                    mod_default is not None
+                    and mod_default not in _ALLOWED_NESTED_MODULE_DEFAULTS
+                ):
+                    errors.append(
+                        "interpreters.{}.nested_modules.{}: unknown default '{}'"
+                        .format(name, mod, mod_default)
+                    )
 
     return errors
 

--- a/hooks/yolt_analyzer.py
+++ b/hooks/yolt_analyzer.py
@@ -358,16 +358,21 @@ def run_hook():
         from grammar_classifier import GrammarClassifier
         from rule_classifier import (
             DECISION_SAFE, DECISION_UNSAFE,
+            ShellRulesValidationError,
             load_allow_patterns, load_shell_rules,
         )
     except ImportError as e:
         _log_hook_decision(command, "import-error", str(e))
         sys.exit(0)
 
-    shell_rules = load_shell_rules(
-        rules_dir=yolt_dir / "rules",
-        user_overrides_path=Path.home() / ".claude" / "yolt" / "shell.json",
-    )
+    try:
+        shell_rules = load_shell_rules(
+            rules_dir=yolt_dir / "rules",
+            user_overrides_path=Path.home() / ".claude" / "yolt" / "shell.json",
+        )
+    except ShellRulesValidationError as e:
+        _log_hook_decision(command, "rules-validation-error", str(e))
+        sys.exit(0)
 
     cwd_str = hook_input.get("cwd") or os.getcwd()
     cwd = Path(cwd_str)

--- a/tests/test_grammar_classifier.py
+++ b/tests/test_grammar_classifier.py
@@ -223,6 +223,36 @@ class TestClassifyScenarios(unittest.TestCase):
     def test_find_delete_unsafe(self):
         self.assertDecision("find . -name '*.py' -delete", DECISION_UNSAFE)
 
+    def test_find_exec_unsafe(self):
+        self.assertDecision(
+            r"find . -name '*.py' -exec rm {} \;", DECISION_UNSAFE,
+        )
+
+    def test_find_execdir_unsafe(self):
+        self.assertDecision(
+            r"find . -name '*.py' -execdir rm {} \;", DECISION_UNSAFE,
+        )
+
+    def test_find_ok_unsafe(self):
+        self.assertDecision(
+            r"find . -name '*.py' -ok rm {} \;", DECISION_UNSAFE,
+        )
+
+    def test_find_okdir_unsafe(self):
+        self.assertDecision(
+            r"find . -name '*.py' -okdir rm {} \;", DECISION_UNSAFE,
+        )
+
+    def test_gh_api_input_split_unsafe(self):
+        self.assertDecision(
+            "gh api /repos/x/y/issues --input body.json", DECISION_UNSAFE,
+        )
+
+    def test_gh_api_input_inline_unsafe(self):
+        self.assertDecision(
+            "gh api /repos/x/y/issues --input=body.json", DECISION_UNSAFE,
+        )
+
     def test_sed_inplace_unsafe(self):
         self.assertDecision("sed -i 's/a/b/' file.txt", DECISION_UNSAFE)
 

--- a/tests/test_rule_classifier.py
+++ b/tests/test_rule_classifier.py
@@ -515,6 +515,111 @@ class TestValidateShellRules(unittest.TestCase):
         })
         self.assertTrue(any("rogue" in e for e in errors), errors)
 
+    def test_nested_module_unknown_default_flagged(self):
+        # `_classify_nested_module` only resolves "safe" and "unsafe"; any
+        # other value silently degrades to `unknown` at classify time.
+        errors = validate_shell_rules({
+            "interpreters": {
+                "python3": {
+                    "module_flag": "-m",
+                    "nested_modules": {
+                        "pip": {"default": "bogus"},
+                    },
+                },
+            },
+        })
+        self.assertTrue(
+            any("bogus" in e and "default" in e for e in errors), errors,
+        )
+
+    def test_nested_module_safe_default_accepted(self):
+        errors = validate_shell_rules({
+            "interpreters": {
+                "python3": {
+                    "module_flag": "-m",
+                    "nested_modules": {
+                        "unittest": {"default": "safe"},
+                    },
+                },
+            },
+        })
+        self.assertEqual(errors, [])
+
+    def test_nested_module_unsafe_default_accepted(self):
+        errors = validate_shell_rules({
+            "interpreters": {
+                "python3": {
+                    "module_flag": "-m",
+                    "nested_modules": {
+                        "blah": {"default": "unsafe"},
+                    },
+                },
+            },
+        })
+        self.assertEqual(errors, [])
+
+
+class TestLoadShellRulesValidation(unittest.TestCase):
+    """Verify validation is wired into `load_shell_rules` itself — the
+    production load path used by the hook entry and CLI — not just into
+    tests that call `validate_shell_rules` directly."""
+
+    def setUp(self):
+        self._tmp = tempfile.mkdtemp(prefix="yolt-shell-rules-")
+        self.tmp = Path(self._tmp)
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self._tmp, ignore_errors=True)
+
+    def _write(self, name, data):
+        path = self.tmp / name
+        path.write_text(json.dumps(data))
+        return path
+
+    def test_real_rules_load_clean(self):
+        # The bundled rules/shell.json must load through the validating
+        # path without raising.
+        rules = load_shell_rules(REPO_ROOT / "rules")
+        self.assertIn("commands", rules)
+
+    def test_malformed_default_raises(self):
+        # Drop a malformed rules dir in place of the real one.
+        rules_dir = self.tmp / "rules"
+        rules_dir.mkdir()
+        (rules_dir / "shell.json").write_text(json.dumps({
+            "commands": {"mycli": {"default": "totally-made-up"}},
+        }))
+        from rule_classifier import ShellRulesValidationError
+        with self.assertRaises(ShellRulesValidationError) as ctx:
+            load_shell_rules(rules_dir)
+        self.assertTrue(
+            any("totally-made-up" in e for e in ctx.exception.errors),
+            ctx.exception.errors,
+        )
+
+    def test_malformed_override_raises(self):
+        # Real defaults are clean; the user override introduces drift.
+        override = self._write("shell.json", {
+            "commands": {"mycli": {"default": "safe", "phantom_key": []}},
+        })
+        from rule_classifier import ShellRulesValidationError
+        with self.assertRaises(ShellRulesValidationError) as ctx:
+            load_shell_rules(REPO_ROOT / "rules", user_overrides_path=override)
+        self.assertTrue(
+            any("phantom_key" in e for e in ctx.exception.errors),
+            ctx.exception.errors,
+        )
+
+    def test_validate_false_bypasses_check(self):
+        rules_dir = self.tmp / "rules"
+        rules_dir.mkdir()
+        (rules_dir / "shell.json").write_text(json.dumps({
+            "commands": {"mycli": {"default": "totally-made-up"}},
+        }))
+        rules = load_shell_rules(rules_dir, validate=False)
+        self.assertIn("commands", rules)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_rule_classifier.py
+++ b/tests/test_rule_classifier.py
@@ -27,9 +27,11 @@ from rule_classifier import (  # noqa: E402
     check_unsafe_flags,
     classify_sql_text,
     load_allow_patterns,
+    load_shell_rules,
     match_allow_patterns,
     parse_aws_positionals,
     parse_sql_cli_argv,
+    validate_shell_rules,
 )
 
 
@@ -61,6 +63,53 @@ class TestCheckUnsafeFlags(unittest.TestCase):
     def test_none_of_the_above(self):
         spec = {"unsafe_flag_values": {"-X": ["POST"]}}
         self.assertIsNone(check_unsafe_flags(["--foo", "bar"], spec))
+
+    def test_unsafe_flag_value_prefix_split_form(self):
+        spec = {"unsafe_flag_value_prefix": {"--input": "*"}}
+        result = check_unsafe_flags(["--input", "body.json"], spec)
+        self.assertIsNotNone(result)
+        self.assertIn("--input", result)
+        self.assertIn("body.json", result)
+
+    def test_unsafe_flag_value_prefix_inline_form(self):
+        spec = {"unsafe_flag_value_prefix": {"--input": "*"}}
+        result = check_unsafe_flags(["--input=body.json"], spec)
+        self.assertIsNotNone(result)
+        self.assertIn("body.json", result)
+
+    def test_unsafe_flag_value_prefix_find_exec(self):
+        spec = {
+            "unsafe_flag_value_prefix": {
+                "-exec": "*", "-execdir": "*", "-ok": "*", "-okdir": "*",
+            },
+        }
+        self.assertIsNotNone(
+            check_unsafe_flags(["-name", "*.py", "-exec", "rm", "{}", r"\;"], spec)
+        )
+        self.assertIsNotNone(
+            check_unsafe_flags(["-execdir", "rm", "{}", r"\;"], spec)
+        )
+        self.assertIsNotNone(
+            check_unsafe_flags(["-ok", "rm", "{}", r"\;"], spec)
+        )
+        self.assertIsNotNone(
+            check_unsafe_flags(["-okdir", "rm", "{}", r"\;"], spec)
+        )
+
+    def test_unsafe_flag_value_prefix_no_value(self):
+        # Flag at end of argv with no value following — no match.
+        spec = {"unsafe_flag_value_prefix": {"--input": "*"}}
+        self.assertIsNone(check_unsafe_flags(["--input"], spec))
+
+    def test_unsafe_flag_value_prefix_narrow_pattern(self):
+        # Glob narrower than `*` must still match the actual value.
+        spec = {"unsafe_flag_value_prefix": {"--input": "body.*"}}
+        self.assertIsNotNone(
+            check_unsafe_flags(["--input", "body.json"], spec)
+        )
+        self.assertIsNone(
+            check_unsafe_flags(["--input", "request.json"], spec)
+        )
 
 
 class TestParseAwsPositionals(unittest.TestCase):
@@ -390,6 +439,81 @@ class TestParseSqlCliArgv(unittest.TestCase):
         # `-cmd` captured as SQL flag; remaining positional[0] is the DB,
         # no positional[1].
         self.assertEqual(sqls, ["SELECT 1"])
+
+
+class TestValidateShellRules(unittest.TestCase):
+    def test_default_rules_validate_clean(self):
+        rules = load_shell_rules(REPO_ROOT / "rules")
+        errors = validate_shell_rules(rules)
+        self.assertEqual(
+            errors, [],
+            "rules/shell.json has schema drift: {}".format(errors),
+        )
+
+    def test_unknown_top_level_key_flagged(self):
+        errors = validate_shell_rules({"bogus_key": []})
+        self.assertTrue(any("bogus_key" in e for e in errors), errors)
+
+    def test_unknown_command_key_flagged(self):
+        errors = validate_shell_rules({
+            "commands": {"mycli": {"default": "safe", "made_up_flag": []}}
+        })
+        self.assertTrue(any("made_up_flag" in e for e in errors), errors)
+
+    def test_unknown_default_flagged(self):
+        errors = validate_shell_rules({
+            "commands": {"mycli": {"default": "not-a-real-default"}}
+        })
+        self.assertTrue(
+            any("not-a-real-default" in e for e in errors), errors,
+        )
+
+    def test_unknown_nested_subcommand_key_flagged(self):
+        errors = validate_shell_rules({
+            "commands": {
+                "mycli": {
+                    "default": "subcommand",
+                    "nested_subcommand": {
+                        "sub": {"default": "safe", "ghost_field": []},
+                    },
+                },
+            },
+        })
+        self.assertTrue(any("ghost_field" in e for e in errors), errors)
+
+    def test_unknown_service_override_key_flagged(self):
+        errors = validate_shell_rules({
+            "commands": {
+                "aws": {
+                    "default": "aws_cli",
+                    "service_overrides": {
+                        "s3": {"bogus": []},
+                    },
+                },
+            },
+        })
+        self.assertTrue(any("bogus" in e for e in errors), errors)
+
+    def test_unknown_interpreter_key_flagged(self):
+        errors = validate_shell_rules({
+            "interpreters": {
+                "python3": {"inline_flag": "-c", "weird_field": []},
+            },
+        })
+        self.assertTrue(any("weird_field" in e for e in errors), errors)
+
+    def test_unknown_nested_module_key_flagged(self):
+        errors = validate_shell_rules({
+            "interpreters": {
+                "python3": {
+                    "module_flag": "-m",
+                    "nested_modules": {
+                        "pip": {"safe_subcommands": ["list"], "rogue": []},
+                    },
+                },
+            },
+        })
+        self.assertTrue(any("rogue" in e for e in errors), errors)
 
 
 if __name__ == "__main__":

--- a/tests/test_yolt_hook.py
+++ b/tests/test_yolt_hook.py
@@ -511,5 +511,81 @@ class TestHookLogFile(unittest.TestCase):
         self.assertIn("hookSpecificOutput", result.stdout)
 
 
+class TestHookMalformedShellOverride(unittest.TestCase):
+    """If `~/.claude/yolt/shell.json` contains schema drift, the hook
+    must exit silently (Claude Code falls through to its default prompt)
+    and record the failure to the log so the user can diagnose."""
+
+    def setUp(self):
+        self._tmp = tempfile.mkdtemp(prefix="yolt-bad-override-")
+        self.tmp = Path(self._tmp)
+        self.fake_home = self.tmp / "home"
+        (self.fake_home / ".claude" / "yolt").mkdir(parents=True)
+        self.override_path = self.fake_home / ".claude" / "yolt" / "shell.json"
+        self.log_path = self.tmp / "yolt.log"
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self._tmp, ignore_errors=True)
+
+    def _run(self, command):
+        env = dict(os.environ)
+        env["HOME"] = str(self.fake_home)
+        env["YOLT_LOG_FILE"] = str(self.log_path)
+        retval = subprocess.run(
+            [sys.executable, str(HOOKS_DIR / "yolt_analyzer.py"), "--hook"],
+            input=json.dumps({
+                "tool_name": "Bash",
+                "tool_input": {"command": command},
+            }),
+            capture_output=True,
+            text=True,
+            timeout=30,
+            env=env,
+        )
+        return retval
+
+    def _records(self):
+        if not self.log_path.exists():
+            return []
+        retval = []
+        for line in self.log_path.read_text().splitlines():
+            line = line.strip()
+            if line:
+                retval.append(json.loads(line))
+        return retval
+
+    def test_unknown_command_key_in_override_logs_rules_error(self):
+        self.override_path.write_text(json.dumps({
+            "commands": {"mycli": {"default": "safe", "phantom_key": []}},
+        }))
+        result = self._run("ls /tmp")
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(result.stdout.strip(), "")
+        recs = self._records()
+        self.assertEqual(len(recs), 1)
+        self.assertEqual(recs[0]["decision"], "rules-validation-error")
+        self.assertIn("phantom_key", recs[0]["reason"])
+
+    def test_unknown_nested_module_default_in_override_logs_rules_error(self):
+        self.override_path.write_text(json.dumps({
+            "interpreters": {
+                "python3": {
+                    "module_flag": "-m",
+                    "nested_modules": {
+                        "pip": {"default": "bogus"},
+                    },
+                },
+            },
+        }))
+        result = self._run("ls /tmp")
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(result.stdout.strip(), "")
+        recs = self._records()
+        self.assertEqual(len(recs), 1)
+        self.assertEqual(recs[0]["decision"], "rules-validation-error")
+        self.assertIn("bogus", recs[0]["reason"])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- Extend `check_unsafe_flags()` in `hooks/rule_classifier.py` to honor `unsafe_flag_value_prefix`. The rule data already declared this field for `find -exec / -execdir / -ok / -okdir` and `gh api --input`, but the implementation only evaluated `unsafe_flag_values`, `unsafe_flag_any_value`, and `unsafe_flags_without_value`. Both split (`--flag value`) and inline (`--flag=value`) forms are matched; the value is fnmatch'd against the per-flag glob.
- Add `validate_shell_rules()` for load-time schema drift detection. A new `TestValidateShellRules` suite asserts the bundled `rules/shell.json` validates clean and that unknown top-level keys, command keys, defaults, nested subcommand keys, service-override keys, interpreter keys, and nested module keys are all flagged.
- Add regression coverage in `tests/test_grammar_classifier.py` for the four `find` exec-family flags and `gh api --input` in both forms.

After this change:

```
$ python3 hooks/grammar_classifier.py "find . -name '*.py' -exec rm {} \;"
{"decision": "unsafe", "reason": "find: flag -exec rm"}
$ python3 hooks/grammar_classifier.py 'gh api /repos/x/y/issues --input body.json'
{"decision": "unsafe", "reason": "gh api: flag --input body.json"}
```

Closes #15.

## Test plan

- [x] `python3 -m unittest discover -v tests` — 237 tests pass
- [x] CLI repros classify as `unsafe`:
  - [x] `find . -name '*.py' -exec rm {} \;`
  - [x] `find . -name '*.py' -execdir rm {} \;`
  - [x] `find . -name '*.py' -ok rm {} \;`
  - [x] `find . -name '*.py' -okdir rm {} \;`
  - [x] `gh api /repos/x/y/issues --input body.json`
  - [x] `gh api /repos/x/y/issues --input=body.json`
- [x] `validate_shell_rules(load_shell_rules(REPO_ROOT / "rules"))` returns `[]`
