### PR TITLE
Fix Python alias resolution for local shadowing

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,8 +361,11 @@ under control flow (`if cond: import x`, dead `if False:` branches,
 applied — we cannot statically prove they execute. Top-level
 reassignment of a bound name (`from os import system; system = print`,
 including assignments inside top-level `if`/`for` blocks) drops the
-binding; function-internal rebinds keep the module-level binding
-intact since they have their own scope.
+binding. Function / lambda-local rebinds shadow the imported binding
+within that deferred scope, but do not mutate the module-level
+snapshot. Class bodies execute immediately in their own local
+namespace, so class-local assignments likewise shadow imported names
+for later direct class-body calls.
 
 Module-scope calls resolve against the binding snapshot effective at
 their source line, so a call that appears *before* a later rebind /

--- a/hooks/yolt_analyzer.py
+++ b/hooks/yolt_analyzer.py
@@ -12,6 +12,8 @@ import datetime
 import json
 import os
 import sys
+import symtable
+from collections import defaultdict, deque
 from fnmatch import fnmatch
 from pathlib import Path
 
@@ -53,10 +55,8 @@ class SafetyAnalyzer(ast.NodeVisitor):
         the script imports, calls, then later rebinds or re-imports the
         same name — the earlier call should still see the original
         binding.
-      - `alias_table`: the *final* snapshot, applied to calls that live
-        inside function / class bodies. Those bodies execute when their
-        enclosing function/class is invoked, conceptually after the
-        module-level code finishes, so they see the final state.
+      - `alias_table`: the *final* module snapshot, applied to deferred
+        function / lambda bodies after local shadowing is checked.
 
     Supported import forms (recorded as binding events):
 
@@ -79,8 +79,12 @@ class SafetyAnalyzer(ast.NodeVisitor):
         inside top-level `if`/`for` blocks) are recorded as "drop"
         events at their source line, so a later module-scope call no
         longer resolves through the old binding.
-      - Function-internal rebinds do NOT participate, because those
-        introduce their own scope.
+      - Function / lambda bodies may shadow imported names locally.
+        That local shadowing suppresses alias rewriting inside the
+        deferred scope, but does not mutate the module-level snapshot.
+      - Class bodies execute immediately and have their own ordered
+        local bindings, so they need a class-local shadowing layer on
+        top of the surrounding module snapshot.
 
     `_resolve` rewrites the leading binding of each call target. Names
     that have no recorded binding effective at the call's position are
@@ -95,8 +99,9 @@ class SafetyAnalyzer(ast.NodeVisitor):
         self.imports = set()
         self.import_modules = set()
         self.safe_imports = set(rules.get("_safe_imports", []))
-        # Final snapshot: used for calls inside function / class bodies.
-        # Populated by `_collect_top_level_bindings` before the AST walk.
+        # Final module snapshot: used for deferred function / lambda
+        # bodies after local shadowing is checked. Populated by
+        # `_collect_top_level_bindings` before the AST walk.
         self.alias_table = {}
         # Ordered list of (lineno, name, target_or_None) module-scope
         # binding events. `target=None` means the event drops the binding
@@ -107,6 +112,13 @@ class SafetyAnalyzer(ast.NodeVisitor):
         # or class body. Calls at depth 0 use position-specific
         # resolution; deeper calls use the final snapshot.
         self._scope_depth = 0
+        # Lexically-active deferred scopes (functions / lambdas). Each
+        # entry is the set of names that shadow outer bindings.
+        self._shadow_stack = []
+        # Symbol-table-derived shadow sets keyed by AST scope location.
+        self._scope_shadow_queues = {}
+        # Immediate class-body scopes layered on top of module scope.
+        self._class_scope_stack = []
 
     def visit_Import(self, node):
         for alias in node.names:
@@ -138,19 +150,34 @@ class SafetyAnalyzer(ast.NodeVisitor):
         for d in node.args.kw_defaults:
             if d is not None:
                 self.visit(d)
-        self._scope_depth += 1
+        self._push_deferred_scope(node)
         try:
             self.visit(node.body)
         finally:
-            self._scope_depth -= 1
+            self._pop_deferred_scope()
 
     def visit_ClassDef(self, node):
-        # A class body executes at module load (it's just a sequence of
-        # statements run in a fresh namespace), so calls inside it must
-        # resolve against the position-aware module snapshot. Decorators,
-        # bases, and keyword arguments also evaluate at the class
-        # statement's position. Do NOT bump `_scope_depth`.
-        self.generic_visit(node)
+        # Decorators, bases, and keywords evaluate in the surrounding
+        # scope at the class statement's position.
+        for d in node.decorator_list:
+            self.visit(d)
+        for b in node.bases:
+            self.visit(b)
+        for kw in node.keywords:
+            self.visit(kw.value)
+
+        # The class body itself executes immediately in its own local
+        # namespace, with ordered shadowing over the surrounding scope.
+        class_scope = {
+            "base": self._table_for_class_definition(node.lineno),
+            "events": self._collect_class_scope_events(node.body),
+        }
+        self._class_scope_stack.append(class_scope)
+        try:
+            for stmt in node.body:
+                self.visit(stmt)
+        finally:
+            self._class_scope_stack.pop()
 
     def _visit_function_like(self, node):
         """Walk a `def` / `async def` carefully: decorators, positional
@@ -176,12 +203,39 @@ class SafetyAnalyzer(ast.NodeVisitor):
         for d in node.args.kw_defaults:
             if d is not None:
                 self.visit(d)
-        self._scope_depth += 1
+        self._push_deferred_scope(node)
         try:
             for stmt in node.body:
                 self.visit(stmt)
         finally:
-            self._scope_depth -= 1
+            self._pop_deferred_scope()
+
+    def _push_deferred_scope(self, node):
+        """Enter a deferred function / lambda scope. The body resolves
+        against the final module snapshot, but any names declared local
+        in the lexical function stack suppress alias rewriting."""
+        self._scope_depth += 1
+        self._shadow_stack.append(self._shadow_names_for_scope(node))
+
+    def _pop_deferred_scope(self):
+        self._shadow_stack.pop()
+        self._scope_depth -= 1
+
+    def _shadow_names_for_scope(self, node):
+        """Look up the precomputed local-shadow set for a function or
+        lambda scope. If matching metadata is absent, fall back to an
+        empty set rather than guessing."""
+        key = self._scope_key_for_node(node)
+        queue = self._scope_shadow_queues.get(key)
+        if not queue:
+            return set()
+        return set(queue.popleft())
+
+    @staticmethod
+    def _scope_key_for_node(node):
+        if isinstance(node, ast.Lambda):
+            return ("function", node.lineno, "lambda")
+        return ("function", node.lineno, node.name)
 
     def _collect_top_level_bindings(self, tree):
         """Walk the module-level body (only) and build the line-ordered
@@ -261,6 +315,16 @@ class SafetyAnalyzer(ast.NodeVisitor):
                 final[name] = target
         self.alias_table = final
 
+    def _collect_class_scope_events(self, body):
+        """Collect ordered local-name binding events for a class body.
+        These bindings shadow module aliases for later direct class-body
+        calls, but they are not themselves resolved to dotted imports."""
+        events = []
+        for stmt in body:
+            events.extend(self._binding_events_in_immediate_scope(stmt))
+        events.sort(key=lambda e: e[0])
+        return events
+
     def _snapshot_at_line(self, lineno):
         """Replay binding events strictly before `lineno` and return the
         resulting name -> target dict. Used for module-scope calls so
@@ -275,6 +339,36 @@ class SafetyAnalyzer(ast.NodeVisitor):
             else:
                 snapshot[name] = target
         return snapshot
+
+    @staticmethod
+    def _class_snapshot_at_line(scope, lineno):
+        """Apply class-local shadowing events strictly before `lineno`
+        on top of the class scope's surrounding base snapshot."""
+        snapshot = dict(scope["base"])
+        for evt_line, name in scope["events"]:
+            if evt_line >= lineno:
+                break
+            snapshot.pop(name, None)
+        return snapshot
+
+    def _current_immediate_table(self, lineno):
+        """Return the surrounding immediate-execution binding snapshot
+        for the current position: innermost class scope if present,
+        otherwise module scope."""
+        if self._class_scope_stack:
+            return self._class_snapshot_at_line(
+                self._class_scope_stack[-1], lineno
+            )
+        return self._snapshot_at_line(lineno)
+
+    def _table_for_class_definition(self, lineno):
+        """Resolve the surrounding snapshot that a class body starts
+        from. Class bodies nested under deferred scopes still see the
+        final module alias table, with outer function shadowing handled
+        separately via `_shadow_stack`."""
+        if self._scope_depth > 0:
+            return dict(self.alias_table)
+        return self._current_immediate_table(lineno)
 
     @staticmethod
     def _names_in_target(target):
@@ -303,6 +397,77 @@ class SafetyAnalyzer(ast.NodeVisitor):
             return
         for child in ast.iter_child_nodes(stmt):
             yield from SafetyAnalyzer._walk_module_scope(child)
+
+    @staticmethod
+    def _walk_immediate_scope(stmt):
+        """Yield descendants that still execute in the current immediate
+        scope. Stops at nested function / class / lambda bodies and at
+        comprehension scopes."""
+        yield stmt
+        if isinstance(
+            stmt,
+            (
+                ast.FunctionDef,
+                ast.AsyncFunctionDef,
+                ast.ClassDef,
+                ast.Lambda,
+                ast.ListComp,
+                ast.SetComp,
+                ast.DictComp,
+                ast.GeneratorExp,
+            ),
+        ):
+            return
+        for child in ast.iter_child_nodes(stmt):
+            yield from SafetyAnalyzer._walk_immediate_scope(child)
+
+    def _binding_events_in_immediate_scope(self, stmt):
+        """Collect ordered local-binding events produced by `stmt` in an
+        immediate-execution scope such as a class body."""
+        events = []
+        if isinstance(stmt, ast.Import):
+            for alias in stmt.names:
+                local = alias.asname or alias.name.split(".")[0]
+                events.append((stmt.lineno, local))
+            return events
+        if isinstance(stmt, ast.ImportFrom):
+            for alias in stmt.names:
+                if alias.name == "*":
+                    continue
+                events.append((stmt.lineno, alias.asname or alias.name))
+            return events
+        if isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            events.append((stmt.lineno, stmt.name))
+            return events
+
+        for node in self._walk_immediate_scope(stmt):
+            line = getattr(node, "lineno", stmt.lineno)
+            if isinstance(node, ast.Assign):
+                for tgt in node.targets:
+                    for name in self._names_in_target(tgt):
+                        events.append((line, name))
+            elif isinstance(node, ast.AugAssign):
+                for name in self._names_in_target(node.target):
+                    events.append((line, name))
+            elif isinstance(node, ast.AnnAssign):
+                if node.value is not None:
+                    for name in self._names_in_target(node.target):
+                        events.append((line, name))
+            elif isinstance(node, (ast.For, ast.AsyncFor)):
+                for name in self._names_in_target(node.target):
+                    events.append((line, name))
+            elif isinstance(node, (ast.With, ast.AsyncWith)):
+                for item in node.items:
+                    if item.optional_vars is not None:
+                        for name in self._names_in_target(item.optional_vars):
+                            events.append((line, name))
+            elif isinstance(node, ast.ExceptHandler):
+                if node.name:
+                    events.append((line, node.name))
+            elif isinstance(node, ast.NamedExpr):
+                for name in self._names_in_target(node.target):
+                    events.append((line, name))
+        return events
 
     def visit_Call(self, node):
         call_name = self._get_call_name(node)
@@ -339,11 +504,14 @@ class SafetyAnalyzer(ast.NodeVisitor):
         binding effective at the call's position; otherwise return `name`
         unchanged. Never guesses for unknown leading names - see class
         docstring for the supported forms and out-of-scope cases."""
+        head, sep, rest = name.partition(".")
+        for shadowed in reversed(self._shadow_stack):
+            if head in shadowed:
+                return name
         if self._scope_depth == 0:
-            table = self._snapshot_at_line(node.lineno)
+            table = self._current_immediate_table(node.lineno)
         else:
             table = self.alias_table
-        head, sep, rest = name.partition(".")
         if head not in table:
             return name
         resolved_head = table[head]
@@ -446,6 +614,7 @@ class SafetyAnalyzer(ast.NodeVisitor):
             return retval
 
         self.source_lines = source.splitlines()
+        self._scope_shadow_queues = self._build_scope_shadow_queues(source)
         self._collect_top_level_bindings(tree)
         self.visit(tree)
 
@@ -469,6 +638,36 @@ class SafetyAnalyzer(ast.NodeVisitor):
             retval["reason"] = "; ".join(reasons)
 
         return retval
+
+    @staticmethod
+    def _build_scope_shadow_queues(source):
+        """Build per-scope local shadow-name sets using Python's own
+        symbol-table analysis. These sets suppress alias rewriting inside
+        deferred function / lambda scopes without trying to resolve the
+        local binding itself."""
+        queues = defaultdict(deque)
+
+        def walk(table):
+            for child in table.get_children():
+                if child.get_type() == "annotation":
+                    continue
+                if child.get_type() == "function":
+                    shadowed = set()
+                    for ident in child.get_identifiers():
+                        sym = child.lookup(ident)
+                        if (
+                            sym.is_local()
+                            or sym.is_parameter()
+                            or sym.is_imported()
+                        ):
+                            shadowed.add(ident)
+                    queues[("function", child.get_lineno(), child.get_name())].append(
+                        shadowed
+                    )
+                walk(child)
+
+        walk(symtable.symtable(source, "<yolt>", "exec"))
+        return queues
 
 
 def make_hook_response(decision, reason=None):

--- a/hooks/yolt_analyzer.py
+++ b/hooks/yolt_analyzer.py
@@ -171,6 +171,7 @@ class SafetyAnalyzer(ast.NodeVisitor):
         class_scope = {
             "base": self._table_for_class_definition(node.lineno),
             "events": self._collect_class_scope_events(node.body),
+            "scope_depth_at_entry": self._scope_depth,
         }
         self._class_scope_stack.append(class_scope)
         try:
@@ -361,6 +362,17 @@ class SafetyAnalyzer(ast.NodeVisitor):
             )
         return self._snapshot_at_line(lineno)
 
+    def _direct_class_body_table(self, lineno):
+        """Return the innermost class-body snapshot when the current
+        position is in that class's direct body, not in a nested
+        deferred scope such as a method or lambda."""
+        if not self._class_scope_stack:
+            return None
+        scope = self._class_scope_stack[-1]
+        if scope["scope_depth_at_entry"] != self._scope_depth:
+            return None
+        return self._class_snapshot_at_line(scope, lineno)
+
     def _table_for_class_definition(self, lineno):
         """Resolve the surrounding snapshot that a class body starts
         from. Class bodies nested under deferred scopes still see the
@@ -508,9 +520,10 @@ class SafetyAnalyzer(ast.NodeVisitor):
         for shadowed in reversed(self._shadow_stack):
             if head in shadowed:
                 return name
-        if self._scope_depth == 0:
+        table = self._direct_class_body_table(node.lineno)
+        if table is None and self._scope_depth == 0:
             table = self._current_immediate_table(node.lineno)
-        else:
+        elif table is None:
             table = self.alias_table
         if head not in table:
             return name

--- a/tests/test_yolt_analyzer.py
+++ b/tests/test_yolt_analyzer.py
@@ -497,6 +497,29 @@ class TestImportScopeAndOrder(unittest.TestCase):
         result = self._analyze(source)
         self.assertTrue(result["safe"], result)
 
+    def test_nested_class_body_assignment_shadows_import_binding(self):
+        source = (
+            "from os import system\n"
+            "def outer():\n"
+            "    class C:\n"
+            "        system = print\n"
+            '        system("hello")\n'
+        )
+        result = self._analyze(source)
+        self.assertTrue(result["safe"], result)
+
+    def test_nested_class_body_definition_shadows_import_binding(self):
+        source = (
+            "from os import system\n"
+            "def outer():\n"
+            "    class C:\n"
+            "        def system(self):\n"
+            "            pass\n"
+            '        system("hello")\n'
+        )
+        result = self._analyze(source)
+        self.assertTrue(result["safe"], result)
+
     def test_async_function_default_arg_uses_position_snapshot(self):
         source = (
             "from os import system\n"

--- a/tests/test_yolt_analyzer.py
+++ b/tests/test_yolt_analyzer.py
@@ -293,6 +293,37 @@ class TestImportScopeAndOrder(unittest.TestCase):
         self.assertFalse(result["safe"], result)
         self.assertIn("os.system", result["reason"])
 
+    def test_function_local_shadow_suppresses_module_alias(self):
+        source = (
+            "from os import system\n"
+            "def f():\n"
+            "    system = print\n"
+            '    system("hello")\n'
+        )
+        result = self._analyze(source)
+        self.assertTrue(result["safe"], result)
+
+    def test_function_local_alias_shadow_suppresses_module_alias(self):
+        source = (
+            "import os as x\n"
+            "def f():\n"
+            "    x = print\n"
+            '    x("hello")\n'
+        )
+        result = self._analyze(source)
+        self.assertTrue(result["safe"], result)
+
+    def test_outer_function_local_shadow_applies_to_inner_body(self):
+        source = (
+            "from os import system\n"
+            "def outer():\n"
+            "    system = print\n"
+            "    def inner():\n"
+            '        system("hello")\n'
+        )
+        result = self._analyze(source)
+        self.assertTrue(result["safe"], result)
+
     # --- Module-scope execution order: PR #20 review item 3 ---
 
     def test_call_before_top_level_rebind_still_flagged(self):
@@ -432,6 +463,38 @@ class TestImportScopeAndOrder(unittest.TestCase):
         result = self._analyze(source)
         # Final snapshot has system dropped, so the method body call
         # does not resolve to os.system.
+        self.assertTrue(result["safe"], result)
+
+    def test_class_body_assignment_shadows_import_binding(self):
+        source = (
+            "from os import system\n"
+            "class C:\n"
+            "    system = print\n"
+            '    system("hello")\n'
+        )
+        result = self._analyze(source)
+        self.assertTrue(result["safe"], result)
+
+    def test_class_body_definition_shadows_import_binding(self):
+        source = (
+            "from os import system\n"
+            "class C:\n"
+            "    def system(self, msg):\n"
+            "        return msg\n"
+            '    system("hello")\n'
+        )
+        result = self._analyze(source)
+        self.assertTrue(result["safe"], result)
+
+    def test_class_body_inside_function_sees_outer_shadow(self):
+        source = (
+            "from os import system\n"
+            "def outer():\n"
+            "    system = print\n"
+            "    class C:\n"
+            '        system("hello")\n'
+        )
+        result = self._analyze(source)
         self.assertTrue(result["safe"], result)
 
     def test_async_function_default_arg_uses_position_snapshot(self):


### PR DESCRIPTION
## Summary

- add scope-aware local shadow suppression for deferred function/lambda bodies using Python's symbol-table analysis
- add ordered class-body local shadowing so class-local assignments/defs stop resolving through module import aliases
- extend analyzer docs and regressions for function-local, nested-function, and class-body shadowing cases

Closes #21.

## Test plan

- [x] `python3 -m unittest discover -s tests -p 'test_yolt_analyzer.py'`
- [x] direct analyzer repros for function-local shadowing, class-body shadowing, and the original late-import unsafe case
