### PR TITLE
Path-aware CLI classification for nested mutating verbs (#17)

### DIFF
--- a/hooks/rule_classifier.py
+++ b/hooks/rule_classifier.py
@@ -416,10 +416,13 @@ _ALLOWED_COMMAND_KEYS = frozenset({
     "safe_subcommands", "unsafe_subcommands",
     "safe_subcommand_patterns", "unsafe_subcommand_patterns",
     "nested_subcommand",
+    "empty_decision",
     "service_overrides",
     "safe_operation_patterns", "unsafe_operation_patterns",
     "sql_flags", "sql_file_flags", "sql_positional_index",
 })
+
+_ALLOWED_EMPTY_DECISIONS = frozenset({"safe", "unsafe"})
 
 _ALLOWED_SERVICE_OVERRIDE_KEYS = frozenset({
     "_note",
@@ -519,6 +522,14 @@ def _validate_command_spec(path, spec, errors):
     default = spec.get("default")
     if default is not None and default not in _ALLOWED_DEFAULTS:
         errors.append("{}: unknown default '{}'".format(path, default))
+
+    empty_decision = spec.get("empty_decision")
+    if empty_decision is not None and empty_decision not in _ALLOWED_EMPTY_DECISIONS:
+        errors.append(
+            "{}: empty_decision must be 'safe' or 'unsafe', got '{}'".format(
+                path, empty_decision
+            )
+        )
 
     nested = spec.get("nested_subcommand", {})
     if isinstance(nested, dict):
@@ -795,6 +806,12 @@ class RuleClassifier:
                     return (DECISION_SAFE, "{} {}: read-only".format(cmd_name, sub))
                 if nested_default == "unsafe":
                     return (DECISION_UNSAFE, "{} {}: mutating".format(cmd_name, sub))
+            empty_decision = nested_spec.get("empty_decision")
+            if empty_decision and not rest:
+                if empty_decision == "safe":
+                    return (DECISION_SAFE, "{} {}: read-only (no positional)".format(cmd_name, sub))
+                if empty_decision == "unsafe":
+                    return (DECISION_UNSAFE, "{} {}: mutating (no positional)".format(cmd_name, sub))
             return self._match_subcommand_lists(
                 "{} {}".format(cmd_name, sub), rest, nested_spec
             )

--- a/rules/shell.json
+++ b/rules/shell.json
@@ -457,8 +457,9 @@
       ],
       "nested_subcommand": {
         "repo": {
-          "safe_subcommands": ["list", "ls", "index", "update"],
-          "unsafe_subcommands": ["add", "remove", "rm"]
+          "safe_subcommands": ["list", "ls"],
+          "unsafe_subcommands": ["add", "remove", "rm", "update", "index"],
+          "_note": "'update' refreshes the local repo cache; 'index' writes or merges an index.yaml. Both mutate state."
         }
       },
       "_note": "'repo' moved into nested_subcommand: helm repo list is safe, helm repo add is unsafe."

--- a/rules/shell.json
+++ b/rules/shell.json
@@ -305,7 +305,7 @@
       ],
       "safe_subcommands": [
         "log", "status", "diff", "show", "blame",
-        "branch", "tag",
+        "branch",
         "rev-parse", "rev-list", "describe", "name-rev",
         "reflog",
         "ls-files", "ls-tree", "ls-remote",
@@ -325,7 +325,6 @@
         "merge", "rebase", "cherry-pick", "revert", "am",
         "reset", "restore", "checkout", "switch",
         "clean",
-        "tag",
         "apply", "format-patch",
         "clone",
         "init",
@@ -334,16 +333,31 @@
         "notes", "filter-branch", "filter-repo",
         "submodule"
       ],
-      "_note": "Some subcommands overlap (tag both lists). Safe list is checked first, so 'git tag' is safe (listing); 'git tag v1' still passes safe, which is slightly permissive. Acceptable trade-off."
+      "nested_subcommand": {
+        "tag": {
+          "empty_decision": "safe",
+          "unsafe_flag_any_value": [
+            "-d", "--delete",
+            "-a", "--annotate",
+            "-s", "--sign",
+            "-u", "--local-user",
+            "-f", "--force",
+            "-m", "--message",
+            "-F", "--file"
+          ],
+          "_note": "Bare 'git tag' lists. Any positional after flag-skipping (a tagname) or any mutating flag (-d, -a, -s, -f, -m, -F) classifies as not-safe. Falls back to unknown for positional + no unsafe flag."
+        }
+      },
+      "_note": "Removed 'tag' from flat safe/unsafe lists. It now lives under nested_subcommand.tag with positional-aware classification: bare 'git tag' lists safely; 'git tag v1' is unknown (not silently safe); mutating flags are explicit."
     },
 
     "docker": {
       "default": "subcommand",
       "safe_subcommands": [
-        "ps", "images", "image", "container",
+        "ps", "images",
         "inspect", "logs", "stats", "top", "port",
         "diff", "history", "info", "version", "events",
-        "system", "volume", "network", "context", "search"
+        "context", "search"
       ],
       "unsafe_subcommands": [
         "run", "exec", "kill", "stop", "start", "restart",
@@ -354,7 +368,41 @@
         "login", "logout",
         "compose", "swarm", "service", "stack"
       ],
-      "_note": "Some top-level names (image, container, volume, network, system) have destructive sub-subcommands (prune, rm). We list them as safe because their default 'ls'/'inspect' verbs dominate usage; we'd need nested-subcommand rules for full fidelity."
+      "nested_subcommand": {
+        "image": {
+          "safe_subcommands": ["ls", "inspect", "history"],
+          "unsafe_subcommands": [
+            "rm", "prune", "build", "pull", "push",
+            "load", "save", "tag", "import"
+          ]
+        },
+        "container": {
+          "safe_subcommands": [
+            "ls", "inspect", "top", "logs", "port",
+            "diff", "stats", "wait"
+          ],
+          "unsafe_subcommands": [
+            "rm", "prune", "run", "exec", "start", "stop",
+            "restart", "kill", "pause", "unpause",
+            "create", "commit", "cp", "rename", "update", "attach"
+          ]
+        },
+        "volume": {
+          "safe_subcommands": ["ls", "inspect"],
+          "unsafe_subcommands": ["create", "rm", "prune"]
+        },
+        "network": {
+          "safe_subcommands": ["ls", "inspect"],
+          "unsafe_subcommands": [
+            "create", "rm", "prune", "connect", "disconnect"
+          ]
+        },
+        "system": {
+          "safe_subcommands": ["info", "df", "events"],
+          "unsafe_subcommands": ["prune"]
+        }
+      },
+      "_note": "Top-level 'image', 'container', 'volume', 'network', 'system' moved into nested_subcommand with explicit safe/unsafe sub-subcommands. Bare 'docker image' (no further positional) now classifies as unknown instead of silently safe."
     },
 
     "kubectl": {
@@ -363,7 +411,6 @@
         "get", "describe", "logs", "explain",
         "top", "cluster-info", "version",
         "api-resources", "api-versions",
-        "config",
         "auth",
         "diff",
         "events",
@@ -377,7 +424,23 @@
         "label", "annotate",
         "cordon", "uncordon", "drain", "taint",
         "cp"
-      ]
+      ],
+      "nested_subcommand": {
+        "config": {
+          "safe_subcommands": [
+            "view", "current-context",
+            "get-contexts", "get-clusters", "get-users"
+          ],
+          "unsafe_subcommands": [
+            "set", "set-context", "set-cluster", "set-credentials",
+            "use-context",
+            "unset",
+            "delete-context", "delete-cluster", "delete-user",
+            "rename-context"
+          ]
+        }
+      },
+      "_note": "'config' moved into nested_subcommand: kubectl config view is safe, kubectl config set-context is unsafe. Bare 'kubectl config' (no further positional) is unknown."
     },
 
     "helm": {
@@ -385,13 +448,20 @@
       "safe_subcommands": [
         "get", "list", "ls", "status", "history",
         "show", "search", "inspect", "lint", "template",
-        "env", "version", "repo"
+        "env", "version"
       ],
       "unsafe_subcommands": [
         "install", "upgrade", "uninstall", "delete",
         "rollback", "test", "push", "pull", "package",
         "dependency", "plugin", "registry", "create"
-      ]
+      ],
+      "nested_subcommand": {
+        "repo": {
+          "safe_subcommands": ["list", "ls", "index", "update"],
+          "unsafe_subcommands": ["add", "remove", "rm"]
+        }
+      },
+      "_note": "'repo' moved into nested_subcommand: helm repo list is safe, helm repo add is unsafe."
     },
 
     "aws": {

--- a/tests/test_grammar_classifier.py
+++ b/tests/test_grammar_classifier.py
@@ -399,6 +399,119 @@ class TestValuelessGlobalFlags(unittest.TestCase):
         self.assertDecision("gh --no-pager pr list", DECISION_SAFE)
 
 
+class TestNestedSubcommandPaths(unittest.TestCase):
+    """Issue #17: path-aware classification for nested mutating verbs that
+    previously stopped at the first subcommand and were treated as safe."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.clf = _make_classifier()
+
+    def assertDecision(self, cmd, expected):
+        d, r = self.clf.classify(cmd)
+        self.assertEqual(
+            d, expected,
+            "cmd={!r}: got {}, reason={}".format(cmd, d, r),
+        )
+
+    # --- Acceptance criteria from issue #17 ---
+
+    def test_git_tag_create_not_safe(self):
+        # 'git tag v1.2.3' creates a lightweight tag. Was silently safe.
+        d, _ = self.clf.classify("git tag v1.2.3")
+        self.assertNotEqual(d, DECISION_SAFE)
+
+    def test_docker_image_rm_unsafe(self):
+        self.assertDecision("docker image rm alpine", DECISION_UNSAFE)
+
+    def test_kubectl_config_set_context_unsafe(self):
+        self.assertDecision("kubectl config set-context prod", DECISION_UNSAFE)
+
+    def test_helm_repo_add_unsafe(self):
+        self.assertDecision(
+            "helm repo add foo https://example.com",
+            DECISION_UNSAFE,
+        )
+
+    # --- git tag: positional means create, flag-based deletes/annotates ---
+
+    def test_git_tag_bare_lists_safe(self):
+        self.assertDecision("git tag", DECISION_SAFE)
+
+    def test_git_tag_dash_l_lists_safe(self):
+        self.assertDecision("git tag -l", DECISION_SAFE)
+
+    def test_git_tag_delete_unsafe(self):
+        self.assertDecision("git tag -d v1.2.3", DECISION_UNSAFE)
+
+    def test_git_tag_annotated_unsafe(self):
+        d, _ = self.clf.classify('git tag -a v1.2.3 -m "release"')
+        self.assertEqual(d, DECISION_UNSAFE)
+
+    # --- docker.image / container / volume / network / system ---
+
+    def test_docker_image_ls_safe(self):
+        self.assertDecision("docker image ls", DECISION_SAFE)
+
+    def test_docker_image_prune_unsafe(self):
+        self.assertDecision("docker image prune", DECISION_UNSAFE)
+
+    def test_docker_container_ls_safe(self):
+        self.assertDecision("docker container ls", DECISION_SAFE)
+
+    def test_docker_container_rm_unsafe(self):
+        self.assertDecision("docker container rm myctr", DECISION_UNSAFE)
+
+    def test_docker_volume_create_unsafe(self):
+        self.assertDecision("docker volume create vol1", DECISION_UNSAFE)
+
+    def test_docker_volume_ls_safe(self):
+        self.assertDecision("docker volume ls", DECISION_SAFE)
+
+    def test_docker_network_connect_unsafe(self):
+        self.assertDecision(
+            "docker network connect bridge myctr", DECISION_UNSAFE,
+        )
+
+    def test_docker_system_prune_unsafe(self):
+        self.assertDecision("docker system prune", DECISION_UNSAFE)
+
+    def test_docker_system_df_safe(self):
+        self.assertDecision("docker system df", DECISION_SAFE)
+
+    def test_bare_docker_image_no_longer_silently_safe(self):
+        # Was safe pre-issue-17. Now a partially-modeled namespace without
+        # a sub-subcommand should not auto-allow.
+        d, _ = self.clf.classify("docker image")
+        self.assertNotEqual(d, DECISION_SAFE)
+
+    # --- kubectl.config ---
+
+    def test_kubectl_config_view_safe(self):
+        self.assertDecision("kubectl config view", DECISION_SAFE)
+
+    def test_kubectl_config_use_context_unsafe(self):
+        self.assertDecision(
+            "kubectl config use-context prod", DECISION_UNSAFE,
+        )
+
+    def test_kubectl_config_delete_context_unsafe(self):
+        self.assertDecision(
+            "kubectl config delete-context prod", DECISION_UNSAFE,
+        )
+
+    # --- helm.repo ---
+
+    def test_helm_repo_list_safe(self):
+        self.assertDecision("helm repo list", DECISION_SAFE)
+
+    def test_helm_repo_update_safe(self):
+        self.assertDecision("helm repo update", DECISION_SAFE)
+
+    def test_helm_repo_remove_unsafe(self):
+        self.assertDecision("helm repo remove foo", DECISION_UNSAFE)
+
+
 class TestPythonHeredoc(unittest.TestCase):
     @classmethod
     def setUpClass(cls):

--- a/tests/test_grammar_classifier.py
+++ b/tests/test_grammar_classifier.py
@@ -505,8 +505,13 @@ class TestNestedSubcommandPaths(unittest.TestCase):
     def test_helm_repo_list_safe(self):
         self.assertDecision("helm repo list", DECISION_SAFE)
 
-    def test_helm_repo_update_safe(self):
-        self.assertDecision("helm repo update", DECISION_SAFE)
+    def test_helm_repo_update_unsafe(self):
+        # `helm repo update` refreshes the local repo cache - mutation.
+        self.assertDecision("helm repo update", DECISION_UNSAFE)
+
+    def test_helm_repo_index_unsafe(self):
+        # `helm repo index ./charts` writes / merges an index.yaml.
+        self.assertDecision("helm repo index ./charts", DECISION_UNSAFE)
 
     def test_helm_repo_remove_unsafe(self):
         self.assertDecision("helm repo remove foo", DECISION_UNSAFE)


### PR DESCRIPTION
## Summary

- Adds `nested_subcommand` rule data so common CLIs with mutating
  nested verbs (`docker image rm`, `kubectl config set-context`,
  `helm repo add`, `git tag v1.2.3`) no longer silently classify as
  `safe`.
- Introduces a small `empty_decision` field on nested specs so
  `git tag` (bare or `-l`) can keep classifying safe while any
  positional-tagname or mutating flag falls to `unsafe`/`unknown`.
- Removes `image / container / volume / network / system` from the
  flat `docker` safe list (now under `nested_subcommand`); same for
  `kubectl config` and `helm repo`. Bare `docker image`, `kubectl
  config`, `helm repo` now classify `unknown` (ask) instead of
  silently safe.

Closes #17.

## Acceptance

The four reproductions from the issue no longer classify safe:

```
git tag v1.2.3                       -> unknown   (not safe)
docker image rm alpine               -> unsafe
kubectl config set-context prod      -> unsafe
helm repo add foo https://...        -> unsafe
```

Bare reads in the same namespaces stay safe:

```
git tag                              -> safe
git tag -l                           -> safe
docker image ls                      -> safe
kubectl config view                  -> safe
helm repo list                       -> safe
```

## Test plan

- [x] `python3 -m unittest discover -s tests` — all 327 tests pass
      (added ~25 new cases covering acceptance + bare reads +
      partially-modeled-namespace fallback).
- [x] Manual sanity: bare `docker`, `kubectl config`, `helm repo`
      classify `unknown` (conservative fail-closed).
- [x] `git tag -d v1.2.3`, `git tag -a v1 -m "..."`, `git tag -s
      v1` all classify unsafe via `unsafe_flag_any_value`.
