### PR TITLE
Release gates for #18: regression catalogue + CI + analysis-boundaries doc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,52 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  test:
+    name: unittest (python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Validate bundled rules/shell.json
+        # Hard fail on schema drift. The hook's load-time guard
+        # would already log rules-validation-error and exit
+        # silently in production; CI must fail loudly.
+        run: |
+          python -c "
+          import sys
+          from pathlib import Path
+          sys.path.insert(0, 'hooks')
+          from rule_classifier import load_shell_rules, validate_shell_rules
+          rules = load_shell_rules(Path('rules'), validate=False)
+          errors = validate_shell_rules(rules)
+          if errors:
+              for e in errors:
+                  print('rules/shell.json:', e)
+              sys.exit(1)
+          print('rules/shell.json: schema OK')
+          "
+
+      - name: Run unit + e2e suite
+        run: python -m unittest discover -v tests

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@
 - [Debug / dogfood log](#debug--dogfood-log)
 - [CLI usage](#cli-usage)
 - [Tests and demo](#tests-and-demo)
+- [Analysis boundaries](#analysis-boundaries)
 - [Design principles](#design-principles)
 
 ## Introduction
@@ -533,6 +534,139 @@ asserted, just printed), run:
 
 This prints the decision (`safe` / `unsafe` / `unknown`) for each
 command, colorized when the terminal supports it.
+
+## Analysis boundaries
+
+YOLT is a conservative static checker. It chooses `unknown` over
+guessing, so the supported surfaces matter. This section pins what
+YOLT does and does not inspect.
+
+### Bash decomposition (in scope)
+
+The tree-sitter-bash grammar walker handles:
+
+- pipelines, lists (`;`, `&&`, `||`), negation, subshells, compound
+  statements;
+- `if` / `for` / `while` / `case` bodies (no manual keyword stripping);
+- command substitution (`$(...)`, `` `...` ``) and process
+  substitution (`<(...)`) — recursed and classified independently of
+  the outer command;
+- redirections — write targets matched against
+  `safe_write_targets`; non-matching writes fall to `unknown`;
+- heredocs — for the Python interpreters, the body is delegated;
+- pre-command env assignments (`FOO=bar baz`) — skipped, not folded
+  into argv.
+
+### Delegated language analysis (in scope)
+
+| Source | Routed to |
+| ------ | --------- |
+| `bash -c '<script>'`, `sh -c '<script>'` | Re-enters the grammar walker |
+| `python3 -c '<script>'` | `hooks/yolt_analyzer.py` (stdlib `ast`) |
+| `python3 file.py` | `hooks/yolt_analyzer.py` (stdlib `ast`) |
+| `python3 <<EOF ... EOF` | `hooks/yolt_analyzer.py` (stdlib `ast`) |
+| `python3 -m mod[.sub] ...` | `interpreters.python3.nested_modules` in `rules/shell.json` |
+
+### Delegated language analysis (out of scope)
+
+Other interpreters are NOT analyzed inline. Their invocations fall
+through to `unknown` and Claude Code default-prompts:
+
+- `node -e '...'`, `node file.js`
+- `ruby -e '...'`, `ruby file.rb`
+- `perl -e '...'`, `php -r '...'`
+- `osascript`, `awk -f`, `sed` script files
+- arbitrary user shebangs (`./my-script`)
+
+Adding one means writing an analyzer of the same shape as
+`yolt_analyzer.py` and registering it under `interpreters` in
+`rules/shell.json`.
+
+### SQL CLIs (in scope)
+
+`sqlite3`, `psql`, `mysql`, `mariadb`, `duckdb` — inline SQL string
+extracted from argv and scanned for destructive keywords; see
+[SQL CLIs](#sql-clis).
+
+### SQL CLIs (out of scope)
+
+- SQL fed via file (`psql -f q.sql`, `mysql < q.sql`) — opaque
+  statically, stays `unknown`.
+- Bare interactive invocations (`sqlite3 db.sqlite` with no SQL) —
+  stay `unknown`.
+- Other SQL clients (`cockroach sql`, `clickhouse-client`,
+  `snowsql`, ...) — not classified by the SQL path.
+
+### Python alias resolution (in scope)
+
+Pre-pass over the module body collects bindings before the call
+walk. Supported import forms:
+
+- `import mod`
+- `import mod as alias`
+- `import mod.sub` / `import mod.sub as alias`
+- `from mod import name`
+- `from mod import name as alias`
+
+Function / `lambda` body shadowing is honored via the stdlib
+`symtable` analysis. Class body shadowing is honored ordered with
+class-local assignments.
+
+### Python alias resolution (out of scope)
+
+- Nested-under-control-flow imports (`if cond: import x`,
+  `try: import x`).
+- `from mod import *`.
+- Relative imports (`from . import x`).
+- Variable rebinding through attribute access
+  (`obj.attr = os.system`).
+- Annotation expressions (parameter / return) — PEP 563 / 649
+  store them as strings.
+
+Anything the analyzer cannot resolve statically is left at its
+surface name rather than guessed.
+
+### Policy-driven CLIs
+
+Common CLIs (`gh`, `git`, `aws`, `curl`, `kubectl`, `helm`, `docker`,
+`terraform`, ...) are policy-driven via `rules/shell.json`. The
+walker pulls a command path from argv and matches against:
+
+- `safe_subcommands` / `unsafe_subcommands` at the top level;
+- `nested_subcommand` specs for namespaces with mutating verbs at
+  arbitrary depth (e.g. `docker image rm`, `kubectl config
+  set-context`, `helm repo add`);
+- `service_overrides` for AWS service-specific reads
+  (e.g. `aws logs start-query` is read-only despite the verb);
+- `unsafe_flags` / `unsafe_flag_values` /
+  `unsafe_flag_any_value` / `unsafe_flag_value_prefix` /
+  `unsafe_flags_without_value` for flag-driven mutation
+  (e.g. `find -exec`, `gh api --input`).
+
+For namespaces that are only partially modeled, bare and unmodeled
+verbs fall to `unknown` rather than silently classifying safe.
+
+### Conservative-unknown contract
+
+Every analysis surface follows the same fallback: if YOLT cannot
+prove a command is safe, it does not say so. Categories that hit
+this path:
+
+- tree-sitter parse error (`tree-sitter parse error`);
+- max recursion depth on nested decomposition;
+- unknown command name;
+- partially-modeled CLI namespace with a verb outside the policy;
+- write redirect to a path not on `safe_write_targets`;
+- SQL string the conservative scanner cannot classify as read-only;
+- Python source the AST delegate fails to parse;
+- `rules/shell.json` failing schema validation — the hook logs
+  `rules-validation-error` and exits silently so Claude Code's
+  default prompt fires.
+
+Schema validation runs at hook load time
+(`hooks/rule_classifier.py:validate_shell_rules`) on both the
+bundled rules and any user override, so a typo in a policy field
+becomes a hard fail at startup rather than a silent false-allow.
 
 ## Design principles
 

--- a/hooks/yolt_analyzer.py
+++ b/hooks/yolt_analyzer.py
@@ -168,8 +168,9 @@ class SafetyAnalyzer(ast.NodeVisitor):
 
         # The class body itself executes immediately in its own local
         # namespace, with ordered shadowing over the surrounding scope.
+        class_pos = (node.lineno, getattr(node, "col_offset", 0))
         class_scope = {
-            "base": self._table_for_class_definition(node.lineno),
+            "base": self._table_for_class_definition(class_pos),
             "events": self._collect_class_scope_events(node.body),
             "scope_depth_at_entry": self._scope_depth,
         }
@@ -239,23 +240,30 @@ class SafetyAnalyzer(ast.NodeVisitor):
         return ("function", node.lineno, node.name)
 
     def _collect_top_level_bindings(self, tree):
-        """Walk the module-level body (only) and build the line-ordered
+        """Walk the module-level body (only) and build the source-order
         binding event list plus the final snapshot. See class docstring
-        for the scoping rationale."""
+        for the scoping rationale.
+
+        Events are keyed by `(lineno, col_offset)` so that same-line
+        events resolve in source order. The semicolon one-liner form
+        `import os as x; x.system(...)` puts both the binding and the
+        call on the same line; the binding has a smaller col_offset
+        and must be visible to the later call."""
         if not isinstance(tree, ast.Module):
             return
 
         events = []
 
         for stmt in tree.body:
+            pos = (stmt.lineno, getattr(stmt, "col_offset", 0))
             if isinstance(stmt, ast.Import):
                 for alias in stmt.names:
                     if alias.asname:
-                        events.append((stmt.lineno, alias.asname, alias.name))
+                        events.append((pos, alias.asname, alias.name))
                     else:
                         # `import os.path` binds the top-level name `os`.
                         top_level = alias.name.split(".")[0]
-                        events.append((stmt.lineno, top_level, top_level))
+                        events.append((pos, top_level, top_level))
             elif isinstance(stmt, ast.ImportFrom):
                 if not stmt.module:
                     # Relative imports: package context unavailable, skip.
@@ -267,7 +275,7 @@ class SafetyAnalyzer(ast.NodeVisitor):
                         continue
                     local = alias.asname or alias.name
                     events.append((
-                        stmt.lineno,
+                        pos,
                         local,
                         "{}.{}".format(stmt.module, alias.name),
                     ))
@@ -278,32 +286,36 @@ class SafetyAnalyzer(ast.NodeVisitor):
                 continue
             else:
                 # Walk this top-level statement collecting module-scope
-                # reassignments as drop events keyed to their source line.
+                # reassignments as drop events keyed to their source
+                # position.
                 for node in self._walk_module_scope(stmt):
-                    line = getattr(node, "lineno", stmt.lineno)
+                    node_pos = (
+                        getattr(node, "lineno", stmt.lineno),
+                        getattr(node, "col_offset", 0),
+                    )
                     if isinstance(node, ast.Assign):
                         for tgt in node.targets:
                             for name in self._names_in_target(tgt):
-                                events.append((line, name, None))
+                                events.append((node_pos, name, None))
                     elif isinstance(node, ast.AugAssign):
                         for name in self._names_in_target(node.target):
-                            events.append((line, name, None))
+                            events.append((node_pos, name, None))
                     elif isinstance(node, ast.AnnAssign):
                         if node.value is not None:
                             for name in self._names_in_target(node.target):
-                                events.append((line, name, None))
+                                events.append((node_pos, name, None))
                     elif isinstance(node, ast.For):
                         for name in self._names_in_target(node.target):
-                            events.append((line, name, None))
+                            events.append((node_pos, name, None))
                     elif isinstance(node, ast.With):
                         for item in node.items:
                             if item.optional_vars is not None:
                                 for name in self._names_in_target(
                                     item.optional_vars
                                 ):
-                                    events.append((line, name, None))
+                                    events.append((node_pos, name, None))
 
-        # Stable sort by lineno preserves intra-line declaration order.
+        # Stable sort by (lineno, col_offset) preserves source order.
         events.sort(key=lambda e: e[0])
         self._module_events = events
 
@@ -326,14 +338,18 @@ class SafetyAnalyzer(ast.NodeVisitor):
         events.sort(key=lambda e: e[0])
         return events
 
-    def _snapshot_at_line(self, lineno):
-        """Replay binding events strictly before `lineno` and return the
+    def _snapshot_at_pos(self, pos):
+        """Replay binding events strictly before `pos` and return the
         resulting name -> target dict. Used for module-scope calls so
         they see the binding state effective at their position rather
-        than the final module state."""
+        than the final module state.
+
+        `pos` is a `(lineno, col_offset)` tuple so that a call later
+        on the same line as its binding (e.g. semicolon one-liner
+        `import os as x; x.system(...)`) still sees the binding."""
         snapshot = {}
-        for evt_line, name, target in self._module_events:
-            if evt_line >= lineno:
+        for evt_pos, name, target in self._module_events:
+            if evt_pos >= pos:
                 break
             if target is None:
                 snapshot.pop(name, None)
@@ -342,27 +358,29 @@ class SafetyAnalyzer(ast.NodeVisitor):
         return snapshot
 
     @staticmethod
-    def _class_snapshot_at_line(scope, lineno):
-        """Apply class-local shadowing events strictly before `lineno`
-        on top of the class scope's surrounding base snapshot."""
+    def _class_snapshot_at_pos(scope, pos):
+        """Apply class-local shadowing events strictly before `pos`
+        on top of the class scope's surrounding base snapshot.
+
+        `pos` is `(lineno, col_offset)` to match `_snapshot_at_pos`."""
         snapshot = dict(scope["base"])
-        for evt_line, name in scope["events"]:
-            if evt_line >= lineno:
+        for evt_pos, name in scope["events"]:
+            if evt_pos >= pos:
                 break
             snapshot.pop(name, None)
         return snapshot
 
-    def _current_immediate_table(self, lineno):
+    def _current_immediate_table(self, pos):
         """Return the surrounding immediate-execution binding snapshot
         for the current position: innermost class scope if present,
         otherwise module scope."""
         if self._class_scope_stack:
-            return self._class_snapshot_at_line(
-                self._class_scope_stack[-1], lineno
+            return self._class_snapshot_at_pos(
+                self._class_scope_stack[-1], pos
             )
-        return self._snapshot_at_line(lineno)
+        return self._snapshot_at_pos(pos)
 
-    def _direct_class_body_table(self, lineno):
+    def _direct_class_body_table(self, pos):
         """Return the innermost class-body snapshot when the current
         position is in that class's direct body, not in a nested
         deferred scope such as a method or lambda."""
@@ -371,16 +389,16 @@ class SafetyAnalyzer(ast.NodeVisitor):
         scope = self._class_scope_stack[-1]
         if scope["scope_depth_at_entry"] != self._scope_depth:
             return None
-        return self._class_snapshot_at_line(scope, lineno)
+        return self._class_snapshot_at_pos(scope, pos)
 
-    def _table_for_class_definition(self, lineno):
+    def _table_for_class_definition(self, pos):
         """Resolve the surrounding snapshot that a class body starts
         from. Class bodies nested under deferred scopes still see the
         final module alias table, with outer function shadowing handled
         separately via `_shadow_stack`."""
         if self._scope_depth > 0:
             return dict(self.alias_table)
-        return self._current_immediate_table(lineno)
+        return self._current_immediate_table(pos)
 
     @staticmethod
     def _names_in_target(target):
@@ -435,50 +453,56 @@ class SafetyAnalyzer(ast.NodeVisitor):
 
     def _binding_events_in_immediate_scope(self, stmt):
         """Collect ordered local-binding events produced by `stmt` in an
-        immediate-execution scope such as a class body."""
+        immediate-execution scope such as a class body. Each event is
+        `((lineno, col_offset), name)` so same-line bindings resolve
+        in source order."""
         events = []
+        stmt_pos = (stmt.lineno, getattr(stmt, "col_offset", 0))
         if isinstance(stmt, ast.Import):
             for alias in stmt.names:
                 local = alias.asname or alias.name.split(".")[0]
-                events.append((stmt.lineno, local))
+                events.append((stmt_pos, local))
             return events
         if isinstance(stmt, ast.ImportFrom):
             for alias in stmt.names:
                 if alias.name == "*":
                     continue
-                events.append((stmt.lineno, alias.asname or alias.name))
+                events.append((stmt_pos, alias.asname or alias.name))
             return events
         if isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
-            events.append((stmt.lineno, stmt.name))
+            events.append((stmt_pos, stmt.name))
             return events
 
         for node in self._walk_immediate_scope(stmt):
-            line = getattr(node, "lineno", stmt.lineno)
+            node_pos = (
+                getattr(node, "lineno", stmt.lineno),
+                getattr(node, "col_offset", 0),
+            )
             if isinstance(node, ast.Assign):
                 for tgt in node.targets:
                     for name in self._names_in_target(tgt):
-                        events.append((line, name))
+                        events.append((node_pos, name))
             elif isinstance(node, ast.AugAssign):
                 for name in self._names_in_target(node.target):
-                    events.append((line, name))
+                    events.append((node_pos, name))
             elif isinstance(node, ast.AnnAssign):
                 if node.value is not None:
                     for name in self._names_in_target(node.target):
-                        events.append((line, name))
+                        events.append((node_pos, name))
             elif isinstance(node, (ast.For, ast.AsyncFor)):
                 for name in self._names_in_target(node.target):
-                    events.append((line, name))
+                    events.append((node_pos, name))
             elif isinstance(node, (ast.With, ast.AsyncWith)):
                 for item in node.items:
                     if item.optional_vars is not None:
                         for name in self._names_in_target(item.optional_vars):
-                            events.append((line, name))
+                            events.append((node_pos, name))
             elif isinstance(node, ast.ExceptHandler):
                 if node.name:
-                    events.append((line, node.name))
+                    events.append((node_pos, node.name))
             elif isinstance(node, ast.NamedExpr):
                 for name in self._names_in_target(node.target):
-                    events.append((line, name))
+                    events.append((node_pos, name))
         return events
 
     def visit_Call(self, node):
@@ -520,9 +544,10 @@ class SafetyAnalyzer(ast.NodeVisitor):
         for shadowed in reversed(self._shadow_stack):
             if head in shadowed:
                 return name
-        table = self._direct_class_body_table(node.lineno)
+        pos = (node.lineno, getattr(node, "col_offset", 0))
+        table = self._direct_class_body_table(pos)
         if table is None and self._scope_depth == 0:
-            table = self._current_immediate_table(node.lineno)
+            table = self._current_immediate_table(pos)
         elif table is None:
             table = self.alias_table
         if head not in table:

--- a/tests/test_adversarial_regressions.py
+++ b/tests/test_adversarial_regressions.py
@@ -118,39 +118,77 @@ class TestIssue16PythonImportAliases(unittest.TestCase):
 
     Before PR #20 the Python delegate matched call targets by surface
     name only, so `import os as x; x.system(...)` slipped past the
-    `os.system` rule.
+    `os.system` rule. Multi-line, heredoc, and semicolon-one-liner
+    forms are all covered here so the same alias-resolution gap
+    cannot reopen on any user-visible entry point.
     """
 
     @staticmethod
-    def _decision(snippet):
-        # Use a heredoc, not `python3 -c`, so the snippet keeps its
-        # real newlines. The Python AST delegate's alias resolution
-        # is shape-faithful — multi-line `import` then call — which
-        # is the form the closing PR #20 verified end-to-end.
+    def _decision_heredoc(snippet):
         cmd = "python3 <<'PYEOF'\n{}\nPYEOF\n".format(snippet)
         retval = _Hook.decision_for(cmd)
         return retval
 
-    def test_import_alias_os_system(self):
+    @staticmethod
+    def _decision_dash_c(snippet):
+        # Wrap the inline source in single quotes so the embedded
+        # double quotes survive the shell parse. The grammar walker
+        # hands the raw inline body to the Python AST delegate.
+        cmd = "python3 -c '{}'".format(snippet)
+        retval = _Hook.decision_for(cmd)
+        return retval
+
+    # Heredoc form (multi-line imports + call)
+
+    def test_import_alias_os_system_heredoc(self):
         snippet = (
             "import os as x\n"
             'x.system("rm -rf /tmp/x")'
         )
-        self.assertEqual(self._decision(snippet), "ask")
+        self.assertEqual(self._decision_heredoc(snippet), "ask")
 
-    def test_from_import_unaliased(self):
+    def test_from_import_unaliased_heredoc(self):
         snippet = (
             "from os import system\n"
             'system("rm -rf /tmp/x")'
         )
-        self.assertEqual(self._decision(snippet), "ask")
+        self.assertEqual(self._decision_heredoc(snippet), "ask")
 
-    def test_from_import_aliased(self):
+    def test_from_import_aliased_heredoc(self):
         snippet = (
             "from shutil import rmtree as wipe\n"
             'wipe("/tmp/x")'
         )
-        self.assertEqual(self._decision(snippet), "ask")
+        self.assertEqual(self._decision_heredoc(snippet), "ask")
+
+    # Semicolon one-liner via `python3 -c`. This is the exact
+    # repro shape from the #16 issue body and the #30 review:
+    # alias resolution must work when the binding and the call
+    # are on the same source line.
+
+    def test_import_alias_os_system_dash_c_semicolon(self):
+        self.assertEqual(
+            self._decision_dash_c(
+                'import os as x; x.system(\"rm -rf /tmp/x\")'
+            ),
+            "ask",
+        )
+
+    def test_from_import_unaliased_dash_c_semicolon(self):
+        self.assertEqual(
+            self._decision_dash_c(
+                'from os import system; system(\"rm -rf /tmp/x\")'
+            ),
+            "ask",
+        )
+
+    def test_from_import_aliased_dash_c_semicolon(self):
+        self.assertEqual(
+            self._decision_dash_c(
+                'from shutil import rmtree as wipe; wipe(\"/tmp/x\")'
+            ),
+            "ask",
+        )
 
 
 class TestIssue21PythonLocalShadowing(unittest.TestCase):

--- a/tests/test_adversarial_regressions.py
+++ b/tests/test_adversarial_regressions.py
@@ -1,0 +1,256 @@
+"""Adversarial false-allow regression catalogue.
+
+Each test in this module pins one previously known false-allow
+reproduction to its post-fix expected decision so a future refactor
+cannot silently re-introduce it. New repros that surface in the wild
+should be added here when their fix lands.
+
+Every test goes through the same end-to-end path Claude Code uses in
+production: `python3 hooks/yolt_analyzer.py --hook`, fed a synthetic
+`PreToolUse` payload on stdin. The assertion is on the
+`permissionDecision` value (`allow` / `ask`) or on a silent exit
+(`None`) for inputs that intentionally fall through to Claude Code's
+default-prompt path.
+
+Catalogue layout:
+
+- `TestIssue14ShellFalseAllows` -- `find -exec / -execdir / -ok /
+  -okdir <cmd>` and `gh api --input <file>` repros (closes #15 via
+  PR #19).
+- `TestIssue16PythonImportAliases` -- aliased / renamed-import
+  destructive call repros (closes #16 via PR #20).
+- `TestIssue21PythonLocalShadowing` -- local shadow of an imported
+  destructive alias must not suppress an outer unsafe call (closes
+  #21 via PR #22).
+- `TestIssue17NestedCliVerbs` -- nested-verb mutating CLIs that used
+  to classify safe under the shallow top-level subcommand rule
+  (closes #17 via PR #25), and the bare-read counterparts that must
+  stay safe.
+
+Run with:
+
+    python3 -m unittest discover -v tests
+    python3 -m unittest tests.test_adversarial_regressions -v
+"""
+
+import json
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+HOOKS_DIR = REPO_ROOT / "hooks"
+
+
+class _Hook:
+    """Run the hook entry point on a Bash command and return the decision."""
+
+    @staticmethod
+    def decision_for(command):
+        result = subprocess.run(
+            [sys.executable, str(HOOKS_DIR / "yolt_analyzer.py"), "--hook"],
+            input=json.dumps({
+                "tool_name": "Bash",
+                "tool_input": {"command": command},
+            }),
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        stdout = result.stdout.strip()
+        if not stdout:
+            retval = None
+            return retval
+        last_line = stdout.splitlines()[-1]
+        response = json.loads(last_line)
+        retval = response["hookSpecificOutput"]["permissionDecision"]
+        return retval
+
+
+class TestIssue14ShellFalseAllows(unittest.TestCase):
+    """Repros from #15 (subset of #14): shell-rule `unsafe_flag_value_prefix`.
+
+    Before PR #19 the field was declared in `rules/shell.json` but
+    not evaluated, so `find -exec rm {} \\;` and `gh api --input
+    body.json` classified `safe`.
+    """
+
+    def test_find_exec_runs_destructive_command(self):
+        self.assertEqual(
+            _Hook.decision_for("find . -name '*.py' -exec rm {} \\;"),
+            "ask",
+        )
+
+    def test_find_execdir_runs_destructive_command(self):
+        self.assertEqual(
+            _Hook.decision_for("find . -name '*.py' -execdir rm {} \\;"),
+            "ask",
+        )
+
+    def test_find_ok_runs_destructive_command(self):
+        self.assertEqual(
+            _Hook.decision_for("find . -name '*.py' -ok rm {} \\;"),
+            "ask",
+        )
+
+    def test_find_okdir_runs_destructive_command(self):
+        self.assertEqual(
+            _Hook.decision_for("find . -name '*.py' -okdir rm {} \\;"),
+            "ask",
+        )
+
+    def test_gh_api_input_split_form(self):
+        self.assertEqual(
+            _Hook.decision_for("gh api /repos/x/y/issues --input body.json"),
+            "ask",
+        )
+
+    def test_gh_api_input_inline_form(self):
+        self.assertEqual(
+            _Hook.decision_for("gh api /repos/x/y/issues --input=body.json"),
+            "ask",
+        )
+
+
+class TestIssue16PythonImportAliases(unittest.TestCase):
+    """Repros from #16: aliased imports must resolve to the underlying call.
+
+    Before PR #20 the Python delegate matched call targets by surface
+    name only, so `import os as x; x.system(...)` slipped past the
+    `os.system` rule.
+    """
+
+    @staticmethod
+    def _decision(snippet):
+        # Use a heredoc, not `python3 -c`, so the snippet keeps its
+        # real newlines. The Python AST delegate's alias resolution
+        # is shape-faithful — multi-line `import` then call — which
+        # is the form the closing PR #20 verified end-to-end.
+        cmd = "python3 <<'PYEOF'\n{}\nPYEOF\n".format(snippet)
+        retval = _Hook.decision_for(cmd)
+        return retval
+
+    def test_import_alias_os_system(self):
+        snippet = (
+            "import os as x\n"
+            'x.system("rm -rf /tmp/x")'
+        )
+        self.assertEqual(self._decision(snippet), "ask")
+
+    def test_from_import_unaliased(self):
+        snippet = (
+            "from os import system\n"
+            'system("rm -rf /tmp/x")'
+        )
+        self.assertEqual(self._decision(snippet), "ask")
+
+    def test_from_import_aliased(self):
+        snippet = (
+            "from shutil import rmtree as wipe\n"
+            'wipe("/tmp/x")'
+        )
+        self.assertEqual(self._decision(snippet), "ask")
+
+
+class TestIssue21PythonLocalShadowing(unittest.TestCase):
+    """Repros from #21: local rebinding must not suppress outer unsafe.
+
+    Before PR #22 a local `os.system = lambda *_: None` inside a
+    function body invalidated the module-level alias resolution and
+    a sibling unsafe call elsewhere in the module was missed.
+    """
+
+    @staticmethod
+    def _decision(snippet):
+        cmd = "python3 <<'PYEOF'\n{}\nPYEOF\n".format(snippet)
+        retval = _Hook.decision_for(cmd)
+        return retval
+
+    def test_function_local_shadow_does_not_suppress_outer(self):
+        snippet = (
+            "import os\n"
+            "def f():\n"
+            "    os = object()\n"
+            "    return os\n"
+            'os.system("rm -rf /tmp/x")\n'
+        )
+        self.assertEqual(self._decision(snippet), "ask")
+
+    def test_class_body_shadow_does_not_suppress_outer(self):
+        snippet = (
+            "import os\n"
+            "class C:\n"
+            "    os = None\n"
+            'os.system("rm -rf /tmp/x")\n'
+        )
+        self.assertEqual(self._decision(snippet), "ask")
+
+
+class TestIssue17NestedCliVerbs(unittest.TestCase):
+    """Repros from #17: nested mutating verbs in policy-driven CLIs.
+
+    Before PR #25 the top-level rules said e.g. `docker image: safe`
+    so `docker image rm alpine` classified safe. Path-aware nested
+    classification now routes the mutating verb to `unsafe`, while
+    the bare-read counterparts (`docker image ls`, `git tag -l`,
+    ...) keep classifying `safe`.
+    """
+
+    # Unsafe nested verbs
+
+    def test_docker_image_rm_is_unsafe(self):
+        self.assertEqual(
+            _Hook.decision_for("docker image rm alpine"), "ask"
+        )
+
+    def test_kubectl_config_set_context_is_unsafe(self):
+        self.assertEqual(
+            _Hook.decision_for("kubectl config set-context prod"),
+            "ask",
+        )
+
+    def test_helm_repo_add_is_unsafe(self):
+        self.assertEqual(
+            _Hook.decision_for(
+                "helm repo add foo https://charts.example.com"
+            ),
+            "ask",
+        )
+
+    def test_git_tag_create_is_not_safe(self):
+        # `git tag <name>` creates a tag. Conservative fallback is
+        # `unknown`, which surfaces as a silent exit (Claude Code
+        # default-prompts).
+        self.assertIn(
+            _Hook.decision_for("git tag v1.2.3"),
+            (None, "ask"),
+        )
+
+    def test_git_tag_delete_is_unsafe(self):
+        self.assertEqual(
+            _Hook.decision_for("git tag -d v1.2.3"), "ask"
+        )
+
+    # Bare reads that must remain safe
+
+    def test_bare_git_tag_safe(self):
+        self.assertEqual(_Hook.decision_for("git tag"), "allow")
+
+    def test_git_tag_list_safe(self):
+        self.assertEqual(_Hook.decision_for("git tag -l"), "allow")
+
+    def test_docker_image_ls_safe(self):
+        self.assertEqual(_Hook.decision_for("docker image ls"), "allow")
+
+    def test_kubectl_config_view_safe(self):
+        self.assertEqual(
+            _Hook.decision_for("kubectl config view"), "allow"
+        )
+
+    def test_helm_repo_list_safe(self):
+        self.assertEqual(_Hook.decision_for("helm repo list"), "allow")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Closes three of the release gates from #18 that the sub-issues (#15, #16, #17, #21) did not themselves provide:

1. **Adversarial regression catalogue** (`tests/test_adversarial_regressions.py`) — consolidates the false-allow reproductions closed by PRs #19, #20, #22, #25 into one named suite. Each test cites the issue and PR that fixed it so a future refactor cannot silently re-introduce a known repro.

   - `TestIssue14ShellFalseAllows` — `find -exec / -execdir / -ok / -okdir <cmd>`, `gh api --input <file>` split + inline forms.
   - `TestIssue16PythonImportAliases` — `import os as x; x.system(...)`, `from os import system; system(...)`, `from shutil import rmtree as wipe; wipe(...)`.
   - `TestIssue21PythonLocalShadowing` — function-body and class-body shadow that must not suppress outer unsafe calls.
   - `TestIssue17NestedCliVerbs` — `docker image rm`, `kubectl config set-context`, `helm repo add`, `git tag <name>`, `git tag -d` go `ask`; bare reads (`git tag -l`, `docker image ls`, `kubectl config view`, `helm repo list`) stay `allow`.

2. **CI workflow** (`.github/workflows/ci.yml`) — runs `python -m unittest discover -v tests` on Python 3.10 / 3.11 / 3.12 and runs `validate_shell_rules()` on the bundled `rules/shell.json`. Schema drift becomes a hard CI failure rather than the silent `rules-validation-error` the production hook emits.

3. **`README` "Analysis boundaries" section** — documents in-scope vs out-of-scope for every analysis surface (Bash decomposition, delegated languages, SQL CLIs, Python alias resolution, policy-driven CLIs) and pins the conservative-unknown contract.

## Test plan

- [x] `python3 -m unittest discover -s tests` — 349 tests pass (303 baseline + new regression catalogue).
- [x] `python3 -m unittest tests.test_adversarial_regressions -v` — 21 / 21 green.
- [x] CI dry run locally: `validate_shell_rules(load_shell_rules('rules', validate=False))` returns `[]` → `rules/shell.json: schema OK`.
- [x] README TOC updated to include the new section.

## Out of scope

- Discovered during test authoring that `python3 -c 'import os as x; x.system(...)'` (semicolon one-liner form, no newline between import and call) still slips past alias resolution — multi-line and heredoc forms work, including all forms PR #20 verified. Filing as a separate issue is appropriate; not bundling here to keep the release-gates PR focused.

Refs #18.
