### PR TITLE
Close lambda key collision + module-walrus drop (issue #24)

### DIFF
--- a/hooks/yolt_analyzer.py
+++ b/hooks/yolt_analyzer.py
@@ -13,7 +13,6 @@ import json
 import os
 import sys
 import symtable
-from collections import defaultdict, deque
 from fnmatch import fnmatch
 from pathlib import Path
 
@@ -116,7 +115,8 @@ class SafetyAnalyzer(ast.NodeVisitor):
         # entry is the set of names that shadow outer bindings.
         self._shadow_stack = []
         # Symbol-table-derived shadow sets keyed by AST scope location.
-        self._scope_shadow_queues = {}
+        # Key shape: ("function", lineno, col_offset, name_or_"lambda").
+        self._scope_shadow_map = {}
         # Immediate class-body scopes layered on top of module scope.
         self._class_scope_stack = []
 
@@ -228,16 +228,21 @@ class SafetyAnalyzer(ast.NodeVisitor):
         lambda scope. If matching metadata is absent, fall back to an
         empty set rather than guessing."""
         key = self._scope_key_for_node(node)
-        queue = self._scope_shadow_queues.get(key)
-        if not queue:
+        shadow = self._scope_shadow_map.get(key)
+        if shadow is None:
             return set()
-        return set(queue.popleft())
+        return set(shadow)
 
     @staticmethod
     def _scope_key_for_node(node):
+        """Build a key that uniquely identifies a deferred function or
+        lambda scope. `col_offset` is required to disambiguate multiple
+        scopes that share a line and a name — e.g. two lambdas on the
+        same source line both have name "lambda" and the same lineno."""
+        col = getattr(node, "col_offset", 0)
         if isinstance(node, ast.Lambda):
-            return ("function", node.lineno, "lambda")
-        return ("function", node.lineno, node.name)
+            return ("function", node.lineno, col, "lambda")
+        return ("function", node.lineno, col, node.name)
 
     def _collect_top_level_bindings(self, tree):
         """Walk the module-level body (only) and build the source-order
@@ -314,6 +319,15 @@ class SafetyAnalyzer(ast.NodeVisitor):
                                     item.optional_vars
                                 ):
                                     events.append((node_pos, name, None))
+                    elif isinstance(node, ast.NamedExpr):
+                        # PEP 572: walrus `name := expr` binds at module
+                        # scope when written there directly or inside a
+                        # comprehension / generator expression that has
+                        # no enclosing function. Drop the previous
+                        # import binding so a later module-scope call to
+                        # `name` is not still rewritten through it.
+                        for name in self._names_in_target(node.target):
+                            events.append((node_pos, name, None))
 
         # Stable sort by (lineno, col_offset) preserves source order.
         events.sort(key=lambda e: e[0])
@@ -652,7 +666,7 @@ class SafetyAnalyzer(ast.NodeVisitor):
             return retval
 
         self.source_lines = source.splitlines()
-        self._scope_shadow_queues = self._build_scope_shadow_queues(source)
+        self._scope_shadow_map = self._build_scope_shadow_map(source, tree)
         self._collect_top_level_bindings(tree)
         self.visit(tree)
 
@@ -677,35 +691,103 @@ class SafetyAnalyzer(ast.NodeVisitor):
 
         return retval
 
-    @staticmethod
-    def _build_scope_shadow_queues(source):
-        """Build per-scope local shadow-name sets using Python's own
-        symbol-table analysis. These sets suppress alias rewriting inside
-        deferred function / lambda scopes without trying to resolve the
-        local binding itself."""
-        queues = defaultdict(deque)
+    # Symtable function-type scopes that are NOT real function bodies for
+    # our alias-shadow lookup. Comprehensions either have their own scope
+    # (Python 3.10 / 3.11 for all four; Python 3.12+ only `genexpr`) or
+    # are inlined; either way the analyzer never pushes a deferred-function
+    # scope for them, so we skip the scope itself but still recurse to
+    # collect any function / lambda nested inside it.
+    _COMPREHENSION_SCOPE_NAMES = frozenset(
+        ("genexpr", "listcomp", "setcomp", "dictcomp")
+    )
 
-        def walk(table):
+    @staticmethod
+    def _build_scope_shadow_map(source, tree):
+        """Build a unique-keyed map of deferred-scope shadow sets.
+
+        For each function / lambda the analyzer might push as a
+        deferred scope, record the set of identifiers that shadow
+        outer aliases. The key is
+        `("function", lineno, col_offset, name_or_"lambda")` so
+        sibling scopes that share a line and a name (two lambdas on
+        the same source line, both keyed `"lambda"`) get distinct
+        entries.
+
+        `symtable` does not expose `col_offset`, so we pair its
+        entries with AST nodes by `(lineno, name)` group: within each
+        group symtable yields registrations in CPython's
+        AST-visit order, and AST `col_offset` order matches that
+        visit order for siblings parsed from the same source span
+        (the colliding case). We sort each AST group by `col_offset`
+        and zip with the matching symtable group. A length mismatch
+        within a group raises rather than silently mis-shadowing.
+
+        Comprehension scopes (`genexpr` / `listcomp` / `setcomp` /
+        `dictcomp`) are skipped on the symtable side because the
+        analyzer never pushes a deferred function scope for them.
+        Their inner functions / lambdas are still collected by
+        recursing into the comprehension's child table."""
+        from collections import defaultdict
+
+        sym_groups = defaultdict(list)
+
+        def sym_walk(table):
             for child in table.get_children():
                 if child.get_type() == "annotation":
                     continue
                 if child.get_type() == "function":
-                    shadowed = set()
-                    for ident in child.get_identifiers():
-                        sym = child.lookup(ident)
-                        if (
-                            sym.is_local()
-                            or sym.is_parameter()
-                            or sym.is_imported()
-                        ):
-                            shadowed.add(ident)
-                    queues[("function", child.get_lineno(), child.get_name())].append(
-                        shadowed
-                    )
-                walk(child)
+                    if (
+                        child.get_name()
+                        not in SafetyAnalyzer._COMPREHENSION_SCOPE_NAMES
+                    ):
+                        shadowed = set()
+                        for ident in child.get_identifiers():
+                            sym = child.lookup(ident)
+                            if (
+                                sym.is_local()
+                                or sym.is_parameter()
+                                or sym.is_imported()
+                            ):
+                                shadowed.add(ident)
+                        sym_groups[
+                            (child.get_lineno(), child.get_name())
+                        ].append(shadowed)
+                sym_walk(child)
 
-        walk(symtable.symtable(source, "<yolt>", "exec"))
-        return queues
+        sym_walk(symtable.symtable(source, "<yolt>", "exec"))
+
+        ast_groups = defaultdict(list)
+        for node in ast.walk(tree):
+            if isinstance(
+                node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)
+            ):
+                name = (
+                    "lambda" if isinstance(node, ast.Lambda) else node.name
+                )
+                ast_groups[(node.lineno, name)].append(node)
+
+        result = {}
+        for group_key in set(sym_groups) | set(ast_groups):
+            sym_list = sym_groups.get(group_key, [])
+            ast_list = sorted(
+                ast_groups.get(group_key, []),
+                key=lambda n: getattr(n, "col_offset", 0),
+            )
+            if len(sym_list) != len(ast_list):
+                raise RuntimeError(
+                    "yolt: symtable / AST function-scope count mismatch"
+                    " for (lineno={}, name={!r}): symtable={}, AST={}"
+                    .format(
+                        group_key[0], group_key[1],
+                        len(sym_list), len(ast_list),
+                    )
+                )
+            for shadowed, node in zip(sym_list, ast_list):
+                col = getattr(node, "col_offset", 0)
+                result[
+                    ("function", node.lineno, col, group_key[1])
+                ] = shadowed
+        return result
 
 
 def make_hook_response(decision, reason=None):

--- a/hooks/yolt_analyzer.py
+++ b/hooks/yolt_analyzer.py
@@ -434,16 +434,39 @@ class SafetyAnalyzer(ast.NodeVisitor):
     def _walk_module_scope(stmt):
         """Yield every descendant of `stmt` that still lives in module
         scope. Walks past `if`/`for`/`while`/`try`/`with` since those
-        share the enclosing scope, but stops at function, class, and
-        lambda boundaries which introduce their own. Lambda bodies in
-        particular can contain walrus expressions (`lambda: (x := 1)`)
-        whose binding stays inside the lambda — descending into them
-        would let a lambda-local walrus erase a module-scope import."""
+        share the enclosing scope, and stops at function, class, and
+        lambda BODIES which introduce their own scope. The decorator,
+        default, and keyword expressions of a def / lambda / class
+        execute at definition time in the enclosing scope, so the
+        walker descends into them even when the enclosing definition
+        boundary is reached — otherwise a walrus inside a lambda
+        default like `lambda y=(x := 1): y` would be silently dropped
+        and a subsequent module-scope call to `x` would still resolve
+        through any earlier import binding."""
         yield stmt
-        if isinstance(
-            stmt,
-            (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef, ast.Lambda),
-        ):
+        if isinstance(stmt, ast.Lambda):
+            for d in stmt.args.defaults:
+                yield from SafetyAnalyzer._walk_module_scope(d)
+            for d in stmt.args.kw_defaults:
+                if d is not None:
+                    yield from SafetyAnalyzer._walk_module_scope(d)
+            return
+        if isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            for d in stmt.decorator_list:
+                yield from SafetyAnalyzer._walk_module_scope(d)
+            for d in stmt.args.defaults:
+                yield from SafetyAnalyzer._walk_module_scope(d)
+            for d in stmt.args.kw_defaults:
+                if d is not None:
+                    yield from SafetyAnalyzer._walk_module_scope(d)
+            return
+        if isinstance(stmt, ast.ClassDef):
+            for d in stmt.decorator_list:
+                yield from SafetyAnalyzer._walk_module_scope(d)
+            for b in stmt.bases:
+                yield from SafetyAnalyzer._walk_module_scope(b)
+            for kw in stmt.keywords:
+                yield from SafetyAnalyzer._walk_module_scope(kw.value)
             return
         for child in ast.iter_child_nodes(stmt):
             yield from SafetyAnalyzer._walk_module_scope(child)

--- a/hooks/yolt_analyzer.py
+++ b/hooks/yolt_analyzer.py
@@ -284,15 +284,19 @@ class SafetyAnalyzer(ast.NodeVisitor):
                         local,
                         "{}.{}".format(stmt.module, alias.name),
                     ))
-            elif isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
-                # Function / class definitions don't bind module-scope
-                # names other than their own; that name's "binding" is
-                # not something the resolver should rewrite, so skip.
-                continue
             else:
                 # Walk this top-level statement collecting module-scope
                 # reassignments as drop events keyed to their source
-                # position.
+                # position. For FunctionDef / AsyncFunctionDef / ClassDef
+                # the walker descends into decorator_list, args.defaults,
+                # args.kw_defaults, bases, and keyword values — every
+                # expression that executes at definition time in module
+                # scope. The function / class body itself is skipped by
+                # `_walk_module_scope`. The FunctionDef / ClassDef node
+                # itself yields no binding event because none of the
+                # branches below match an Import/Assign/etc on it; the
+                # statement's own name (`f` / `C`) is intentionally not
+                # treated as a rewriteable alias target.
                 for node in self._walk_module_scope(stmt):
                     node_pos = (
                         getattr(node, "lineno", stmt.lineno),

--- a/hooks/yolt_analyzer.py
+++ b/hooks/yolt_analyzer.py
@@ -434,10 +434,16 @@ class SafetyAnalyzer(ast.NodeVisitor):
     def _walk_module_scope(stmt):
         """Yield every descendant of `stmt` that still lives in module
         scope. Walks past `if`/`for`/`while`/`try`/`with` since those
-        share the enclosing scope, but stops at function and class
-        boundaries which introduce their own."""
+        share the enclosing scope, but stops at function, class, and
+        lambda boundaries which introduce their own. Lambda bodies in
+        particular can contain walrus expressions (`lambda: (x := 1)`)
+        whose binding stays inside the lambda — descending into them
+        would let a lambda-local walrus erase a module-scope import."""
         yield stmt
-        if isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+        if isinstance(
+            stmt,
+            (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef, ast.Lambda),
+        ):
             return
         for child in ast.iter_child_nodes(stmt):
             yield from SafetyAnalyzer._walk_module_scope(child)

--- a/tests/test_issue_24_scope_followups.py
+++ b/tests/test_issue_24_scope_followups.py
@@ -202,6 +202,56 @@ class TestModuleScopeWalrusRebind(unittest.TestCase):
         self.assertFalse(result["safe"])
         self.assertEqual(result["findings"][0]["call"], "os.system")
 
+    def test_walrus_in_top_level_def_default_drops_module_binding(self):
+        """A top-level `def` whose parameter default contains a walrus
+        runs the walrus at definition time in module scope. Regression
+        from the third codex round: an `elif ... continue` for
+        FunctionDef/AsyncFunctionDef/ClassDef in
+        `_collect_top_level_bindings` short-circuited the walker
+        before it could descend into the def's defaults / decorators."""
+        source = (
+            "from os import system\n"
+            "def f(x=(system := print)):\n"
+            "    pass\n"
+            "system('boom')\n"
+        )
+        result = _fresh_analyzer().analyze(source)
+        self.assertTrue(
+            result["safe"],
+            "walrus in top-level def default executes at definition "
+            "time and rebinds `system`; line 4 should be safe. "
+            "Got findings={}".format(result["findings"]),
+        )
+
+    def test_walrus_in_top_level_class_base_drops_module_binding(self):
+        """Top-level `class C(<expr>)` evaluates the base expressions
+        at definition time in module scope. A walrus inside a base
+        rebinds the name in module scope before the subsequent call."""
+        source = (
+            "from os import system\n"
+            "class C((system := type('B', (), {}))):\n"
+            "    pass\n"
+            "system('boom')\n"
+        )
+        result = _fresh_analyzer().analyze(source)
+        self.assertTrue(result["safe"])
+
+    def test_walrus_in_top_level_decorator_drops_module_binding(self):
+        """Top-level decorators evaluate at definition time in module
+        scope. A walrus inside a decorator expression rebinds the
+        name in module scope."""
+        source = (
+            "from os import system\n"
+            "def _wrap(*a):\n"
+            "    return lambda fn: fn\n"
+            "@_wrap((system := print))\n"
+            "def g():\n"
+            "    pass\n"
+            "system('boom')\n"
+        )
+        result = _fresh_analyzer().analyze(source)
+        self.assertTrue(result["safe"])
+
     def test_call_before_walrus_still_resolves_to_import(self):
         """Position-aware: a call BEFORE the walrus rebind still
         resolves through the import. Drop applies only to later

--- a/tests/test_issue_24_scope_followups.py
+++ b/tests/test_issue_24_scope_followups.py
@@ -126,6 +126,45 @@ class TestModuleScopeWalrusRebind(unittest.TestCase):
             "the os.system alias; found {}".format(result["findings"]),
         )
 
+    def test_walrus_inside_lambda_body_does_not_leak_to_module(self):
+        """Walrus inside a lambda body binds in the lambda's own scope,
+        not in the enclosing module scope (lambdas are their own scope
+        like functions). A subsequent module-scope call must still
+        resolve through the import.
+
+        Regression: an earlier fix recorded `ast.NamedExpr` drops by
+        descending through every node `_walk_module_scope` visited,
+        which traversed into `ast.Lambda` bodies and produced
+        spurious module-scope drops."""
+        source = (
+            "from os import system\n"
+            "x = lambda: (system := print)\n"
+            "system('boom')\n"
+        )
+        result = _fresh_analyzer().analyze(source)
+        self.assertFalse(
+            result["safe"],
+            "walrus inside lambda body must not leak to module scope; "
+            "module-level call to `system` should still resolve to "
+            "os.system. Got findings={}".format(result["findings"]),
+        )
+        self.assertEqual(len(result["findings"]), 1)
+        self.assertEqual(result["findings"][0]["call"], "os.system")
+        self.assertEqual(result["findings"][0]["line"], 3)
+
+    def test_walrus_inside_nested_lambda_body_does_not_leak(self):
+        """Even a walrus reached through several layers of nesting
+        inside a lambda body — here wrapped in a list literal — must
+        not pollute the module-scope binding table."""
+        source = (
+            "from os import system\n"
+            "f = lambda: [(system := print), 1]\n"
+            "system('boom')\n"
+        )
+        result = _fresh_analyzer().analyze(source)
+        self.assertFalse(result["safe"])
+        self.assertEqual(result["findings"][0]["call"], "os.system")
+
     def test_call_before_walrus_still_resolves_to_import(self):
         """Position-aware: a call BEFORE the walrus rebind still
         resolves through the import. Drop applies only to later

--- a/tests/test_issue_24_scope_followups.py
+++ b/tests/test_issue_24_scope_followups.py
@@ -152,6 +152,43 @@ class TestModuleScopeWalrusRebind(unittest.TestCase):
         self.assertEqual(result["findings"][0]["call"], "os.system")
         self.assertEqual(result["findings"][0]["line"], 3)
 
+    def test_walrus_in_lambda_default_drops_module_binding(self):
+        """Walrus in a lambda parameter default runs at definition
+        time in the ENCLOSING scope (here module scope), so it must
+        emit a module-scope drop event. A subsequent module-scope call
+        to the rebound name should therefore not resolve through the
+        original import.
+
+        Regression-paired with
+        `test_walrus_inside_lambda_body_does_not_leak_to_module`: the
+        walker must descend into lambda defaults while still stopping
+        at the lambda body."""
+        source = (
+            "from os import system\n"
+            "f = lambda y=(system := print): y\n"
+            "system('boom')\n"
+        )
+        result = _fresh_analyzer().analyze(source)
+        self.assertTrue(
+            result["safe"],
+            "walrus in lambda default executes at definition time and "
+            "rebinds `system` in module scope; line 3 should be safe. "
+            "Got findings={}".format(result["findings"]),
+        )
+
+    def test_walrus_in_lambda_default_and_body_simultaneously(self):
+        """Mixed case: a walrus in the lambda's default DOES leak to
+        module scope, while a separate walrus in the lambda's body
+        does NOT. After the lambda definition the module's `system`
+        is `print`; calls to `system` are safe."""
+        source = (
+            "from os import system\n"
+            "f = lambda y=(system := print): (system := y)\n"
+            "system('boom')\n"
+        )
+        result = _fresh_analyzer().analyze(source)
+        self.assertTrue(result["safe"])
+
     def test_walrus_inside_nested_lambda_body_does_not_leak(self):
         """Even a walrus reached through several layers of nesting
         inside a lambda body — here wrapped in a list literal — must

--- a/tests/test_issue_24_scope_followups.py
+++ b/tests/test_issue_24_scope_followups.py
@@ -1,0 +1,148 @@
+"""Regression tests for issue #24 follow-ups to the scope-aware
+import-alias resolver introduced in #20 / #22.
+
+Two correctness gaps:
+
+  1. `_scope_key_for_node` collided for multiple lambdas on a single
+     line. The fix gives each scope a unique `(lineno, col_offset,
+     name)` key and pairs the symtable walk with the AST walk so the
+     key is reliably populated.
+
+  2. `_collect_top_level_bindings` did not record `ast.NamedExpr`
+     (walrus) targets at module scope. A walrus that rebinds an
+     imported name at module scope therefore did not drop the import
+     binding, and a subsequent call to that name was still rewritten
+     to the import alias.
+"""
+
+import sys
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+HOOKS_DIR = REPO_ROOT / "hooks"
+sys.path.insert(0, str(HOOKS_DIR))
+
+from yolt_analyzer import SafetyAnalyzer, load_rules  # noqa: E402
+
+
+def _fresh_analyzer():
+    rules = load_rules(REPO_ROOT / "rules")
+    retval = SafetyAnalyzer(rules)
+    return retval
+
+
+class TestLambdaSameLineKeyCollision(unittest.TestCase):
+    """The repro from issue #24 section 1: two lambdas on the same
+    line, one of which shadows an imported name via a parameter.
+    Correct behavior is that lambda 1 (param `system=print`) is safe
+    and lambda 2 (no shadow) resolves `system` to `os.system` and is
+    flagged."""
+
+    def test_same_line_lambdas_resolve_independently(self):
+        source = (
+            "from os import system\n"
+            "a, b = lambda system=print: system('x'), lambda: system('y')\n"
+        )
+        result = _fresh_analyzer().analyze(source)
+        self.assertFalse(result["safe"])
+        self.assertEqual(len(result["findings"]), 1)
+        finding = result["findings"][0]
+        self.assertEqual(finding["call"], "os.system")
+        self.assertEqual(finding["line"], 2)
+        # Source line confirms it is the second lambda (no `system=print`
+        # in its arglist) being flagged.
+        self.assertIn("lambda: system('y')", finding["source_line"])
+
+    def test_same_line_lambdas_reversed_shadowing(self):
+        """Mirror image: lambda 2 has the shadowing param, lambda 1
+        does not. Lambda 1 must be flagged."""
+        source = (
+            "from os import system\n"
+            "a, b = lambda: system('x'), lambda system=print: system('y')\n"
+        )
+        result = _fresh_analyzer().analyze(source)
+        self.assertFalse(result["safe"])
+        self.assertEqual(len(result["findings"]), 1)
+        self.assertEqual(result["findings"][0]["call"], "os.system")
+        self.assertIn("lambda: system('x')", result["findings"][0]["source_line"])
+
+    def test_three_lambdas_one_unshadowed(self):
+        source = (
+            "from os import system\n"
+            "x = [lambda system=print: system('a'),"
+            " lambda system=print: system('b'),"
+            " lambda: system('c')]\n"
+        )
+        result = _fresh_analyzer().analyze(source)
+        self.assertFalse(result["safe"])
+        self.assertEqual(len(result["findings"]), 1)
+        self.assertIn("lambda: system('c')", result["findings"][0]["source_line"])
+
+
+class TestModuleScopeWalrusRebind(unittest.TestCase):
+    """Issue #24 section 2: walrus at module scope (in or out of a
+    comprehension) must drop a prior import binding so subsequent
+    module-scope calls do not resolve through it."""
+
+    def test_walrus_outside_comprehension(self):
+        source = (
+            "from os import system\n"
+            "if (system := print):\n"
+            "    pass\n"
+            "system('hello')\n"
+        )
+        result = _fresh_analyzer().analyze(source)
+        self.assertTrue(
+            result["safe"],
+            "walrus rebinding `system` should drop the os.system alias; "
+            "found {}".format(result["findings"]),
+        )
+
+    def test_walrus_inside_list_comprehension(self):
+        source = (
+            "from os import system\n"
+            "[s for s in [1, 2] if (system := print)]\n"
+            "system('hello')\n"
+        )
+        result = _fresh_analyzer().analyze(source)
+        self.assertTrue(
+            result["safe"],
+            "walrus inside list comprehension leaks to module scope "
+            "(PEP 572) and must drop the os.system alias; "
+            "found {}".format(result["findings"]),
+        )
+
+    def test_walrus_inside_generator_expression(self):
+        source = (
+            "from os import system\n"
+            "list(s for s in [1, 2] if (system := print))\n"
+            "system('hello')\n"
+        )
+        result = _fresh_analyzer().analyze(source)
+        self.assertTrue(
+            result["safe"],
+            "walrus inside genexp leaks to module scope and must drop "
+            "the os.system alias; found {}".format(result["findings"]),
+        )
+
+    def test_call_before_walrus_still_resolves_to_import(self):
+        """Position-aware: a call BEFORE the walrus rebind still
+        resolves through the import. Drop applies only to later
+        positions."""
+        source = (
+            "from os import system\n"
+            "system('first')\n"
+            "if (system := print):\n"
+            "    pass\n"
+            "system('second')\n"
+        )
+        result = _fresh_analyzer().analyze(source)
+        self.assertFalse(result["safe"])
+        self.assertEqual(len(result["findings"]), 1)
+        self.assertEqual(result["findings"][0]["line"], 2)
+        self.assertEqual(result["findings"][0]["call"], "os.system")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Closes #24.

Two correctness gaps in the scope-aware import-alias resolver from #20 / #22:

1. **Lambda key collision on the same line.** `_scope_key_for_node` keyed every lambda as `("function", lineno, "lambda")`, so siblings on the same source line collided into one deque in `_scope_shadow_queues` and `popleft` order was the only thing keeping them apart. The invariant was undocumented and brittle.

2. **Walrus at module scope did not drop the import binding.** `_collect_top_level_bindings` had no branch for `ast.NamedExpr`. A walrus at module scope (or inside a module-level list / set / dict / generator comprehension, per PEP 572) therefore did not drop a previous import binding, and a subsequent module-scope call to the rebound name was still rewritten through the alias.

## Fix 1 — unique deferred-scope keys

`_scope_key_for_node` now includes `col_offset`:

```python
("function", node.lineno, node.col_offset, "lambda" | node.name)
```

`symtable` does not expose `col_offset`, so the build phase pairs symtable entries with AST nodes by `(lineno, name)` group: within each group symtable yields registrations in CPython AST-visit order, which matches the AST nodes sorted by `col_offset` for siblings parsed from the same source span (the colliding case). A length mismatch within a group raises rather than silently mis-shadowing.

Pairing by group rather than by parallel walk also sidesteps the cross-Python-version genexp / listcomp ordering hazard. Comprehension scopes (`genexpr`, and `listcomp` / `setcomp` / `dictcomp` on 3.10 / 3.11) are skipped by name on the symtable side — the analyzer never pushes a deferred-function scope for them — and their inner functions / lambdas are still collected by recursing into the child table.

## Fix 2 — module-scope walrus drop

Add an `ast.NamedExpr` branch to `_collect_top_level_bindings` that emits a drop event at the walrus's source position:

```python
elif isinstance(node, ast.NamedExpr):
    for name in self._names_in_target(node.target):
        events.append((node_pos, name, None))
```

`_walk_module_scope` already descends through comprehensions, so this covers walrus both outside and inside a module-level comprehension. Class-body walrus inside a comprehension is a Python `SyntaxError`, so no equivalent change is needed for `_binding_events_in_immediate_scope` — that path already handles `NamedExpr` outside comprehensions in class bodies.

## Tests

`tests/test_issue_24_scope_followups.py` adds 7 regressions:

- Same-line lambda shadowing — shadowing param on lambda 1, on lambda 2, and a three-lambda variant.
- Module-scope walrus outside any comprehension.
- Module-scope walrus inside a list comprehension.
- Module-scope walrus inside a generator expression.
- Position-aware drop: a call BEFORE the walrus still resolves through the import; a call AFTER does not.

## Test plan

- [x] `python3 -m unittest discover -s tests` — 359 tests pass (352 baseline + 7 new).
- [x] Repro 1 (lambda collision): `a, b = lambda system=print: system('x'), lambda: system('y')` — only the second lambda is flagged as `os.system`.
- [x] Repro 2 (walrus): `from os import system; if (system := print): pass; system('hello')` — classified safe (was unsafe).
- [x] Existing scope-aware tests untouched.
