### PR TITLE
find write-action flags route through safe_write_targets (closes #27)

### DIFF
--- a/hooks/rule_classifier.py
+++ b/hooks/rule_classifier.py
@@ -333,7 +333,30 @@ def aggregate_decisions(decisions):
     return (DECISION_SAFE, "; ".join(safe_reasons) if safe_reasons else "no commands")
 
 
-def check_unsafe_flags(cmd_args, spec):
+def _expand_home(path):
+    home = os.environ.get("HOME")
+    if home and path.startswith("~/"):
+        return home + path[1:]
+    return path
+
+
+def _path_matches_safe_write_targets(target, safe_write_targets):
+    """Return True if `target` matches any of `safe_write_targets` under
+    fnmatch semantics. Mirrors the redirect-target check that
+    `grammar_classifier._target_is_safe_write` runs against `> file`
+    redirects, so flag-value writes (e.g. `find -fprint FILE`) and
+    redirect writes use the same allow list."""
+    if not safe_write_targets:
+        return False
+    expanded = _expand_home(target)
+    for pat in safe_write_targets:
+        pat_expanded = _expand_home(pat)
+        if fnmatch(target, pat) or fnmatch(expanded, pat_expanded):
+            return True
+    return False
+
+
+def check_unsafe_flags(cmd_args, spec, safe_write_targets=None):
     """Check whether cmd_args contains a flag combination the command spec
     declares unsafe. Returns a human-readable description, or None.
 
@@ -350,11 +373,17 @@ def check_unsafe_flags(cmd_args, spec):
       `--flag value`); the value is matched against the glob
       (`find -exec rm`, `gh api --input body.json`). `"*"` matches any
       value.
+    - `write_flag_value_targets`: list of flags whose immediately
+      following value is a file path the command will write to
+      (`find -fprint FILE`). The path is checked against the top-level
+      `safe_write_targets` allow list; a non-matching path makes the
+      call unsafe. Requires `safe_write_targets` to be passed in.
     """
     unsafe_flag_values = spec.get("unsafe_flag_values", {})
     unsafe_flag_any_value = set(spec.get("unsafe_flag_any_value", []))
     unsafe_flags_without_value = set(spec.get("unsafe_flags_without_value", []))
     unsafe_flag_value_prefix = spec.get("unsafe_flag_value_prefix", {})
+    write_flag_value_targets = set(spec.get("write_flag_value_targets", []))
 
     i = 0
     while i < len(cmd_args):
@@ -387,6 +416,15 @@ def check_unsafe_flags(cmd_args, spec):
                 if fnmatch(value, pat):
                     return "{} {}".format(flag, value)
 
+        if flag in write_flag_value_targets:
+            value = inline_value
+            if value is None and i + 1 < len(cmd_args):
+                value = cmd_args[i + 1]
+            if value is not None and not _path_matches_safe_write_targets(
+                value, safe_write_targets
+            ):
+                return "{} {}".format(flag, value)
+
         if flag in unsafe_flag_any_value:
             return flag
 
@@ -412,6 +450,7 @@ _ALLOWED_COMMAND_KEYS = frozenset({
     "default", "_note", "_skip_first_positional",
     "unsafe_flag_values", "unsafe_flag_any_value",
     "unsafe_flags_without_value", "unsafe_flag_value_prefix",
+    "write_flag_value_targets",
     "valueless_flags",
     "safe_subcommands", "unsafe_subcommands",
     "safe_subcommand_patterns", "unsafe_subcommand_patterns",
@@ -609,6 +648,7 @@ class RuleClassifier:
         self.commands = rules.get("commands", {})
         self.shell_builtins_safe = set(rules.get("shell_builtins_safe", []))
         self.interpreters = rules.get("interpreters", {})
+        self.safe_write_targets = list(rules.get("safe_write_targets", []))
         self.python_analyzer_factory = python_analyzer_factory
         # When a `bash -c '<script>'` interpreter call needs nested analysis,
         # the grammar walker injects itself here as a callable
@@ -759,7 +799,9 @@ class RuleClassifier:
         spec = self.commands[cmd_name]
         default = spec.get("default", "unknown")
 
-        unsafe_match = check_unsafe_flags(cmd_args, spec)
+        unsafe_match = check_unsafe_flags(
+            cmd_args, spec, safe_write_targets=self.safe_write_targets
+        )
         if unsafe_match:
             return (DECISION_UNSAFE, "{}: flag {}".format(cmd_name, unsafe_match))
 
@@ -797,7 +839,9 @@ class RuleClassifier:
         nested = spec.get("nested_subcommand", {})
         if sub in nested:
             nested_spec = nested[sub]
-            nested_unsafe = check_unsafe_flags(remaining_args, nested_spec)
+            nested_unsafe = check_unsafe_flags(
+                remaining_args, nested_spec, safe_write_targets=self.safe_write_targets
+            )
             if nested_unsafe:
                 return (DECISION_UNSAFE, "{} {}: flag {}".format(cmd_name, sub, nested_unsafe))
             if "default" in nested_spec:

--- a/rules/shell.json
+++ b/rules/shell.json
@@ -216,7 +216,8 @@
       "unsafe_flag_any_value": ["-delete"],
       "unsafe_flags_without_value": ["-delete"],
       "unsafe_flag_value_prefix": {"-exec": "*", "-execdir": "*", "-ok": "*", "-okdir": "*"},
-      "_note": "find is read-only until you add -delete, -exec, -execdir, -ok, or -okdir."
+      "write_flag_value_targets": ["-fprint", "-fprintf", "-fls", "-fls0"],
+      "_note": "find is read-only until you add -delete, -exec, -execdir, -ok, -okdir, or a -fprint/-fprintf/-fls/-fls0 that writes outside safe_write_targets."
     },
     "xargs": {
       "default": "delegate_to_argument",

--- a/tests/test_adversarial_regressions.py
+++ b/tests/test_adversarial_regressions.py
@@ -26,6 +26,10 @@ Catalogue layout:
   to classify safe under the shallow top-level subcommand rule
   (closes #17 via PR #25), and the bare-read counterparts that must
   stay safe.
+- `TestIssue27FindWriteFlags` -- `find -fprint / -fprintf / -fls /
+  -fls0 FILE` repros (closes #27). Path argument was unchecked, so
+  writes outside `safe_write_targets` classified safe. The fix
+  routes the path through the same allow list redirects use.
 
 Run with:
 
@@ -288,6 +292,51 @@ class TestIssue17NestedCliVerbs(unittest.TestCase):
 
     def test_helm_repo_list_safe(self):
         self.assertEqual(_Hook.decision_for("helm repo list"), "allow")
+
+
+class TestIssue27FindWriteFlags(unittest.TestCase):
+    """Repros from #27: `find` write-action flags that take a path
+    argument (`-fprint`, `-fprintf`, `-fls`, `-fls0`) classified `safe`
+    before this fix because their path argument bypassed the redirect-
+    based `safe_write_targets` check. After the fix the path argument
+    routes through the same allow list, so writes to `/tmp/...` stay
+    safe but writes to `/etc/profile` / `/var/log/...` ask."""
+
+    def test_fprint_to_etc_is_unsafe(self):
+        self.assertEqual(
+            _Hook.decision_for("find / -name '*' -fprint /etc/profile"),
+            "ask",
+        )
+
+    def test_fprint_to_tmp_is_safe(self):
+        self.assertEqual(
+            _Hook.decision_for("find / -fprint /tmp/list.txt"),
+            "allow",
+        )
+
+    def test_fprintf_to_etc_is_unsafe(self):
+        self.assertEqual(
+            _Hook.decision_for("find / -fprintf /etc/passwd '%p\\n'"),
+            "ask",
+        )
+
+    def test_fprintf_to_tmp_is_safe(self):
+        self.assertEqual(
+            _Hook.decision_for("find / -fprintf /tmp/list.txt '%p\\n'"),
+            "allow",
+        )
+
+    def test_fls_to_var_log_is_unsafe(self):
+        self.assertEqual(
+            _Hook.decision_for("find / -fls /var/log/x.log"),
+            "ask",
+        )
+
+    def test_fls0_to_tmp_is_safe(self):
+        self.assertEqual(
+            _Hook.decision_for("find / -fls0 /tmp/list.bin"),
+            "allow",
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_rule_classifier.py
+++ b/tests/test_rule_classifier.py
@@ -111,6 +111,75 @@ class TestCheckUnsafeFlags(unittest.TestCase):
             check_unsafe_flags(["--input", "request.json"], spec)
         )
 
+    # write_flag_value_targets: flag value is a write-target path,
+    # decision routes through the top-level safe_write_targets allow list.
+    # Repros from issue #27 (find -fprint / -fprintf / -fls / -fls0).
+
+    def test_write_flag_value_targets_unsafe_outside_allow(self):
+        spec = {"write_flag_value_targets": ["-fprint"]}
+        result = check_unsafe_flags(
+            ["-fprint", "/etc/profile"], spec,
+            safe_write_targets=["/tmp/*", "/dev/null"],
+        )
+        self.assertIsNotNone(result)
+        self.assertIn("-fprint", result)
+        self.assertIn("/etc/profile", result)
+
+    def test_write_flag_value_targets_safe_in_allow(self):
+        spec = {"write_flag_value_targets": ["-fprint"]}
+        self.assertIsNone(check_unsafe_flags(
+            ["-fprint", "/tmp/list.txt"], spec,
+            safe_write_targets=["/tmp/*", "/dev/null"],
+        ))
+
+    def test_write_flag_value_targets_fprintf_first_arg_is_path(self):
+        # -fprintf FILE FORMAT — only the FILE position is the write target.
+        spec = {"write_flag_value_targets": ["-fprintf"]}
+        self.assertIsNotNone(check_unsafe_flags(
+            ["-fprintf", "/etc/passwd", "%p\n"], spec,
+            safe_write_targets=["/tmp/*"],
+        ))
+        self.assertIsNone(check_unsafe_flags(
+            ["-fprintf", "/tmp/out.txt", "%p\n"], spec,
+            safe_write_targets=["/tmp/*"],
+        ))
+
+    def test_write_flag_value_targets_no_value(self):
+        # Flag at end of argv with no following value — no match.
+        spec = {"write_flag_value_targets": ["-fprint"]}
+        self.assertIsNone(check_unsafe_flags(
+            ["-fprint"], spec, safe_write_targets=["/tmp/*"],
+        ))
+
+    def test_write_flag_value_targets_empty_allow_list_blocks_everything(self):
+        # No safe_write_targets configured -> any value is unsafe.
+        spec = {"write_flag_value_targets": ["-fprint"]}
+        self.assertIsNotNone(check_unsafe_flags(
+            ["-fprint", "/tmp/list.txt"], spec, safe_write_targets=[],
+        ))
+        self.assertIsNotNone(check_unsafe_flags(
+            ["-fprint", "/tmp/list.txt"], spec, safe_write_targets=None,
+        ))
+
+    def test_write_flag_value_targets_home_expansion(self):
+        spec = {"write_flag_value_targets": ["-fprint"]}
+        # ~/.cache/* in allow list matches user-supplied ~/.cache/foo.
+        self.assertIsNone(check_unsafe_flags(
+            ["-fprint", "~/.cache/list.txt"], spec,
+            safe_write_targets=["~/.cache/*"],
+        ))
+
+    def test_write_flag_value_targets_inline_equals_form(self):
+        # find doesn't use --flag=value but the parser supports it
+        # uniformly; cover for consistency with other flag families.
+        spec = {"write_flag_value_targets": ["--out"]}
+        self.assertIsNotNone(check_unsafe_flags(
+            ["--out=/etc/profile"], spec, safe_write_targets=["/tmp/*"],
+        ))
+        self.assertIsNone(check_unsafe_flags(
+            ["--out=/tmp/out.txt"], spec, safe_write_targets=["/tmp/*"],
+        ))
+
 
 class TestParseAwsPositionals(unittest.TestCase):
     def test_simple(self):


### PR DESCRIPTION
## Summary

- `find` write-action flags `-fprint FILE`, `-fprintf FILE FORMAT`, `-fls FILE`, `-fls0 FILE` no longer classify `safe` regardless of target.
- New per-command spec field `write_flag_value_targets`: list of flags whose value is a write-target path. The path is checked against the existing top-level `safe_write_targets` allow list — same list `> FILE` redirects use — so writes to `/tmp/*` / `~/.cache/*` / `/dev/null` stay safe, writes to `/etc/profile` etc. flip to `ask`.
- Path expansion and fnmatch semantics mirror `grammar_classifier._target_is_safe_write` so flag-value writes and redirect writes resolve the same way.

## Repro

```
find / -name '*' -fprint /etc/profile     # before: safe   after: ask
find / -fprintf /etc/passwd '%p\n'        # before: safe   after: ask
find / -fls    /var/log/x.log             # before: safe   after: ask
find / -fls0   /tmp/list.bin              # before: safe   after: safe (allowed by /tmp/*)
find / -fprint /tmp/list.txt              # before: safe   after: safe (allowed by /tmp/*)
```

## Test plan

- [x] `python3 -m unittest discover -v tests` — 379 / 379 OK on `feature/issue-27-find-write-flags`.
- [x] New unit coverage in `tests/test_rule_classifier.py::TestCheckUnsafeFlags` (7 cases: outside-allow, in-allow, `-fprintf` first-arg-is-path semantics, no-value, empty / None allow list, `~/` home expansion, inline `--flag=value` form).
- [x] New regression coverage in `tests/test_adversarial_regressions.py::TestIssue27FindWriteFlags` (6 cases covering the four flags through the real `yolt_analyzer.py --hook` path).
- [x] Manual smoke matrix via `grammar_classifier.py` — all 9 cases (4 new flag pairs + bare `find` + `-delete` + `-exec`) classify as expected.

## Out of scope

Issue #27 calls out four more areas worth verifying (`-newerXY`, `-printf` format leaks, GNU `-files0-from -`, BSD/macOS find divergence). None of those write files, so they're left for a follow-up — keeping this PR narrow to the bug actually filed.

Closes #27
