### PR TITLE
Honor explicit Bash allow patterns and surface workflow hints

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,9 +203,9 @@ Add to `~/.claude/settings.json`:
 YOLT reads your `permissions.allow` Bash() entries from
 `~/.claude/settings.json`, the project's `.claude/settings.json`, and
 `.claude/settings.local.json`. After the rule classifier runs on each
-AST `command` node, any node that would otherwise be `unknown` is
-upgraded to `safe` if its reconstructed argv matches one of those
-patterns.
+AST `command` node, any node that would otherwise be `unknown` or
+`unsafe` is upgraded to `safe` if its reconstructed argv matches one
+of those patterns.
 
 This earns its keep on compound forms. The built-in matcher only sees
 the outer wrapper, so a `for ... do CMD; done` whose `CMD` you've
@@ -217,9 +217,15 @@ Two rules apply:
 - The match uses `fnmatch` glob semantics — the same semantics Claude
   Code's outer matcher uses. `Bash(env)` matches `env` exactly;
   `Bash(aws s3 ls*)` matches anything that starts with `aws s3 ls`.
-- A match **never weakens an `unsafe` decision**. If your rules say
-  `aws iam delete-user` is mutating, a permissive `Bash(aws *)` does
-  not turn it into safe — YOLT keeps flagging mutating calls.
+- A match is an explicit user override. Keep patterns narrow:
+  `Bash(aws ecs list-services*)` is fine; `Bash(git *)` or
+  `Bash(gh *)` will allow matching mutating commands anywhere YOLT
+  reconstructs the same argv, including inside compound forms.
+
+For common self-PR workflow writes (`git push`, `git commit`,
+`gh issue create`, `gh pr comment`, ...), YOLT's `ask` message now
+includes a paste-ready `Bash(...)` suggestion when no allow pattern
+matched yet.
 
 ## Dependencies
 

--- a/hooks/grammar_classifier.py
+++ b/hooks/grammar_classifier.py
@@ -368,7 +368,7 @@ class GrammarClassifier:
 
         sub = argv[i]
         if sub in {"add", "commit"}:
-            return "Bash({} {}:*)".format(" ".join(prefix), sub)
+            return "Bash({} {}*)".format(" ".join(prefix), sub)
 
         if sub != "push":
             return None
@@ -402,7 +402,7 @@ class GrammarClassifier:
             "issue": {"create", "comment", "edit"},
         }
         if action in allowed.get(namespace, set()):
-            return "Bash(gh {} {}:*)".format(namespace, action)
+            return "Bash(gh {} {}*)".format(namespace, action)
         return None
 
     @staticmethod

--- a/hooks/grammar_classifier.py
+++ b/hooks/grammar_classifier.py
@@ -84,6 +84,31 @@ class GrammarClassifier:
             return (DECISION_SAFE, "no commands")
         return aggregate_decisions(decisions)
 
+    def suggest_allow_pattern(self, command):
+        """Best-effort `Bash(...)` allow hint for a single primary command.
+
+        This is intentionally narrow and only covers the self-PR workflow
+        write shapes we document today. Compound shells with multiple
+        primary commands return `None` rather than guessing."""
+        if not command or not command.strip():
+            return None
+
+        src = command.encode("utf-8")
+        tree = self._parser.parse(src)
+        root = tree.root_node
+        if root.has_error:
+            return None
+
+        commands = []
+        self._collect_primary_command_nodes(root, commands)
+        if len(commands) != 1:
+            return None
+
+        argv = self._argv_from_command(commands[0], src)
+        if not argv:
+            return None
+        return self._suggest_allow_pattern_from_argv(argv)
+
     # --- AST walker ---
 
     def _walk(self, node, src, decisions, _depth):
@@ -186,6 +211,21 @@ class GrammarClassifier:
             return
         for c in node.children:
             self._collect_substitutions(c, src, decisions, _depth)
+
+    def _collect_primary_command_nodes(self, node, commands):
+        if node.type in ("command_substitution", "process_substitution",
+                         "function_definition"):
+            return
+        if node.type == "redirected_statement":
+            cmd = self._first_child(node, "command")
+            if cmd is not None:
+                commands.append(cmd)
+                return
+        if node.type == "command":
+            commands.append(node)
+            return
+        for c in node.children:
+            self._collect_primary_command_nodes(c, commands)
 
     # --- Argv reconstruction ---
 
@@ -299,12 +339,71 @@ class GrammarClassifier:
 
     def _maybe_allow(self, match_string, result):
         decision, reason = result
-        if decision != DECISION_UNKNOWN:
+        if decision == DECISION_SAFE:
             return result
         match = match_allow_patterns(match_string, self.allow_patterns)
         if match is None:
             return result
         return (DECISION_SAFE, "matches user allow pattern '{}'".format(match))
+
+    @staticmethod
+    def _suggest_allow_pattern_from_argv(argv):
+        cmd_name = os.path.basename(argv[0])
+        if cmd_name == "git":
+            return GrammarClassifier._suggest_git_allow_pattern(argv)
+        if cmd_name == "gh":
+            return GrammarClassifier._suggest_gh_allow_pattern(argv)
+        return None
+
+    @staticmethod
+    def _suggest_git_allow_pattern(argv):
+        prefix = ["git"]
+        i = 1
+        if i + 1 < len(argv) and argv[i] == "-C":
+            prefix.extend(["-C", "*"])
+            i += 2
+
+        if i >= len(argv) or argv[i].startswith("-"):
+            return None
+
+        sub = argv[i]
+        if sub in {"add", "commit"}:
+            return "Bash({} {}:*)".format(" ".join(prefix), sub)
+
+        if sub != "push":
+            return None
+
+        hint = prefix + ["push"]
+        j = i + 1
+        if j < len(argv) and argv[j] == "-u":
+            hint.append("-u")
+            j += 1
+        if j + 1 >= len(argv):
+            return None
+
+        remote = argv[j]
+        branch = argv[j + 1]
+        if remote != "origin":
+            return None
+
+        branch_pat = "feature/*" if branch.startswith("feature/") else branch
+        hint.extend([remote, branch_pat])
+        return "Bash({})".format(" ".join(hint))
+
+    @staticmethod
+    def _suggest_gh_allow_pattern(argv):
+        if len(argv) < 3:
+            return None
+
+        namespace = argv[1]
+        action = argv[2]
+        allowed = {
+            "pr": {"create", "comment", "edit", "merge", "ready"},
+            "issue": {"create", "comment", "edit"},
+        }
+        if action in allowed.get(namespace, set()):
+            return "Bash(gh {} {}:*)".format(namespace, action)
+        return None
 
     @staticmethod
     def _slice(node, src):

--- a/hooks/yolt_analyzer.py
+++ b/hooks/yolt_analyzer.py
@@ -721,6 +721,17 @@ def make_hook_response(decision, reason=None):
     return output
 
 
+def format_unsafe_reason(reason, allow_hint=None):
+    message = "YOLT: Mutating command detected:\n  {}".format(reason)
+    if allow_hint:
+        message += (
+            "\n\nTo skip this prompt in future, add to "
+            "~/.claude/settings.json#permissions.allow:\n"
+            '  "{}"'.format(allow_hint)
+        )
+    return message
+
+
 DEFAULT_LOG_PATH = Path.home() / ".claude" / "yolt.log"
 DEFAULT_LOG_MAX_BYTES = 5 * 1024 * 1024  # 5 MB
 
@@ -898,9 +909,8 @@ def run_hook():
         print(json.dumps(response))
         sys.exit(0)
     if decision == DECISION_UNSAFE:
-        response = make_hook_response(
-            "ask", "YOLT: Mutating command detected:\n  {}".format(reason)
-        )
+        allow_hint = classifier.suggest_allow_pattern(command)
+        response = make_hook_response("ask", format_unsafe_reason(reason, allow_hint))
         print(json.dumps(response))
         sys.exit(0)
     # decision == DECISION_UNKNOWN: let Claude Code handle it

--- a/tests/test_grammar_classifier.py
+++ b/tests/test_grammar_classifier.py
@@ -10,7 +10,7 @@ calls in production. Coverage targets:
   - Quoting: bash `'\\''` close-escape-open idiom, `$'...'` ANSI-C strings,
     concatenated strings.
   - Heredocs (with python body), redirects, process substitution.
-  - User allowlist upgrade (and never-weakens-unsafe invariant).
+  - User allowlist upgrade, including explicit overrides of unsafe atoms.
 
 Runs with stdlib unittest plus tree-sitter / tree-sitter-bash:
 
@@ -751,6 +751,21 @@ class TestClassifierAllowPatterns(unittest.TestCase):
         clf = _make_classifier(allow_patterns=[])
         d, _ = clf.classify("somecommand_unknown")
         self.assertEqual(d, DECISION_UNKNOWN)
+
+    def test_suggested_allow_hints_round_trip(self):
+        cases = [
+            ("git -C /tmp/wt add file.txt", "Bash(git -C * add*)"),
+            (
+                'gh issue create --title "x" --body "y"',
+                "Bash(gh issue create*)",
+            ),
+        ]
+        for command, expected_hint in cases:
+            hint = _make_classifier().suggest_allow_pattern(command)
+            self.assertEqual(hint, expected_hint)
+            inner = hint[len("Bash("):-1]
+            d, _ = _make_classifier(allow_patterns=[inner]).classify(command)
+            self.assertEqual(d, DECISION_SAFE, command)
 
 
 class TestSqlCli(unittest.TestCase):

--- a/tests/test_grammar_classifier.py
+++ b/tests/test_grammar_classifier.py
@@ -707,7 +707,7 @@ class TestSafeWriteTargets(unittest.TestCase):
 
 
 class TestClassifierAllowPatterns(unittest.TestCase):
-    """Allowlist upgrades unknowns to safe but never weakens unsafe."""
+    """Allowlist upgrades unknown and unsafe matches to safe."""
 
     def test_unknown_command_upgraded_to_safe(self):
         clf = _make_classifier(allow_patterns=["mycli *"])
@@ -720,15 +720,15 @@ class TestClassifierAllowPatterns(unittest.TestCase):
         d, _ = clf.classify("aws ec2 weird-op --flag")
         self.assertEqual(d, DECISION_SAFE)
 
-    def test_unsafe_not_weakened_by_allowlist(self):
+    def test_unsafe_overridden_by_allowlist(self):
         clf = _make_classifier(allow_patterns=["aws *"])
         d, _ = clf.classify("aws iam delete-user --user-name foo")
-        self.assertEqual(d, DECISION_UNSAFE)
+        self.assertEqual(d, DECISION_SAFE)
 
-    def test_unsafe_in_compound_not_weakened(self):
+    def test_unsafe_in_compound_overridden(self):
         clf = _make_classifier(allow_patterns=["aws *", "rm *"])
         d, _ = clf.classify("aws s3 ls && rm -rf /etc")
-        self.assertEqual(d, DECISION_UNSAFE)
+        self.assertEqual(d, DECISION_SAFE)
 
     def test_no_allowlist_match_stays_unknown(self):
         clf = _make_classifier(allow_patterns=["aws *"])

--- a/tests/test_yolt_hook.py
+++ b/tests/test_yolt_hook.py
@@ -186,10 +186,29 @@ class TestHookEndToEnd(unittest.TestCase):
         self.assertIn("L2", reason)
         self.assertIn("os.system", reason)
 
+    def test_git_push_reason_includes_allow_hint(self):
+        result = HookSubprocess.run_bash(
+            "git -C /tmp/wt-27 push -u origin feature/issue-27-find-write-flags"
+        )
+        resp = HookSubprocess.response_of(result)
+        self.assertIsNotNone(resp)
+        reason = resp["hookSpecificOutput"]["permissionDecisionReason"]
+        self.assertIn("Bash(git -C * push -u origin feature/*)", reason)
+
+    def test_gh_issue_create_reason_includes_allow_hint(self):
+        result = HookSubprocess.run_bash(
+            'gh issue create --title "x" --body "y"'
+        )
+        resp = HookSubprocess.response_of(result)
+        self.assertIsNotNone(resp)
+        reason = resp["hookSpecificOutput"]["permissionDecisionReason"]
+        self.assertIn("Bash(gh issue create:*)", reason)
+
 
 class TestHookAllowlistDiscovery(unittest.TestCase):
     """The hook reads the user's settings.json `permissions.allow` Bash()
-    entries and uses them as a secondary upgrade pass for unknown atoms.
+    entries and uses them as an explicit override for unknown and unsafe
+    atoms.
     Tests scope the lookup via the `cwd` field in the hook payload so
     they don't depend on the real test runner's home directory."""
 
@@ -227,9 +246,12 @@ class TestHookAllowlistDiscovery(unittest.TestCase):
         self._write_settings(["Bash(yolt_test_othertool *)"])
         self.assertIsNone(self._decision("yolt_test_mycli foo bar"))
 
-    def test_allowlist_does_not_override_unsafe(self):
-        self._write_settings(["Bash(rm *)"])
-        self.assertEqual(self._decision("rm -rf /tmp/foo"), "ask")
+    def test_allowlist_overrides_unsafe(self):
+        self._write_settings(["Bash(git push origin feature/*)"])
+        self.assertEqual(
+            self._decision("git push origin feature/issue-35"),
+            "allow",
+        )
 
 
 class TestBootstrapShell(unittest.TestCase):

--- a/tests/test_yolt_hook.py
+++ b/tests/test_yolt_hook.py
@@ -202,7 +202,7 @@ class TestHookEndToEnd(unittest.TestCase):
         resp = HookSubprocess.response_of(result)
         self.assertIsNotNone(resp)
         reason = resp["hookSpecificOutput"]["permissionDecisionReason"]
-        self.assertIn("Bash(gh issue create:*)", reason)
+        self.assertIn("Bash(gh issue create*)", reason)
 
 
 class TestHookAllowlistDiscovery(unittest.TestCase):


### PR DESCRIPTION
## Summary

- treat `permissions.allow` `Bash(...)` entries as an explicit user override for both `unknown` and `unsafe` command decisions, not just `unknown`
- add paste-ready allow-pattern hints for the common self-PR workflow write shapes that still prompt before a user has any allowlist in place (`git add` / `git commit` / `git push`, `gh pr ...`, `gh issue ...`)
- update the classifier docs and tests to match the new contract

## Why this shape

Issue #35 was updated after filing with the verified root cause: YOLT already loads the user's allow patterns, but `_maybe_allow()` only consults them for `unknown` results. That means documented patterns like `Bash(git -C * add:*)` or `Bash(gh issue create:*)` are ignored for the exact `unsafe` commands the `work-on-pr` loop emits.

This change keeps the default rule tables conservative, but treats an explicit user allowlist as authoritative. The new prompt hint remains useful for first-time users who have not populated that allowlist yet.

## Out of scope

- no change to default `git add` / `git push` safety classification in `rules/shell.json`
- no hardcoded `never_allow_even_if_user_says_so` denylist yet
- no expansion yet for `gh api ...` reply endpoints

## Test plan

- [x] `python3 -m unittest -v tests.test_rule_classifier tests.test_grammar_classifier tests.test_yolt_hook.TestHookEndToEnd tests.test_yolt_hook.TestHookAllowlistDiscovery`
- [ ] `python3 -m unittest tests.test_yolt_hook -v`
  - still hits the pre-existing bootstrap/log harness `import-error` failures in this sandboxed environment; not caused by this patch

Closes #35
