### PR TITLE
chore: add .claudeignore + .claude/settings.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,21 @@
+{
+  "permissions": {
+    "deny": [
+      "Read(node_modules/**)",
+      "Read(.venv/**)",
+      "Read(venv/**)",
+      "Read(build/**)",
+      "Read(target/**)",
+      "Read(dist/**)",
+      "Read(.gradle/**)",
+      "Read(.idea/**)",
+      "Read(**/*.pb.go)",
+      "Read(**/*_pb2.py)",
+      "Read(**/*_pb2_grpc.py)",
+      "Read(**/generated/**)",
+      "Read(**/testdata/**)",
+      "Read(**/fixtures/**)",
+      "Read(**/*.orc)"
+    ]
+  }
+}

--- a/.claudeignore
+++ b/.claudeignore
@@ -1,0 +1,22 @@
+# Dependencies / virtualenvs
+node_modules/
+.venv/
+venv/
+
+# Build artifacts
+build/
+target/
+dist/
+.gradle/
+.idea/
+
+# Generated code
+**/*.pb.go
+**/*_pb2.py
+**/*_pb2_grpc.py
+**/generated/
+
+# Large test fixtures
+**/testdata/
+**/fixtures/
+*.orc


### PR DESCRIPTION
Adds .claudeignore and .claude/settings.json permissions.deny to exclude deps, build artifacts, generated code, and large fixtures from Claude Code Glob/Grep/Read. Closes #102, #90.