### PR TITLE
Extend allow-hint enumeration + dedicated python3 -c parse-bail reason

### DIFF
--- a/hooks/grammar_classifier.py
+++ b/hooks/grammar_classifier.py
@@ -386,7 +386,20 @@ class GrammarClassifier:
         if remote != "origin":
             return None
 
-        branch_pat = "feature/*" if branch.startswith("feature/") else branch
+        # Mapped push (`git push origin <local>:<remote>`) carries the
+        # full `local:remote` refspec in `branch`. Generalize only the
+        # remote side to `feature/*` so the hint covers the branch family,
+        # not a single literal pair. See issue #37.
+        if ":" in branch:
+            local, remote_ref = branch.split(":", 1)
+            if remote_ref.startswith("feature/"):
+                branch_pat = "{}:feature/*".format(local)
+            else:
+                branch_pat = "{}:{}".format(local, remote_ref)
+        elif branch.startswith("feature/"):
+            branch_pat = "feature/*"
+        else:
+            branch_pat = branch
         hint.extend([remote, branch_pat])
         return "Bash({})".format(" ".join(hint))
 
@@ -398,8 +411,9 @@ class GrammarClassifier:
         namespace = argv[1]
         action = argv[2]
         allowed = {
-            "pr": {"create", "comment", "edit", "merge", "ready"},
-            "issue": {"create", "comment", "edit"},
+            "pr": {"create", "comment", "edit", "merge", "ready",
+                   "review", "update-branch"},
+            "issue": {"create", "comment", "edit", "close", "reopen"},
         }
         if action in allowed.get(namespace, set()):
             return "Bash(gh {} {}*)".format(namespace, action)

--- a/hooks/rule_classifier.py
+++ b/hooks/rule_classifier.py
@@ -35,6 +35,17 @@ DECISION_UNKNOWN = "unknown"
 
 SUBSTITUTION_PLACEHOLDER = "__YOLT_SUB__"
 
+# Reason marker for an inline `python3 -c` script the static analyzer could
+# not parse. A parse bail is not evidence of a destructive call, so
+# format_unsafe_reason() (yolt_analyzer) keys on this prefix to render a
+# dedicated message instead of the standard "mutating command" envelope.
+# Only the `-c` path uses it; `python3 file.py` parse errors keep the
+# SyntaxError reason because there the broken file is the real problem.
+# See issue #37.
+UNANALYZABLE_INLINE_PYTHON_PREFIX = (
+    "could not statically analyze inline python3 -c script"
+)
+
 ASSIGNMENT_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
 BASH_PATTERN_RE = re.compile(r"^Bash\((.*)\)$")
 
@@ -695,7 +706,8 @@ class RuleClassifier:
         if inline_code is not None:
             if delegate == "python":
                 return self.classify_python_source(
-                    inline_code, "{} {} ...".format(name, inline_flag)
+                    inline_code, "{} {} ...".format(name, inline_flag),
+                    inline=True,
                 )
             if delegate == "bash":
                 if self.bash_analyzer is None:
@@ -784,13 +796,19 @@ class RuleClassifier:
 
         return (DECISION_UNKNOWN, "{} {}: no rule".format(label, sub))
 
-    def classify_python_source(self, source, description):
+    def classify_python_source(self, source, description, inline=False):
         if self.python_analyzer_factory is None:
             return (DECISION_UNKNOWN, "python analyzer unavailable")
         analyzer = self.python_analyzer_factory()
         result = analyzer.analyze(source)
         if result.get("safe"):
             return (DECISION_SAFE, "python: {}".format(description))
+        if inline and result.get("parse_error"):
+            reason = "{} (parser bailed at line {})".format(
+                UNANALYZABLE_INLINE_PYTHON_PREFIX,
+                result.get("parse_error_lineno", "?"),
+            )
+            return (DECISION_UNSAFE, reason)
         return (DECISION_UNSAFE, "python {}: {}".format(
             description, result.get("reason", "destructive call")
         ))

--- a/hooks/yolt_analyzer.py
+++ b/hooks/yolt_analyzer.py
@@ -691,9 +691,15 @@ class SafetyAnalyzer(ast.NodeVisitor):
         try:
             tree = ast.parse(source)
         except SyntaxError as e:
+            # `parse_error` lets inline `python3 -c` callers tell a parse
+            # bail apart from a real destructive finding (issue #37). The
+            # SyntaxError reason is kept for the `python3 file.py` path,
+            # where a genuine syntax error in the file is the real problem.
             retval = {
                 "safe": False,
                 "reason": "SyntaxError: {}".format(e),
+                "parse_error": True,
+                "parse_error_lineno": e.lineno,
                 "findings": [],
             }
             return retval
@@ -837,7 +843,24 @@ def make_hook_response(decision, reason=None):
 
 
 def format_unsafe_reason(reason, allow_hint=None):
-    message = "YOLT: Mutating command detected:\n  {}".format(reason)
+    from rule_classifier import UNANALYZABLE_INLINE_PYTHON_PREFIX
+
+    # `"; " not in reason` keeps this to single-command reasons. A compound
+    # (aggregate_decisions joins siblings with "; ") falls back to the full
+    # envelope so a destructive sibling's reason is never swallowed.
+    if "; " not in reason and reason.startswith(UNANALYZABLE_INLINE_PYTHON_PREFIX):
+        # Inline `python3 -c` script the analyzer could not parse. Don't
+        # call it "mutating" — it may be valid; YOLT just can't inspect a
+        # one-line multi-statement string. Point the user at a file-based
+        # form the analyzer can read. See issue #37.
+        detail = reason[len(UNANALYZABLE_INLINE_PYTHON_PREFIX):].strip()
+        message = (
+            "YOLT: Could not statically analyze inline python3 -c script\n"
+            "  {}. Write the script to a file under /tmp/\n"
+            "  and run `python3 /tmp/<name>.py` instead.".format(detail)
+        )
+    else:
+        message = "YOLT: Mutating command detected:\n  {}".format(reason)
     if allow_hint:
         message += (
             "\n\nTo skip this prompt in future, add to "


### PR DESCRIPTION
## Summary

Follow-up to #36. Closes the residual allow-hint gaps surfaced while running the `work-on-pr` / `review-pr-loop` skills against a post-#36 yolt build.

### 1. `gh pr review` / `update-branch` / `issue close` / `reopen` enumerated
`_suggest_gh_allow_pattern` now emits a paste-ready hint for these author/reviewer writes (previously a bare ask with no hint). `pr review` is the dominant write in `review-pr-loop`.
- `gh pr review 30 --comment` -> `Bash(gh pr review*)`

### 2. Mapped push hint generalizes only the remote side
`_suggest_git_allow_pattern` for `git push origin <local>:<remote>`:
- before: `Bash(git -C * push origin issue29-fix:feature/issue-29-watch-loop-contract)` (literal one-off pair)
- after: `Bash(git -C * push origin issue29-fix:feature/*)`

Non-`feature/` remotes keep the literal pair.

### 3. Inline `python3 -c` parse bail no longer mislabeled "mutating"
A `-c` script the analyzer cannot parse used to read:
> YOLT: Mutating command detected:
>   python python3 -c ...: SyntaxError: invalid syntax (&lt;unknown&gt;, line 1)

Now:
> YOLT: Could not statically analyze inline python3 -c script
>   (parser bailed at line 1). Write the script to a file under /tmp/
>   and run `python3 /tmp/<name>.py` instead.

Scoped to `-c` only -- `python3 file.py` syntax errors keep the SyntaxError reason (a genuinely broken file is the real problem there). Decision is unchanged (still `ask`); compound reasons fall back to the standard envelope so a destructive sibling is never hidden.

## Implementation
- `SafetyAnalyzer.analyze()` tags parse failures with `parse_error` / `parse_error_lineno`.
- `classify_python_source(..., inline=False)`; the inline `-c` caller passes `inline=True` and emits a shared-constant reason prefix (`UNANALYZABLE_INLINE_PYTHON_PREFIX`).
- `format_unsafe_reason` keys on that prefix (single-command reasons only) to render the dedicated message.

## Testing
- Existing suite: 382/382 pass (`python3 -m unittest discover tests`).
- Note for local runs: the end-to-end hook tests invoke the hook as a subprocess that inherits the real `HOME` and reads `~/.claude/settings.json`. A broad `Bash(python3 *)` allow entry there flips the destructive-python expectations locally (16 failures). Run with a clean `HOME` to reproduce CI:
  `HOME=$(mktemp -d) python3 -m unittest discover tests`
- No new tests added, per the no-tests-unless-requested convention. Happy to add regression cases for the four gaps if you want them in this PR.

Closes #37
