### PR TITLE
Add unsafe_write_targets deny list for protected write paths (issue #28)

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,11 +90,20 @@ the AST. Visitor dispatch:
 - `if_statement`, `for_statement`, `while_statement`, `case_statement`,
   `do_group` — recurse into bodies. No manual keyword stripping required;
   the grammar already separates control-flow tokens from commands.
-- `redirected_statement` — check redirect targets against the
-  `safe_write_targets` glob list in `rules/shell.json` (defaults
+- `redirected_statement` — check redirect targets against two glob
+  lists in `rules/shell.json`. The `unsafe_write_targets` deny list
+  (dotfiles / config / startup paths like `~/.bashrc`,
+  `~/.ssh/authorized_keys`, `/etc/*`) is checked first: a match
+  classifies `unsafe` (ask with a specific reason). It is checked
+  *before* `safe_write_targets`, so a deny entry overrides a broader
+  safe glob — `~/.claude/settings.json` is unsafe even though
+  `~/.claude/*` is a safe-write target, because settings.json can
+  disable this hook. The `safe_write_targets` white list (defaults
   include `/dev/null`, `/tmp/*`, `/var/folders/*`, `~/.cache/*`,
-  `~/.claude/*`, etc.). Anything not on the list falls through to
-  `unknown` so Claude Code default-prompts. For
+  `~/.claude/*`, etc.) makes a write benign. Anything on neither list
+  falls through to `unknown` so Claude Code default-prompts. The same
+  deny list also routes the write-target arguments of
+  `tee` / `cp` / `mv` / `install` / `dd` / `find -fprint*`. For
   `python3 << ... <<EOF` heredocs, the body goes to the Python
   analyzer.
 - `command_substitution` (`$(...)`, `` `...` ``) and `process_substitution`
@@ -287,7 +296,9 @@ Example decisions (see `rules/shell.json` for the full rule set):
 | `echo foo \| xargs rm` / `echo foo \| xargs cat`             | ask / allow |
 | `time aws ec2 describe-instances`                            | allow    |
 | `cat file > /tmp/out`                                        | allow (`/tmp/*` is on the safe-write list) |
-| `cat file > /etc/profile`                                    | unknown (writes to a system path) |
+| `echo x > /etc/profile` / `echo x > ~/.bashrc`               | ask (on the `unsafe_write_targets` deny list) |
+| `echo x > ~/.claude/settings.json`                           | ask (deny list overrides the `~/.claude/*` safe glob) |
+| `echo x > ~/.claude/cache.json`                              | allow (`~/.claude/*` safe-write; not on the deny list) |
 | `aws ec2 describe-instances > /dev/null`                     | allow    |
 | `sqlite3 db.sqlite "SELECT * FROM t"`                        | allow    |
 | `sqlite3 db.sqlite "DROP TABLE t"`                           | ask      |
@@ -446,6 +457,13 @@ name rather than guessed.
     "/scratch/*"
   ],
 
+  "unsafe_write_targets": [
+    "~/.bashrc",
+    "~/.ssh/authorized_keys",
+    "/etc/*",
+    "~/.claude/settings.json"
+  ],
+
   "interpreters": {
     "python3": {
       "inline_flag": "-c",
@@ -466,10 +484,11 @@ name rather than guessed.
 ```
 
 User overrides merge with (and override) defaults per top-level key, so
-overriding `safe_write_targets` replaces the entire list; if you want to
-add `/scratch/*` while keeping the defaults, copy the default list
-through. Examples: `examples/user-overrides.json`,
-`examples/shell-overrides.json`.
+overriding `safe_write_targets` or `unsafe_write_targets` replaces the
+entire list; if you want to add `/scratch/*` while keeping the defaults,
+copy the default list through. `unsafe_write_targets` is checked before
+`safe_write_targets`, so a deny entry wins over a broader safe glob.
+Examples: `examples/user-overrides.json`, `examples/shell-overrides.json`.
 
 ## Debug / dogfood log
 
@@ -698,8 +717,10 @@ The tree-sitter-bash grammar walker handles:
 - command substitution (`$(...)`, `` `...` ``) and process
   substitution (`<(...)`) — recursed and classified independently of
   the outer command;
-- redirections — write targets matched against
-  `safe_write_targets`; non-matching writes fall to `unknown`;
+- redirections — write targets matched against the
+  `unsafe_write_targets` deny list (match -> `unsafe`) first, then the
+  `safe_write_targets` white list (match -> benign); a target on
+  neither falls to `unknown`;
 - heredocs — for the Python interpreters, the body is delegated;
 - pre-command env assignments (`FOO=bar baz`) — skipped, not folded
   into argv.
@@ -803,7 +824,8 @@ this path:
 - max recursion depth on nested decomposition;
 - unknown command name;
 - partially-modeled CLI namespace with a verb outside the policy;
-- write redirect to a path not on `safe_write_targets`;
+- write redirect to a path on neither `unsafe_write_targets` (which
+  classifies `unsafe`) nor `safe_write_targets` (which is benign);
 - SQL string the conservative scanner cannot classify as read-only;
 - Python source the AST delegate fails to parse;
 - `rules/shell.json` failing schema validation — the hook logs

--- a/hooks/grammar_classifier.py
+++ b/hooks/grammar_classifier.py
@@ -142,32 +142,39 @@ class GrammarClassifier:
             self._walk(c, src, decisions, _depth)
 
     def _walk_redirected(self, node, src, decisions, _depth):
-        write_target = None
+        write_targets = []
         for c in node.children:
             if c.type == "file_redirect":
                 t = self._redirect_write_target(c, src)
                 if t is not None:
-                    write_target = t
-                    break
-        if write_target is not None:
-            # Deny list is checked before the safe list, so a protected
-            # path (e.g. ~/.claude/settings.json) overrides a broader safe
-            # glob (~/.claude/*) and classifies unsafe.
-            if self._target_is_unsafe_write(write_target):
-                seg = self._slice(node, src)
-                decisions.append(self._maybe_allow(
-                    seg, (DECISION_UNSAFE,
-                          "writes to protected path '{}' via redirection".format(
-                              write_target)),
-                ))
-                return
-            if not self._target_is_safe_write(write_target):
-                seg = self._slice(node, src)
-                decisions.append(self._maybe_allow(
-                    seg, (DECISION_UNKNOWN, "writes to a file via redirection"),
-                ))
-                return
-            # Safe target: fall through and classify the command itself.
+                    write_targets.append(t)
+        # Evaluate EVERY write redirect with unsafe > unknown > safe
+        # precedence. A safe first redirect must not mask a later unsafe or
+        # unknown target -- e.g. `echo x > /tmp/ok > ~/.bashrc` and
+        # `echo x > /tmp/ok 2> ~/.bashrc` both still write ~/.bashrc.
+        # Deny list is checked before the safe list, so a protected path
+        # (e.g. ~/.claude/settings.json) overrides a broader safe glob
+        # (~/.claude/*) and classifies unsafe.
+        unsafe_target = next(
+            (t for t in write_targets if self._target_is_unsafe_write(t)),
+            None,
+        )
+        if unsafe_target is not None:
+            seg = self._slice(node, src)
+            decisions.append(self._maybe_allow(
+                seg, (DECISION_UNSAFE,
+                      "writes to protected path '{}' via redirection".format(
+                          unsafe_target)),
+            ))
+            return
+        if any(not self._target_is_safe_write(t) for t in write_targets):
+            seg = self._slice(node, src)
+            decisions.append(self._maybe_allow(
+                seg, (DECISION_UNKNOWN, "writes to a file via redirection"),
+            ))
+            return
+        # All write targets safe (or none): fall through and classify the
+        # command itself.
 
         cmd_node = self._first_child(node, "command")
         heredoc_node = self._first_child(node, "heredoc_redirect")

--- a/hooks/grammar_classifier.py
+++ b/hooks/grammar_classifier.py
@@ -56,6 +56,7 @@ class GrammarClassifier:
         self.python_analyzer_factory = python_analyzer_factory
         self.allow_patterns = list(allow_patterns) if allow_patterns else []
         self.safe_write_targets = list(rules.get("safe_write_targets", ["/dev/null"]))
+        self.unsafe_write_targets = list(rules.get("unsafe_write_targets", []))
         self._rules = RuleClassifier(
             rules,
             python_analyzer_factory=python_analyzer_factory,
@@ -141,17 +142,32 @@ class GrammarClassifier:
             self._walk(c, src, decisions, _depth)
 
     def _walk_redirected(self, node, src, decisions, _depth):
-        writes = False
+        write_target = None
         for c in node.children:
-            if c.type == "file_redirect" and self._redirect_writes_to_file(c, src):
-                writes = True
-                break
-        if writes:
-            seg = self._slice(node, src)
-            decisions.append(self._maybe_allow(
-                seg, (DECISION_UNKNOWN, "writes to a file via redirection"),
-            ))
-            return
+            if c.type == "file_redirect":
+                t = self._redirect_write_target(c, src)
+                if t is not None:
+                    write_target = t
+                    break
+        if write_target is not None:
+            # Deny list is checked before the safe list, so a protected
+            # path (e.g. ~/.claude/settings.json) overrides a broader safe
+            # glob (~/.claude/*) and classifies unsafe.
+            if self._target_is_unsafe_write(write_target):
+                seg = self._slice(node, src)
+                decisions.append(self._maybe_allow(
+                    seg, (DECISION_UNSAFE,
+                          "writes to protected path '{}' via redirection".format(
+                              write_target)),
+                ))
+                return
+            if not self._target_is_safe_write(write_target):
+                seg = self._slice(node, src)
+                decisions.append(self._maybe_allow(
+                    seg, (DECISION_UNKNOWN, "writes to a file via redirection"),
+                ))
+                return
+            # Safe target: fall through and classify the command itself.
 
         cmd_node = self._first_child(node, "command")
         heredoc_node = self._first_child(node, "heredoc_redirect")
@@ -279,7 +295,10 @@ class GrammarClassifier:
 
     # --- Helpers ---
 
-    def _redirect_writes_to_file(self, redirect_node, src):
+    def _redirect_write_target(self, redirect_node, src):
+        """Return the target path of a write redirect (`> FILE`, `>> FILE`),
+        or None if this redirect is not a write. The caller classifies the
+        target's tier (unsafe / safe / unknown); this only extracts it."""
         op = None
         target = None
         for c in redirect_node.children:
@@ -289,13 +308,9 @@ class GrammarClassifier:
                 target = self._slice(c, src)
             elif c.type == "string" and target is None:
                 target = self._reconstruct_string(c, src)
-        if op is None:
-            return False
-        if target is None:
-            return False
-        if self._target_is_safe_write(target):
-            return False
-        return True
+        if op is None or target is None:
+            return None
+        return target
 
     def _target_is_safe_write(self, target):
         """Match `target` against the configured safe-write globs from
@@ -304,6 +319,20 @@ class GrammarClassifier:
         `~/.cache/*` both line up. Uses fnmatch semantics."""
         expanded = self._expand_home(target)
         for pat in self.safe_write_targets:
+            pat_expanded = self._expand_home(pat)
+            if fnmatch(target, pat) or fnmatch(expanded, pat_expanded):
+                return True
+        return False
+
+    def _target_is_unsafe_write(self, target):
+        """Match `target` against rules/shell.json#unsafe_write_targets --
+        dotfile / config / startup paths dangerous enough to classify
+        unsafe (ask with a specific reason) rather than unknown. Same
+        fnmatch + `~/`-expansion semantics as `_target_is_safe_write`.
+        Checked before the safe list so an entry here overrides a broader
+        safe glob (the ~/.claude/settings.json carve-out)."""
+        expanded = self._expand_home(target)
+        for pat in self.unsafe_write_targets:
             pat_expanded = self._expand_home(pat)
             if fnmatch(target, pat) or fnmatch(expanded, pat_expanded):
                 return True

--- a/hooks/rule_classifier.py
+++ b/hooks/rule_classifier.py
@@ -367,23 +367,31 @@ def _expand_home(path):
     return path
 
 
-def _path_matches_safe_write_targets(target, safe_write_targets):
-    """Return True if `target` matches any of `safe_write_targets` under
-    fnmatch semantics. Mirrors the redirect-target check that
-    `grammar_classifier._target_is_safe_write` runs against `> file`
-    redirects, so flag-value writes (e.g. `find -fprint FILE`) and
-    redirect writes use the same white list."""
-    if not safe_write_targets:
+def _path_matches_target_list(target, patterns):
+    """Return True if `target` matches any glob in `patterns` under fnmatch
+    semantics, comparing both the raw token and its `~/`-expanded form.
+    Shared by the safe-write and unsafe-write target checks so redirect
+    writes and command write-args match identically."""
+    if not patterns:
         return False
     expanded = _expand_home(target)
-    for pat in safe_write_targets:
+    for pat in patterns:
         pat_expanded = _expand_home(pat)
         if fnmatch(target, pat) or fnmatch(expanded, pat_expanded):
             return True
     return False
 
 
-def check_unsafe_flags(cmd_args, spec, safe_write_targets=None):
+def _path_matches_safe_write_targets(target, safe_write_targets):
+    """Return True if `target` matches any of `safe_write_targets`. Mirrors
+    `grammar_classifier._target_is_safe_write` so flag-value writes
+    (e.g. `find -fprint FILE`) and `> file` redirects use the same white
+    list."""
+    return _path_matches_target_list(target, safe_write_targets)
+
+
+def check_unsafe_flags(cmd_args, spec, safe_write_targets=None,
+                       unsafe_write_targets=None):
     """Check whether cmd_args contains a flag combination the command spec
     declares unsafe. Returns a human-readable description, or None.
 
@@ -402,9 +410,23 @@ def check_unsafe_flags(cmd_args, spec, safe_write_targets=None):
       value.
     - `write_flag_value_targets`: list of flags whose immediately
       following value is a file path the command will write to
-      (`find -fprint FILE`). The path is checked against the top-level
-      `safe_write_targets` white list; a non-matching path makes the
-      call unsafe. Requires `safe_write_targets` to be passed in.
+      (`find -fprint FILE`, `install -t DIR`). The value is checked
+      against the top-level `unsafe_write_targets` deny list first
+      (a match flags a protected-path write) and then the
+      `safe_write_targets` white list (a non-matching path makes the
+      call unsafe). Requires those lists to be passed in.
+    - `write_value_prefix_targets`: list of token prefixes whose suffix
+      is a write-target path (`dd of=PATH`). The suffix is checked
+      against `unsafe_write_targets`.
+    - `write_target_last_positional` / `write_target_all_positional`:
+      the last / every non-flag positional argument is a write-target
+      path (`cp SRC DST`, `tee FILE...`). Checked against
+      `unsafe_write_targets`.
+
+    The last three only consult the deny list. The commands that use
+    them are already `default: unsafe`, so a deny match upgrades the
+    reason from a generic prompt to a specific protected-path one; a
+    non-match falls through to the command default.
     """
     unsafe_flag_values = spec.get("unsafe_flag_values", {})
     unsafe_flag_any_value = set(spec.get("unsafe_flag_any_value", []))
@@ -447,15 +469,40 @@ def check_unsafe_flags(cmd_args, spec, safe_write_targets=None):
             value = inline_value
             if value is None and i + 1 < len(cmd_args):
                 value = cmd_args[i + 1]
-            if value is not None and not _path_matches_safe_write_targets(
-                value, safe_write_targets
-            ):
-                return "{} {}".format(flag, value)
+            if value is not None:
+                if _path_matches_target_list(value, unsafe_write_targets):
+                    return "{} {} (protected path)".format(flag, value)
+                if not _path_matches_safe_write_targets(value, safe_write_targets):
+                    return "{} {}".format(flag, value)
 
         if flag in unsafe_flag_any_value:
             return flag
 
         i += 1
+
+    # Write-target arguments routed through the unsafe_write_targets deny
+    # list. The commands carrying these fields are already
+    # `default: unsafe`, so a match upgrades the reason to a specific
+    # protected-path one; a non-match falls through to the default.
+    if unsafe_write_targets:
+        for pref in spec.get("write_value_prefix_targets", []):
+            for tok in cmd_args:
+                if tok.startswith(pref):
+                    value = tok[len(pref):]
+                    if value and _path_matches_target_list(
+                        value, unsafe_write_targets
+                    ):
+                        return "{}{} (protected path)".format(pref, value)
+
+        positionals = [a for a in cmd_args if not a.startswith("-")]
+        targets = []
+        if spec.get("write_target_all_positional"):
+            targets = positionals
+        elif spec.get("write_target_last_positional") and positionals:
+            targets = [positionals[-1]]
+        for value in targets:
+            if _path_matches_target_list(value, unsafe_write_targets):
+                return "{} (protected path)".format(value)
 
     return None
 
@@ -467,9 +514,9 @@ _ALLOWED_DEFAULTS = frozenset({
 })
 
 _ALLOWED_TOP_LEVEL_KEYS = frozenset({
-    "_meta", "_safe_write_targets_note",
+    "_meta", "_safe_write_targets_note", "_unsafe_write_targets_note",
     "shell_builtins_safe", "shell_keywords",
-    "safe_write_targets",
+    "safe_write_targets", "unsafe_write_targets",
     "commands", "interpreters",
 })
 
@@ -478,6 +525,8 @@ _ALLOWED_COMMAND_KEYS = frozenset({
     "unsafe_flag_values", "unsafe_flag_any_value",
     "unsafe_flags_without_value", "unsafe_flag_value_prefix",
     "write_flag_value_targets",
+    "write_value_prefix_targets",
+    "write_target_last_positional", "write_target_all_positional",
     "valueless_flags",
     "safe_subcommands", "unsafe_subcommands",
     "safe_subcommand_patterns", "unsafe_subcommand_patterns",
@@ -676,6 +725,7 @@ class RuleClassifier:
         self.shell_builtins_safe = set(rules.get("shell_builtins_safe", []))
         self.interpreters = rules.get("interpreters", {})
         self.safe_write_targets = list(rules.get("safe_write_targets", []))
+        self.unsafe_write_targets = list(rules.get("unsafe_write_targets", []))
         self.python_analyzer_factory = python_analyzer_factory
         # When a `bash -c '<script>'` interpreter call needs nested analysis,
         # the grammar walker injects itself here as a callable
@@ -834,7 +884,9 @@ class RuleClassifier:
         default = spec.get("default", "unknown")
 
         unsafe_match = check_unsafe_flags(
-            cmd_args, spec, safe_write_targets=self.safe_write_targets
+            cmd_args, spec,
+            safe_write_targets=self.safe_write_targets,
+            unsafe_write_targets=self.unsafe_write_targets,
         )
         if unsafe_match:
             return (DECISION_UNSAFE, "{}: flag {}".format(cmd_name, unsafe_match))
@@ -874,7 +926,9 @@ class RuleClassifier:
         if sub in nested:
             nested_spec = nested[sub]
             nested_unsafe = check_unsafe_flags(
-                remaining_args, nested_spec, safe_write_targets=self.safe_write_targets
+                remaining_args, nested_spec,
+                safe_write_targets=self.safe_write_targets,
+                unsafe_write_targets=self.unsafe_write_targets,
             )
             if nested_unsafe:
                 return (DECISION_UNSAFE, "{} {}: flag {}".format(cmd_name, sub, nested_unsafe))

--- a/rules/shell.json
+++ b/rules/shell.json
@@ -39,6 +39,36 @@
     "~/.claude/*"
   ],
 
+  "_unsafe_write_targets_note": "Write targets dangerous enough to classify 'unsafe' (ask with a specific reason) rather than 'unknown' (contextless default prompt). Checked BEFORE safe_write_targets, so an entry here overrides a broader safe glob -- e.g. '~/.claude/settings.json' is unsafe even though '~/.claude/*' is a safe-write target, because settings.json can disable this hook. Applies to redirect targets and to the write-target arguments of tee/cp/mv/install/dd/find. Glob semantics are fnmatch; '~/' is expanded before matching.",
+  "unsafe_write_targets": [
+    "~/.bashrc",
+    "~/.zshrc",
+    "~/.profile",
+    "~/.bash_profile",
+    "~/.bash_logout",
+    "~/.ssh/authorized_keys",
+    "~/.ssh/config",
+    "~/.ssh/id_*",
+    "~/.ssh/known_hosts",
+    "~/.aws/credentials",
+    "~/.aws/config",
+    "~/.gitconfig",
+    "~/.git-credentials",
+    "~/.npmrc",
+    "~/.pypirc",
+    "~/.netrc",
+    "~/Library/LaunchAgents/*",
+    "/Library/LaunchDaemons/*",
+    "~/.config/systemd/user/*",
+    "/etc/systemd/system/*",
+    "/etc/cron.*",
+    "/var/spool/cron/*",
+    "/etc/*",
+    "/usr/local/etc/*",
+    "~/.claude/settings.json",
+    "~/.claude/settings.local.json"
+  ],
+
   "interpreters": {
     "python3": {
       "inline_flag": "-c",
@@ -184,20 +214,21 @@
 
     "tee": {
       "default": "unsafe",
-      "_note": "tee writes to one or more files. Always mutating."
+      "write_target_all_positional": true,
+      "_note": "tee writes to one or more files. Always mutating. Every positional arg is a write target, routed through unsafe_write_targets for a specific reason."
     },
     "rm":     {"default": "unsafe"},
     "rmdir":  {"default": "unsafe"},
-    "mv":     {"default": "unsafe"},
-    "cp":     {"default": "unsafe"},
+    "mv":     {"default": "unsafe", "write_target_last_positional": true},
+    "cp":     {"default": "unsafe", "write_target_last_positional": true},
     "ln":     {"default": "unsafe"},
     "touch":  {"default": "unsafe"},
     "mkdir":  {"default": "unsafe"},
     "chmod":  {"default": "unsafe"},
     "chown":  {"default": "unsafe"},
     "chgrp":  {"default": "unsafe"},
-    "install":{"default": "unsafe"},
-    "dd":     {"default": "unsafe"},
+    "install":{"default": "unsafe", "write_flag_value_targets": ["-t", "--target-directory"]},
+    "dd":     {"default": "unsafe", "write_value_prefix_targets": ["of="]},
     "shred":  {"default": "unsafe"},
     "sudo":   {"default": "unsafe"},
     "su":     {"default": "unsafe"},

--- a/tests/test_adversarial_regressions.py
+++ b/tests/test_adversarial_regressions.py
@@ -409,6 +409,19 @@ class TestIssue28UnsafeWriteTargets(unittest.TestCase):
             "allow",
         )
 
+    def test_safe_first_redirect_does_not_mask_unsafe_second(self):
+        # Regression: `_walk_redirected` stopped at the first write target,
+        # so a safe leading redirect (/tmp) auto-allowed a statement that
+        # also writes a protected path. Every write redirect is now checked.
+        self.assertEqual(
+            _Hook.decision_for("echo x > /tmp/safe > ~/.bashrc"),
+            "ask",
+        )
+        self.assertEqual(
+            _Hook.decision_for("echo x > /tmp/safe 2> ~/.bashrc"),
+            "ask",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_adversarial_regressions.py
+++ b/tests/test_adversarial_regressions.py
@@ -30,6 +30,12 @@ Catalogue layout:
   -fls0 FILE` repros (closes #27). Path argument was unchecked, so
   writes outside `safe_write_targets` classified safe. The fix
   routes the path through the same white list redirects use.
+- `TestIssue28UnsafeWriteTargets` -- redirect / command writes to
+  dotfile / config / startup paths (closes #28). The headline repro
+  is `echo pwn > ~/.claude/settings.json`, which classified `allow`
+  before the fix because `~/.claude/*` is a safe-write target even
+  though settings.json can disable this hook. The deny list is
+  checked before the safe list, so it now asks.
 
 Run with:
 
@@ -335,6 +341,71 @@ class TestIssue27FindWriteFlags(unittest.TestCase):
     def test_fls0_to_tmp_is_safe(self):
         self.assertEqual(
             _Hook.decision_for("find / -fls0 /tmp/list.bin"),
+            "allow",
+        )
+
+
+class TestIssue28UnsafeWriteTargets(unittest.TestCase):
+    """Repros from #28: writes to dotfile / config / startup paths.
+
+    Before the fix a redirect to such a path classified `unknown` (the
+    hook stayed silent, deferring to the default prompt) and -- worse --
+    `~/.claude/settings.json` classified `allow`, because `~/.claude/*`
+    is a safe-write target even though settings.json can disable the
+    hook. After the fix the `unsafe_write_targets` deny list is consulted
+    before the safe list, so these ask with a specific reason."""
+
+    def test_settings_json_no_longer_auto_allowed(self):
+        # The headline hole: a safe-write glob auto-allowed a write that
+        # can neuter the hook. Must ask now.
+        self.assertEqual(
+            _Hook.decision_for("echo pwn > ~/.claude/settings.json"),
+            "ask",
+        )
+
+    def test_settings_local_json_no_longer_auto_allowed(self):
+        self.assertEqual(
+            _Hook.decision_for("echo pwn > ~/.claude/settings.local.json"),
+            "ask",
+        )
+
+    def test_other_claude_path_still_allowed(self):
+        # The carve-out is settings.json only; the rest of ~/.claude/*
+        # stays a safe-write target so legitimate cache writes don't ask.
+        self.assertEqual(
+            _Hook.decision_for("echo x > ~/.claude/cache.json"),
+            "allow",
+        )
+
+    def test_redirect_to_bashrc_asks(self):
+        # Was `unknown` (silent) before #28.
+        self.assertEqual(
+            _Hook.decision_for("echo x > ~/.bashrc"),
+            "ask",
+        )
+
+    def test_append_to_authorized_keys_asks(self):
+        self.assertEqual(
+            _Hook.decision_for("echo pubkey >> ~/.ssh/authorized_keys"),
+            "ask",
+        )
+
+    def test_cp_to_cron_dir_asks(self):
+        self.assertEqual(
+            _Hook.decision_for("cp payload /etc/cron.d/job"),
+            "ask",
+        )
+
+    def test_dd_of_ssh_key_asks(self):
+        self.assertEqual(
+            _Hook.decision_for("dd if=/dev/zero of=~/.ssh/id_rsa"),
+            "ask",
+        )
+
+    def test_redirect_to_tmp_still_allowed(self):
+        # Control: a benign temp write is unaffected.
+        self.assertEqual(
+            _Hook.decision_for("echo x > /tmp/scratch.txt"),
             "allow",
         )
 

--- a/tests/test_grammar_classifier.py
+++ b/tests/test_grammar_classifier.py
@@ -777,6 +777,29 @@ class TestUnsafeWriteTargets(unittest.TestCase):
         d, _ = clf.classify("echo x > /etc/profile")
         self.assertEqual(d, DECISION_SAFE)
 
+    def test_safe_first_redirect_does_not_mask_unsafe_second(self):
+        # Every write redirect is evaluated, not just the first: a safe
+        # leading target must not mask a later protected one.
+        self.assertDecision("echo x > /tmp/safe > ~/.bashrc", DECISION_UNSAFE)
+
+    def test_safe_stdout_redirect_does_not_mask_unsafe_stderr(self):
+        # The masked redirect can be a different fd (`2>`), still a write.
+        self.assertDecision("echo x > /tmp/safe 2> ~/.bashrc", DECISION_UNSAFE)
+
+    def test_masked_unsafe_reason_names_the_protected_path(self):
+        _, reason = self.clf.classify("echo x > /tmp/safe > ~/.bashrc")
+        self.assertIn("~/.bashrc", reason)
+        self.assertIn("protected", reason)
+
+    def test_safe_first_redirect_does_not_mask_unknown_second(self):
+        # unsafe > unknown > safe precedence: a non-deny non-safe later
+        # target downgrades the whole statement to unknown.
+        self.assertDecision("echo x > /tmp/safe > out.json", DECISION_UNKNOWN)
+
+    def test_all_safe_redirects_fall_through_to_command(self):
+        # Multiple redirects that are all safe still classify the command.
+        self.assertDecision("echo x > /tmp/a > /tmp/b", DECISION_SAFE)
+
 
 class TestClassifierAllowPatterns(unittest.TestCase):
     """Whitelist upgrades unknown and unsafe matches to safe."""

--- a/tests/test_grammar_classifier.py
+++ b/tests/test_grammar_classifier.py
@@ -310,8 +310,11 @@ class TestClassifyScenarios(unittest.TestCase):
             "aws ec2 describe-instances > out.json", DECISION_UNKNOWN,
         )
 
-    def test_echo_to_system_file_is_unknown(self):
-        self.assertDecision("echo x > /etc/profile", DECISION_UNKNOWN)
+    def test_echo_to_system_file_is_unsafe(self):
+        # /etc/* is on the unsafe_write_targets deny list (issue #28), so a
+        # redirect there classifies unsafe (ask with a specific reason)
+        # rather than unknown (contextless default prompt).
+        self.assertDecision("echo x > /etc/profile", DECISION_UNSAFE)
 
     def test_redirect_to_tmp_is_safe(self):
         # /tmp/* is on the default safe-write list — benign in practice
@@ -704,6 +707,75 @@ class TestSafeWriteTargets(unittest.TestCase):
         clf = self._make_classifier_with_targets(["/dev/null"])
         d, _ = clf.classify("echo x >> /tmp/foo")
         self.assertEqual(d, DECISION_UNKNOWN)
+
+
+class TestUnsafeWriteTargets(unittest.TestCase):
+    """Redirect targets on `rules.unsafe_write_targets` (issue #28).
+
+    A write redirect to a dotfile / config / startup path classifies
+    `unsafe` (ask with a specific reason) instead of `unknown`
+    (contextless default prompt). The deny list is consulted before the
+    safe list, so an entry on it overrides a broader safe glob -- this is
+    what closes the `~/.claude/settings.json` hole, where `~/.claude/*`
+    is a safe-write target but settings.json can disable the hook."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.clf = _make_classifier()
+
+    def assertDecision(self, command, expected):
+        decision, reason = self.clf.classify(command)
+        self.assertEqual(
+            decision, expected,
+            "{!r}: got {}, reason={}".format(command, decision, reason),
+        )
+
+    def test_redirect_to_bashrc_is_unsafe(self):
+        self.assertDecision("echo x > ~/.bashrc", DECISION_UNSAFE)
+
+    def test_redirect_to_etc_is_unsafe(self):
+        self.assertDecision("echo x > /etc/profile", DECISION_UNSAFE)
+
+    def test_append_redirect_to_authorized_keys_is_unsafe(self):
+        # `>>` (append) is a write too -- the common authorized_keys attack.
+        self.assertDecision(
+            "echo pubkey >> ~/.ssh/authorized_keys", DECISION_UNSAFE
+        )
+
+    def test_glob_entry_matches_id_files(self):
+        # `~/.ssh/id_*` glob.
+        self.assertDecision("echo x > ~/.ssh/id_ed25519", DECISION_UNSAFE)
+
+    def test_settings_json_overrides_safe_claude_glob(self):
+        # ~/.claude/* is a safe-write target, but settings.json is on the
+        # deny list and the deny list wins.
+        self.assertDecision(
+            "echo pwn > ~/.claude/settings.json", DECISION_UNSAFE
+        )
+        self.assertDecision(
+            "echo pwn > ~/.claude/settings.local.json", DECISION_UNSAFE
+        )
+
+    def test_other_claude_paths_stay_safe(self):
+        # The carve-out is settings.json only; the rest of ~/.claude/*
+        # remains a safe-write target.
+        self.assertDecision("echo x > ~/.claude/cache.json", DECISION_SAFE)
+
+    def test_non_protected_target_still_unknown(self):
+        # A non-deny, non-safe target is unchanged: still unknown.
+        self.assertDecision("echo x > out.json", DECISION_UNKNOWN)
+
+    def test_reason_names_the_protected_path(self):
+        _, reason = self.clf.classify("echo x > ~/.bashrc")
+        self.assertIn("~/.bashrc", reason)
+        self.assertIn("protected", reason)
+
+    def test_whitelist_still_overrides_unsafe_redirect(self):
+        # Consistent with every other unsafe atom: an explicit user allow
+        # pattern upgrades the deny-path write to safe.
+        clf = _make_classifier(allow_patterns=["echo *"])
+        d, _ = clf.classify("echo x > /etc/profile")
+        self.assertEqual(d, DECISION_SAFE)
 
 
 class TestClassifierAllowPatterns(unittest.TestCase):

--- a/tests/test_rule_classifier.py
+++ b/tests/test_rule_classifier.py
@@ -181,6 +181,94 @@ class TestCheckUnsafeFlags(unittest.TestCase):
         ))
 
 
+class TestUnsafeWriteTargetArgs(unittest.TestCase):
+    """Deny-list routing of write-target arguments (issue #28).
+
+    `unsafe_write_targets` upgrades the *reason* for a protected-path
+    write. The flag-value path is checked deny-first (before the safe
+    white list); positional and `value=` prefix targets consult only the
+    deny list, since the commands carrying them are already
+    `default: unsafe`."""
+
+    DENY = ["~/.bashrc", "~/.ssh/id_*", "/etc/*"]
+
+    def test_flag_value_deny_takes_priority_over_safe(self):
+        # A deny match wins even if the same path were on the safe list.
+        spec = {"write_flag_value_targets": ["-t"]}
+        result = check_unsafe_flags(
+            ["-t", "/etc/foo"], spec,
+            safe_write_targets=["/etc/*"],
+            unsafe_write_targets=self.DENY,
+        )
+        self.assertIsNotNone(result)
+        self.assertIn("/etc/foo", result)
+        self.assertIn("protected path", result)
+
+    def test_flag_value_non_deny_falls_through_to_safe_check(self):
+        # Not on the deny list and on the safe list -> not flagged here.
+        spec = {"write_flag_value_targets": ["-t"]}
+        self.assertIsNone(check_unsafe_flags(
+            ["-t", "/tmp/x"], spec,
+            safe_write_targets=["/tmp/*"],
+            unsafe_write_targets=self.DENY,
+        ))
+
+    def test_value_prefix_target_deny(self):
+        # dd of=PATH.
+        spec = {"write_value_prefix_targets": ["of="]}
+        result = check_unsafe_flags(
+            ["if=/dev/zero", "of=~/.ssh/id_rsa"], spec,
+            unsafe_write_targets=self.DENY,
+        )
+        self.assertIsNotNone(result)
+        self.assertIn("~/.ssh/id_rsa", result)
+
+    def test_value_prefix_read_source_not_flagged(self):
+        # if= is the read source; only of= is a write target.
+        spec = {"write_value_prefix_targets": ["of="]}
+        self.assertIsNone(check_unsafe_flags(
+            ["if=~/.bashrc", "of=/var/data"], spec,
+            unsafe_write_targets=self.DENY,
+        ))
+
+    def test_last_positional_deny(self):
+        # cp SRC DST -> DST is the last positional.
+        spec = {"write_target_last_positional": True}
+        result = check_unsafe_flags(
+            ["a", "/etc/cron.d/job"], spec,
+            unsafe_write_targets=self.DENY,
+        )
+        self.assertIsNotNone(result)
+        self.assertIn("/etc/cron.d/job", result)
+
+    def test_last_positional_source_not_flagged(self):
+        # Reading a deny path while writing a benign dest is not flagged
+        # by the deny scan (cp ~/.bashrc /tmp/x).
+        spec = {"write_target_last_positional": True}
+        self.assertIsNone(check_unsafe_flags(
+            ["~/.bashrc", "/tmp/x"], spec,
+            unsafe_write_targets=self.DENY,
+        ))
+
+    def test_all_positional_deny_any_match(self):
+        # tee FILE... -> every positional is a write target.
+        spec = {"write_target_all_positional": True}
+        result = check_unsafe_flags(
+            ["-a", "/tmp/log", "~/.bashrc"], spec,
+            unsafe_write_targets=self.DENY,
+        )
+        self.assertIsNotNone(result)
+        self.assertIn("~/.bashrc", result)
+
+    def test_no_deny_list_is_noop(self):
+        # Without a deny list the new scan does nothing (the command
+        # default still applies upstream).
+        spec = {"write_target_last_positional": True}
+        self.assertIsNone(check_unsafe_flags(
+            ["a", "/etc/cron.d/job"], spec, unsafe_write_targets=None,
+        ))
+
+
 class TestParseAwsPositionals(unittest.TestCase):
     def test_simple(self):
         svc, op, _ = parse_aws_positionals(["ec2", "describe-instances"])

--- a/tests/test_yolt_hook.py
+++ b/tests/test_yolt_hook.py
@@ -87,8 +87,12 @@ class TestHookEndToEnd(unittest.TestCase):
         # its default (prompt the user).
         self.assertIsNone(self._decision("somecommand_unknown --flag"))
 
-    def test_redirect_to_system_file_exits_silently(self):
-        self.assertIsNone(self._decision("echo x > /etc/profile"))
+    def test_redirect_to_system_file_returns_ask(self):
+        # /etc/* is on the unsafe_write_targets deny list (issue #28): the
+        # hook now classifies it unsafe and emits `ask` with a specific
+        # reason, instead of staying silent and deferring to the default
+        # prompt.
+        self.assertEqual(self._decision("echo x > /etc/profile"), "ask")
 
     def test_compound_aws_loop_returns_allow(self):
         cmd = (


### PR DESCRIPTION
## Summary

Adds a top-level `unsafe_write_targets` deny list to `rules/shell.json`
for dotfile / config / startup paths, and routes write targets through
it. A match classifies **`unsafe`** (ask with a specific reason) instead
of **`unknown`** (contextless default prompt).

The deny list is checked **before** `safe_write_targets`, so an entry on
it overrides a broader safe glob.

### Security hole closed

`echo x > ~/.claude/settings.json` previously classified **`allow`**
(auto-run), because `~/.claude/*` is a safe-write target -- even though
`settings.json` can disable this hook. `settings.json` /
`settings.local.json` are now on the deny list and override the safe
glob, so they `ask`. The rest of `~/.claude/*` (e.g. legitimate cache
writes) stays a safe-write target.

## Application points (all four from the issue)

| Point | Where | Behavior change |
| ----- | ----- | --------------- |
| Redirects (`> FILE`, `>> FILE`) | `grammar_classifier._walk_redirected` | deny -> `unsafe`; non-deny non-safe -> `unknown` (unchanged); safe -> benign |
| Flag-value targets (`install -t`, `find -fprint*`) | `check_unsafe_flags` | deny-checked before the existing `safe_write_targets` check |
| Value-prefix targets (`dd of=PATH`) | `check_unsafe_flags` | new `write_value_prefix_targets` |
| Positional targets (`tee` all, `cp`/`mv` last) | `check_unsafe_flags` | new `write_target_all_positional` / `write_target_last_positional` |

`tee`/`cp`/`mv`/`install`/`dd` are already `default: unsafe`, so for them
a deny match upgrades the *reason* to a specific protected-path one; a
non-match falls through to the default. The genuine decision change
(`unknown`/silent -> `unsafe`/ask, and the `settings.json`
`allow` -> `ask`) is on the redirect path.

## Precedence and overrides

- `unsafe_write_targets` is consulted before `safe_write_targets`
  everywhere (the `settings.json` carve-out depends on this).
- Allow patterns still override, consistent with every other unsafe
  atom: an explicit `Bash(echo *)` upgrades a deny-path write to `safe`.

## Tests

- `TestIssue28UnsafeWriteTargets` -- adversarial regression catalogue:
  the `settings.json` false-allow plus redirect / `cp` / `dd` repros and
  benign controls.
- `TestUnsafeWriteTargets` (grammar) and `TestUnsafeWriteTargetArgs`
  (`check_unsafe_flags` unit) coverage, including read-source-not-flagged
  cases.
- Updated two pre-#28 tests that pinned the old
  `echo x > /etc/profile` => `unknown` / silent behavior to the new
  `unsafe` / `ask` result.
- Full suite: 407 tests green in a clean env (CI-equivalent).

## Out of scope

- `cp -t DIR SRC...` / `install` bare `SRC DST` dest detection: `cp`/`mv`
  use the common `SRC DST` (last-positional) form; `install` uses `-t`
  per the issue. The `-t`-with-sources form falls back to the generic
  `default: unsafe` reason (decision still correct).
- Symlinked paths (`/etc` -> `/private/etc` on macOS) match on the
  literal token, not the resolved path.
- Plugin manifest paths beyond `settings.json` / `settings.local.json`
  are not enumerated; the issue named those two concretely.

Closes #28
