### PR TITLE
Self-improvement review loop mining YOLT friction (#44)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
   - [Python rules — `~/.claude/yolt/rules.json`](#python-rules---claudeyoltrulesjson)
   - [Shell rules — `~/.claude/yolt/shell.json`](#shell-rules---claudeyoltshelljson)
 - [Debug / dogfood log](#debug--dogfood-log)
+- [Self-improvement loop](#self-improvement-loop)
 - [CLI usage](#cli-usage)
 - [Tests and demo](#tests-and-demo)
 - [Analysis boundaries](#analysis-boundaries)
@@ -502,6 +503,105 @@ YOLT rotates the log when it grows past 5 MB by renaming it to
 `<log>.old`, clobbering any previous `.old`. One generation is
 preserved. `YOLT_LOG_MAX_BYTES` overrides the threshold; set
 `YOLT_LOG_MAX_BYTES=0` to disable rotation.
+
+## Self-improvement loop
+
+The dogfood log is also a record of where YOLT got in your way. The
+reviewer (`hooks/yolt_review.py`, issue
+[#44](https://github.com/voitta-ai/voitta-yolt/issues/44)) mines that log
+for recurring friction and distills it into a human-reviewable doc plus a
+suggestion state file under `~/.claude/yolt/`:
+
+- `~/.claude/yolt/review.md` — the doc you read.
+- `~/.claude/yolt/suggestions.json` — suggestion ids with
+  pending / applied / dismissed status that survives regeneration.
+
+Repeated commands are grouped to a conservative prefix (argv head plus
+subcommand tokens — no flags, no values, no paths) and sorted into three
+buckets:
+
+- **`friction-unsafe`** — YOLT returned `ask` on this prefix repeatedly.
+- **`friction-unknown`** — the command fell through to Claude Code's
+  default prompt repeatedly (a rules gap, or a personal/internal CLI).
+- **`fastpath`** — YOLT auto-allowed this prefix at high frequency; a
+  static `permissions.allow` glob would skip the hook startup entirely
+  (a static allow rule
+  [bypasses PreToolUse hooks](#install) natively).
+
+Grouping is stdlib-only and deliberately does not depend on tree-sitter,
+so the reviewer still works when the grammar deps failed to bootstrap.
+Compound commands (pipes, substitutions, loops) are counted but never
+turned into suggestions — a prefix glob cannot express them; rules and
+user overrides handle those (issue
+[#45](https://github.com/voitta-ai/voitta-yolt/issues/45)).
+
+### Did you approve, or did YOLT?
+
+A second log, `~/.claude/yolt-ran.log`, is written by a PostToolUse hook:
+one record per Bash command that actually ran. A command that YOLT said
+`ask` on only reaches PostToolUse if you approved it at the prompt (a
+denied command never runs). The reviewer correlates the two logs by
+timestamp, so each `friction-unsafe` suggestion carries an `approved`
+count — high `approved` is real friction worth acting on; `approved` 0
+means YOLT is very likely doing its job. Override with `YOLT_RAN_LOG_FILE`
+(absolute path) or opt out with `YOLT_RAN_LOG_FILE=""`.
+
+### Routing — and the collision veto
+
+Each suggestion routes to exactly one of three remediations:
+
+- **`settings.json` allow** — for a prefix that is read-only regardless
+  of flags. Fastest, but a static allow rule bypasses YOLT's hook
+  entirely (including its redirect and command-substitution checks).
+- **Local override** — a `~/.claude/yolt/shell.json` rule for anything
+  flag-conditional or verb-class, keeping the AST walk in the loop
+  (generating these directly is issue
+  [#45](https://github.com/voitta-ai/voitta-yolt/issues/45)).
+- **Upstream issue** — a common CLI repeatedly hitting `unknown` is
+  likely a rules gap worth reporting on voitta-ai/voitta-yolt.
+
+The safety-critical part is the **glob-collision veto**: a `fastpath`
+prefix like `gh api` is read-only, but `gh api -X POST` is not, and both
+match `Bash(gh api*)`. Promoting that glob to `permissions.allow` would
+silently bypass YOLT for the POST too. Before recommending any
+`settings.json` glob, the reviewer fnmatches it against every command
+YOLT did *not* classify safe; any hit is recorded as a collision and the
+suggestion is re-routed to a `shell.json` rule instead, never the
+allowlist. Partially-overlapping namespaces stay suggestable —
+`gh pr view*` does not collide with `gh pr merge`.
+
+Only the redacted `shape` field (argv head plus flag names, every value
+stripped to `<...>`) may leave the machine in an upstream issue. The
+`examples` lines are raw log data and stay local.
+
+### Surfacing and applying
+
+- **`/yolt:review`** — the slash command that walks you through pending
+  suggestions, honors the routing above, edits `settings.json` /
+  `shell.json` with your confirmation, and records each as applied or
+  dismissed.
+- **SessionStart** prints a one-line nudge toward `/yolt:review` when
+  there are pending suggestions, throttled to once per 24h. It reads only
+  the small state file — it never parses the decision log.
+- **SessionEnd** regenerates the doc with `--generate --if-stale`: a
+  no-op (just an mtime check) when the log has not changed since the last
+  run, so quiet sessions cost almost nothing.
+
+Run it by hand the same way the hooks do:
+
+```bash
+python3 hooks/yolt_review.py --generate   # parse logs, write doc + state
+python3 hooks/yolt_review.py --status     # {"pending": N, ...}
+python3 hooks/yolt_review.py --list       # full suggestion JSON
+python3 hooks/yolt_review.py --applied <id> [<id> ...]
+python3 hooks/yolt_review.py --dismiss <id> [<id> ...]
+```
+
+Override the state directory with `YOLT_STATE_DIR`. The reviewer is
+read-mostly: it only ever writes its own files under `~/.claude/yolt/`;
+all edits to `settings.json` and override files go through you. A Codex
+CLI parity loop is tracked in issue
+[#46](https://github.com/voitta-ai/voitta-yolt/issues/46).
 
 ## CLI usage
 

--- a/commands/review.md
+++ b/commands/review.md
@@ -1,0 +1,98 @@
+---
+description: Triage YOLT friction into settings.json allowlist entries, local rule overrides, or upstream issues
+---
+
+# /yolt:review
+
+Walk the user through the YOLT self-improvement review (issue #44): turn
+recurring Bash friction (commands YOLT repeatedly prompted on, or
+repeatedly auto-allowed at the cost of hook startup) into concrete
+remediations.
+
+The generator (`hooks/yolt_review.py`) does the parsing and bookkeeping;
+your job is to present its output, get the user's decisions, and apply
+them. Do NOT re-derive suggestions by reading the raw log yourself.
+
+## Steps
+
+1. **Regenerate and load state.** Run, from the plugin's hooks dir:
+
+   ```bash
+   python3 "${CLAUDE_PLUGIN_ROOT}/hooks/yolt_review.py" --generate
+   python3 "${CLAUDE_PLUGIN_ROOT}/hooks/yolt_review.py" --list
+   ```
+
+   `--list` prints the full suggestion JSON. Work from that, not the
+   markdown doc. If there are zero pending suggestions, tell the user and
+   stop.
+
+2. **Present pending suggestions, grouped by bucket**, in this order:
+   - `fastpath` — already auto-allowed; an allowlist entry only saves
+     hook startup.
+   - `friction-unsafe` — YOLT prompted (`ask`). Sort the user's attention
+     by `approved` (how many times they approved at the prompt anyway):
+     high `approved` = real friction; `approved` 0 = YOLT very likely
+     doing its job, lean toward dismiss.
+   - `friction-unknown` — fell through to Claude Code's default prompt.
+
+   For each, show `prefix`, `fires`, `approved` (friction buckets), and
+   the recommended destination.
+
+3. **Honor the routing — this is the safety-critical part:**
+   - A suggestion with a non-empty `glob_collisions` list MUST NOT be
+     written to `settings.json`. Its `Bash(prefix*)` glob would also
+     match a known non-safe command (shown in `glob_collisions`), which
+     would silently bypass YOLT for that command. Route it to a
+     `~/.claude/yolt/shell.json` rule instead (issue #45) and say why.
+   - A `fastpath` suggestion with no collisions → offer to add
+     `settings_pattern` to `permissions.allow` in
+     `~/.claude/settings.json`.
+   - A friction suggestion with no collisions that the user confirms is
+     read-only regardless of flags → same settings.json route.
+   - A friction suggestion that is flag-conditional or verb-class → a
+     `~/.claude/yolt/shell.json` / `rules.json` override (issue #45).
+   - `upstream_candidate: true` → offer to file an issue on
+     voitta-ai/voitta-yolt.
+
+4. **Apply what the user accepts.**
+   - settings.json: read `~/.claude/settings.json`, add the pattern to
+     `permissions.allow` (create the array if absent), write it back.
+     Confirm the exact diff with the user before writing.
+   - Local override: edit `~/.claude/yolt/shell.json` per the README's
+     "Shell rules" schema. (Direct generation of these is tracked in
+     issue #45; for now, hand-write the minimal fragment.)
+   - After each accepted suggestion is applied, record it:
+
+     ```bash
+     python3 "${CLAUDE_PLUGIN_ROOT}/hooks/yolt_review.py" --applied <id> [<id> ...]
+     ```
+
+   - For suggestions the user rejects:
+
+     ```bash
+     python3 "${CLAUDE_PLUGIN_ROOT}/hooks/yolt_review.py" --dismiss <id> [<id> ...]
+     ```
+
+5. **Upstream issues (only on explicit confirmation).** For
+   `upstream_candidate` suggestions the user wants to report:
+   - Use ONLY the redacted `shape` field and flag names — never the raw
+     `examples`, which contain real paths / account ids / possibly
+     secrets. State this to the user.
+   - Draft the issue title and body, show it, and create it only after
+     the user approves:
+
+     ```bash
+     gh issue create --repo voitta-ai/voitta-yolt --title "..." --body-file <tmpfile>
+     ```
+
+6. **Summarize**: what was added to settings.json, what overrides were
+   written, what was dismissed, what was filed upstream.
+
+## Notes
+
+- A static allow rule in `settings.json` bypasses YOLT's PreToolUse hook
+  entirely (including its redirect and command-substitution checks), so
+  keep every pattern narrow. This is exactly why collisions are vetoed.
+- The reviewer is read-mostly: it only writes its own state files under
+  `~/.claude/yolt/`. All edits to `settings.json` and override files go
+  through you, with the user's confirmation.

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -10,6 +10,37 @@
           }
         ]
       }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/post-tool-use.sh"
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/session-start.sh"
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/session-end.sh"
+          }
+        ]
+      }
     ]
   }
 }

--- a/hooks/post-tool-use.sh
+++ b/hooks/post-tool-use.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# YOLT (You Only Live Twice) - PostToolUse hook for Claude Code.
+#
+# Records that a Bash command actually executed, to ~/.claude/yolt-ran.log.
+# Paired with the PreToolUse decision log (~/.claude/yolt.log), this lets
+# the self-improvement reviewer (hooks/yolt_review.py, issue #44) tell
+# "YOLT prompted and the user approved anyway" (friction worth an
+# allowlist/rule) apart from "YOLT prompted and the user declined"
+# (working as intended): a command that was denied at the prompt never
+# reaches PostToolUse, so its absence here is the signal.
+#
+# Unlike the PreToolUse hook this needs no grammar deps, so it skips the
+# bootstrap entirely and just appends a JSON line. Best-effort: any
+# failure exits silently so PostToolUse never breaks the session.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+exec python3 "$SCRIPT_DIR/yolt_analyzer.py" --ran-hook

--- a/hooks/session-end.sh
+++ b/hooks/session-end.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# YOLT (You Only Live Twice) - SessionEnd hook for Claude Code.
+#
+# Regenerates the self-improvement review doc + suggestion state from the
+# session's accumulated decision log (hooks/yolt_review.py, issue #44).
+# Guarded by --if-stale: if the decision log has not changed since the
+# last generation, this is a no-op and no Python parse happens beyond the
+# mtime check, so quiet sessions cost almost nothing.
+#
+# SessionEnd output is ignored by Claude Code; this runs purely for its
+# side effect. Best-effort: any failure exits silently.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+exec python3 "$SCRIPT_DIR/yolt_review.py" --generate --if-stale --quiet

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# YOLT (You Only Live Twice) - SessionStart hook for Claude Code.
+#
+# Reads the suggestion state written by hooks/yolt_review.py (issue #44)
+# and, when there are pending suggestions that have not been surfaced in
+# the last NUDGE_INTERVAL_HOURS, prints a one-line additionalContext
+# nudge pointing the user at /yolt:review. Silent otherwise.
+#
+# Deliberately cheap: it only reads the small state JSON, never parses
+# the decision log (that happens at SessionEnd). Needs no grammar deps.
+# Best-effort: any failure exits silently so SessionStart never breaks.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+exec python3 "$SCRIPT_DIR/yolt_review.py" --nudge

--- a/hooks/yolt_analyzer.py
+++ b/hooks/yolt_analyzer.py
@@ -848,6 +848,7 @@ def format_unsafe_reason(reason, allow_hint=None):
 
 
 DEFAULT_LOG_PATH = Path.home() / ".claude" / "yolt.log"
+DEFAULT_RAN_LOG_PATH = Path.home() / ".claude" / "yolt-ran.log"
 DEFAULT_LOG_MAX_BYTES = 5 * 1024 * 1024  # 5 MB
 
 
@@ -935,6 +936,74 @@ def _log_hook_decision(command, decision, reason):
             f.write(json.dumps(record) + "\n")
     except OSError:
         pass
+
+
+def _resolve_ran_log_path():
+    """Resolve the ran-record log destination.
+
+    - `YOLT_RAN_LOG_FILE` unset -> default to ~/.claude/yolt-ran.log.
+    - `YOLT_RAN_LOG_FILE` set to an empty string -> opt out, no logging.
+    - Otherwise -> the path the user specified.
+
+    The ran log is written by the PostToolUse hook and records which
+    commands actually executed. A ran-record for a command YOLT decided
+    `ask`/`unknown` on means the user approved it at the prompt (a denied
+    command never reaches PostToolUse), which is the signal the
+    self-improvement reviewer (yolt_review.py, issue #44) uses to rank
+    friction.
+    """
+    env_value = os.environ.get("YOLT_RAN_LOG_FILE")
+    if env_value is None:
+        return DEFAULT_RAN_LOG_PATH
+    if env_value == "":
+        return None
+    return Path(env_value)
+
+
+def _log_ran_command(command):
+    """Append a JSON-line ran-record to the resolved ran-log path. Shares
+    the size-based rotation and failure-swallowing conventions of
+    `_log_hook_decision`. The command is truncated to 500 chars.
+    """
+    log_path = _resolve_ran_log_path()
+    if log_path is None:
+        return
+    try:
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        _maybe_rotate_log(log_path, _resolve_log_max_bytes())
+        record = {
+            "ts": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+            "command": command[:500] if command else "",
+        }
+        with open(log_path, "a") as f:
+            f.write(json.dumps(record) + "\n")
+    except OSError:
+        pass
+
+
+def run_ran_hook():
+    """Run as a Claude Code PostToolUse hook.
+
+    Records that a Bash command actually executed. Combined with the
+    PreToolUse decision log, this lets yolt_review.py tell "YOLT prompted
+    and the user approved anyway" (a friction candidate) apart from "YOLT
+    prompted and the user declined" (working as intended). Needs no
+    grammar deps, so the PostToolUse wrapper skips the bootstrap.
+
+    Exits silently on any malformed input; PostToolUse must never break
+    the session.
+    """
+    try:
+        hook_input = json.load(sys.stdin)
+    except (json.JSONDecodeError, EOFError):
+        sys.exit(0)
+    if hook_input.get("tool_name", "") != "Bash":
+        sys.exit(0)
+    command = hook_input.get("tool_input", {}).get("command", "")
+    if not command.strip():
+        sys.exit(0)
+    _log_ran_command(command)
+    sys.exit(0)
 
 
 def run_hook():
@@ -1035,11 +1104,16 @@ def run_hook():
 def run_cli():
     """Run as a CLI tool for direct analysis."""
     if len(sys.argv) < 2:
-        print("Usage: yolt_analyzer.py [--hook | <script.py>]", file=sys.stderr)
+        print("Usage: yolt_analyzer.py [--hook | --ran-hook | <script.py>]",
+              file=sys.stderr)
         sys.exit(1)
 
     if sys.argv[1] == "--hook":
         run_hook()
+        return
+
+    if sys.argv[1] == "--ran-hook":
+        run_ran_hook()
         return
 
     script_path = sys.argv[1]

--- a/hooks/yolt_review.py
+++ b/hooks/yolt_review.py
@@ -1,0 +1,823 @@
+#!/usr/bin/env python3
+"""YOLT self-improvement reviewer (issue #44).
+
+Mines the YOLT decision log (`~/.claude/yolt.log`) and the ran-record log
+(`~/.claude/yolt-ran.log`, written by the PostToolUse hook) for recurring
+friction and wasted hook startups, then writes a human-reviewable markdown
+doc plus a machine-readable suggestion state file:
+
+- `~/.claude/yolt/review.md` -- the doc the user reads/edits.
+- `~/.claude/yolt/suggestions.json` -- suggestion ids with
+  pending/applied/dismissed status that survives regeneration.
+
+Buckets:
+
+- ``friction-unsafe`` -- YOLT said `ask` repeatedly; a ran-record after the
+  decision means the user approved at the prompt.
+- ``friction-unknown`` -- YOLT fell through to Claude Code's default prompt
+  repeatedly (rules gap or personal CLI).
+- ``fastpath`` -- YOLT auto-allowed at high frequency; a `settings.json`
+  allow glob would bypass the hook startup entirely (a static allow rule
+  bypasses PreToolUse hooks natively).
+
+Grouping is a conservative token heuristic (no tree-sitter dependency, so
+the reviewer works even where the grammar deps failed to bootstrap).
+Compound commands (pipes, substitutions, loops) are counted but not turned
+into suggestions -- prefix globs cannot express them; rules / user
+overrides handle those (see issue #45).
+
+Stdlib only. Subcommands:
+
+    --generate [--quiet]   parse logs, merge state, write doc + state
+    --status               print {"pending": N, ...} JSON
+    --nudge                SessionStart helper: emit additionalContext JSON
+                           when pending > 0, throttled to once per
+                           NUDGE_INTERVAL_HOURS
+    --list                 dump the full suggestion state JSON
+    --applied ID [ID ...]  mark suggestions applied
+    --dismiss ID [ID ...]  mark suggestions dismissed
+"""
+
+import argparse
+import datetime
+import hashlib
+import json
+import os
+import re
+import shlex
+import sys
+from fnmatch import fnmatch
+from pathlib import Path
+
+DEFAULT_LOG_PATH = Path.home() / ".claude" / "yolt.log"
+DEFAULT_RAN_LOG_PATH = Path.home() / ".claude" / "yolt-ran.log"
+DEFAULT_STATE_DIR = Path.home() / ".claude" / "yolt"
+
+DOC_NAME = "review.md"
+STATE_NAME = "suggestions.json"
+STATE_VERSION = 1
+
+MIN_FIRES_FRICTION = 3
+MIN_FIRES_FASTPATH = 10
+MAX_GROUP_DEPTH = 3
+MAX_EXAMPLES = 3
+MAX_EXAMPLE_CHARS = 200
+MAX_PER_BUCKET = 20
+NUDGE_INTERVAL_HOURS = 24
+RAN_MATCH_SKEW_SECONDS = 5
+
+KIND_UNSAFE = "friction-unsafe"
+KIND_UNKNOWN = "friction-unknown"
+KIND_FASTPATH = "fastpath"
+
+# Order matters for the doc.
+KINDS = [KIND_UNSAFE, KIND_UNKNOWN, KIND_FASTPATH]
+
+KIND_TITLES = {
+    KIND_UNSAFE: "Friction: YOLT prompted (`ask`)",
+    KIND_UNKNOWN: "Friction: unknown (Claude Code default prompt)",
+    KIND_FASTPATH: "Fast-path candidates (safe, high-frequency)",
+}
+
+# Shell metacharacters that mark a command as compound / not expressible
+# as a prefix glob. Conservative: any hit disqualifies the command from
+# suggestion grouping.
+COMPOUND_RE = re.compile(r"[|;&<>`$\n]")
+SUBCOMMAND_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+ENV_ASSIGN_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
+
+# CLIs common enough that a repeated `unknown` on them suggests a rules
+# gap worth an upstream issue on voitta-ai/voitta-yolt (as opposed to a
+# personal/internal tool, which only warrants a local setting/override).
+UPSTREAM_CLIS = {
+    "aws", "az", "bazel", "brew", "cargo", "docker", "gcloud", "gh",
+    "git", "go", "gradle", "helm", "kubectl", "mvn", "npm", "terraform",
+}
+
+
+def resolve_log_path(cli_value):
+    """Decision log path: --log flag > YOLT_LOG_FILE > default.
+    Empty string means logging is opted out."""
+    retval = None
+    if cli_value:
+        retval = Path(cli_value)
+    else:
+        env_value = os.environ.get("YOLT_LOG_FILE")
+        if env_value is None:
+            retval = DEFAULT_LOG_PATH
+        elif env_value == "":
+            retval = None
+        else:
+            retval = Path(env_value)
+    return retval
+
+
+def resolve_ran_log_path(cli_value):
+    """Ran log path: --ran-log flag > YOLT_RAN_LOG_FILE > default.
+    Empty string means ran-capture is opted out."""
+    retval = None
+    if cli_value:
+        retval = Path(cli_value)
+    else:
+        env_value = os.environ.get("YOLT_RAN_LOG_FILE")
+        if env_value is None:
+            retval = DEFAULT_RAN_LOG_PATH
+        elif env_value == "":
+            retval = None
+        else:
+            retval = Path(env_value)
+    return retval
+
+
+def resolve_state_dir(cli_value):
+    """State dir: --state-dir flag > YOLT_STATE_DIR > ~/.claude/yolt."""
+    retval = None
+    if cli_value:
+        retval = Path(cli_value)
+    else:
+        env_value = os.environ.get("YOLT_STATE_DIR")
+        if env_value:
+            retval = Path(env_value)
+        else:
+            retval = DEFAULT_STATE_DIR
+    return retval
+
+
+def read_jsonl(path):
+    """Read a JSONL file plus its rotated `.old` generation. Returns a
+    list of dict records; malformed lines and missing files are skipped."""
+    retval = []
+    if path is None:
+        return retval
+    candidates = [path.with_suffix(path.suffix + ".old"), path]
+    for candidate in candidates:
+        try:
+            with open(candidate, "r") as f:
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        record = json.loads(line)
+                    except ValueError:
+                        continue
+                    if isinstance(record, dict):
+                        retval.append(record)
+        except OSError:
+            continue
+    return retval
+
+
+def parse_ts(value):
+    """Parse an ISO timestamp; None when missing/unparseable."""
+    retval = None
+    if isinstance(value, str) and value:
+        try:
+            retval = datetime.datetime.fromisoformat(value)
+        except ValueError:
+            retval = None
+    return retval
+
+
+def is_compound(command):
+    """True when the command contains shell metacharacters that a prefix
+    glob cannot express (pipes, lists, redirects, substitutions, ...)."""
+    retval = bool(COMPOUND_RE.search(command))
+    return retval
+
+
+def split_tokens(command):
+    """Tokenize a simple command. shlex first; on unbalanced quoting fall
+    back to whitespace split. Leading env assignments are dropped, same
+    as the grammar walker does."""
+    try:
+        tokens = shlex.split(command)
+    except ValueError:
+        tokens = command.split()
+    while tokens and ENV_ASSIGN_RE.match(tokens[0]):
+        tokens = tokens[1:]
+    retval = tokens
+    return retval
+
+
+def group_key(command):
+    """Conservative grouping prefix: argv[0] plus subcommand-looking
+    tokens (lowercase/alnum/dash, no slash) up to MAX_GROUP_DEPTH deep,
+    stopping at the first flag or value-looking token. None for compound
+    or empty commands."""
+    retval = None
+    if not is_compound(command):
+        tokens = split_tokens(command)
+        if tokens:
+            parts = [tokens[0]]
+            for token in tokens[1:]:
+                if len(parts) >= MAX_GROUP_DEPTH:
+                    break
+                if token.startswith("-"):
+                    break
+                if "/" in token:
+                    break
+                if not SUBCOMMAND_RE.match(token):
+                    break
+                parts.append(token)
+            retval = " ".join(parts)
+    return retval
+
+
+def redact_command(command):
+    """Reduce a command to its shape: argv head + subcommand tokens +
+    flag names; every value token becomes `<...>`. This is the only form
+    that may leave the machine (upstream issue drafts) -- raw log lines
+    carry real paths / account ids / occasionally secrets."""
+    retval = "(compound command)"
+    if not is_compound(command):
+        tokens = split_tokens(command)
+        if tokens:
+            parts = []
+            in_subcommand_run = True
+            depth = 0
+            for index, token in enumerate(tokens):
+                if index == 0:
+                    parts.append(token)
+                    depth = 1
+                    continue
+                if token.startswith("-"):
+                    in_subcommand_run = False
+                    if "=" in token:
+                        flag_name = token.split("=", 1)[0]
+                        parts.append(flag_name + "=<...>")
+                    else:
+                        parts.append(token)
+                    continue
+                if (
+                    in_subcommand_run
+                    and depth < MAX_GROUP_DEPTH
+                    and "/" not in token
+                    and SUBCOMMAND_RE.match(token)
+                ):
+                    parts.append(token)
+                    depth += 1
+                    continue
+                in_subcommand_run = False
+                parts.append("<...>")
+            retval = " ".join(parts)
+    return retval
+
+
+def suggestion_id(kind, prefix):
+    """Stable id so applied/dismissed status survives regeneration."""
+    digest = hashlib.sha256("{}|{}".format(kind, prefix).encode("utf-8"))
+    retval = digest.hexdigest()[:12]
+    return retval
+
+
+def build_ran_index(ran_records):
+    """Map truncated command string -> sorted list of ran timestamps."""
+    retval = {}
+    for record in ran_records:
+        command = record.get("command")
+        ts = parse_ts(record.get("ts"))
+        if not command or ts is None:
+            continue
+        retval.setdefault(command, []).append(ts)
+    for timestamps in retval.values():
+        timestamps.sort()
+    return retval
+
+
+def was_approved(record_ts, command, ran_index):
+    """A ran-record at/after the decision timestamp means the user said
+    yes at the prompt (a denied command never reaches PostToolUse)."""
+    retval = False
+    timestamps = ran_index.get(command)
+    if timestamps and record_ts is not None:
+        skew = datetime.timedelta(seconds=RAN_MATCH_SKEW_SECONDS)
+        cutoff = record_ts - skew
+        for ts in timestamps:
+            # Compare only tz-aware with tz-aware; log writers always
+            # stamp UTC, but guard against hand-edited lines.
+            if (ts.tzinfo is None) != (cutoff.tzinfo is None):
+                continue
+            if ts >= cutoff:
+                retval = True
+                break
+    return retval
+
+
+def annotate_glob_collisions(suggestion, nonsafe_commands):
+    """Record any known-unsafe/unknown command that the suggestion's
+    `Bash(prefix*)` glob would ALSO match.
+
+    This is the safety gate for fast-path suggestions: `gh api` is
+    read-only but `gh api -X POST` is not, and both match `gh api*`.
+    Promoting that glob to `permissions.allow` would bypass YOLT for the
+    POST too (a static allow rule bypasses PreToolUse hooks entirely).
+    Matching uses fnmatch against the real glob, so the warning reflects
+    exactly what Claude Code's matcher would allow. `gh pr view*` does
+    NOT collide with `gh pr merge`, so partially-overlapping namespaces
+    stay suggestable."""
+    pattern = suggestion["prefix"] + "*"
+    collisions = []
+    for command in nonsafe_commands:
+        if fnmatch(command, pattern):
+            collisions.append(command[:MAX_EXAMPLE_CHARS])
+            if len(collisions) >= MAX_EXAMPLES:
+                break
+    suggestion["glob_collisions"] = collisions
+    return suggestion
+
+
+def build_groups(records, ran_index, min_fires, min_fires_safe):
+    """Aggregate log records into suggestion groups. Returns
+    (suggestions, stats)."""
+    decision_to_kind = {
+        "unsafe": KIND_UNSAFE,
+        "unknown": KIND_UNKNOWN,
+        "safe": KIND_FASTPATH,
+    }
+    groups = {}
+    # Every distinct command YOLT did NOT classify safe. Used to veto
+    # fast-path settings.json globs that would also cover a known-unsafe
+    # command (see annotate_glob_collisions): suggesting `Bash(gh api*)`
+    # when `gh api -X POST` is in this set would silently defeat YOLT.
+    nonsafe_commands = set()
+    stats = {
+        "records": len(records),
+        "compound_friction": 0,
+        "broken_install": 0,
+        "first_ts": None,
+        "last_ts": None,
+    }
+    for record in records:
+        decision = record.get("decision")
+        command = record.get("command") or ""
+        ts = parse_ts(record.get("ts"))
+        if ts is not None:
+            if stats["first_ts"] is None or ts < stats["first_ts"]:
+                stats["first_ts"] = ts
+            if stats["last_ts"] is None or ts > stats["last_ts"]:
+                stats["last_ts"] = ts
+        if decision in ("import-error", "rules-validation-error"):
+            stats["broken_install"] += 1
+            continue
+        kind = decision_to_kind.get(decision)
+        if kind is None or not command.strip():
+            continue
+        if kind in (KIND_UNSAFE, KIND_UNKNOWN):
+            nonsafe_commands.add(command.strip())
+        prefix = group_key(command)
+        if prefix is None:
+            if kind in (KIND_UNSAFE, KIND_UNKNOWN):
+                stats["compound_friction"] += 1
+            continue
+        key = (kind, prefix)
+        group = groups.get(key)
+        if group is None:
+            group = {
+                "kind": kind,
+                "prefix": prefix,
+                "fires": 0,
+                "approved": 0,
+                "first_ts": None,
+                "last_ts": None,
+                "examples": [],
+                "reasons": {},
+            }
+            groups[key] = group
+        group["fires"] += 1
+        if ts is not None:
+            if group["first_ts"] is None or ts < group["first_ts"]:
+                group["first_ts"] = ts
+            if group["last_ts"] is None or ts > group["last_ts"]:
+                group["last_ts"] = ts
+        reason = record.get("reason") or ""
+        if reason:
+            group["reasons"][reason] = group["reasons"].get(reason, 0) + 1
+        if kind in (KIND_UNSAFE, KIND_UNKNOWN):
+            if was_approved(ts, command, ran_index):
+                group["approved"] += 1
+        example = command[:MAX_EXAMPLE_CHARS]
+        if example not in group["examples"] and len(group["examples"]) < MAX_EXAMPLES:
+            group["examples"].append(example)
+
+    suggestions = []
+    for (kind, prefix), group in groups.items():
+        threshold = min_fires_safe if kind == KIND_FASTPATH else min_fires
+        if group["fires"] < threshold:
+            continue
+        top_reason = ""
+        if group["reasons"]:
+            top_reason = max(group["reasons"].items(), key=lambda kv: kv[1])[0]
+        argv0 = prefix.split(" ", 1)[0]
+        upstream = bool(kind == KIND_UNKNOWN and argv0 in UPSTREAM_CLIS)
+        suggestion = {
+            "id": suggestion_id(kind, prefix),
+            "kind": kind,
+            "prefix": prefix,
+            "fires": group["fires"],
+            "approved": group["approved"],
+            "first_ts": group["first_ts"].isoformat() if group["first_ts"] else None,
+            "last_ts": group["last_ts"].isoformat() if group["last_ts"] else None,
+            "settings_pattern": "Bash({}*)".format(prefix),
+            "upstream_candidate": upstream,
+            "top_reason": top_reason,
+            "shape": redact_command(group["examples"][0]) if group["examples"] else prefix,
+            "examples": group["examples"],
+            "glob_collisions": [],
+            "status": "pending",
+        }
+        annotate_glob_collisions(suggestion, nonsafe_commands)
+        suggestions.append(suggestion)
+
+    suggestions.sort(key=lambda s: (KINDS.index(s["kind"]), -s["fires"], s["prefix"]))
+
+    # Cap per bucket so the doc stays reviewable.
+    capped = []
+    bucket_counts = {}
+    dropped = 0
+    for suggestion in suggestions:
+        count = bucket_counts.get(suggestion["kind"], 0)
+        if count >= MAX_PER_BUCKET:
+            dropped += 1
+            continue
+        bucket_counts[suggestion["kind"]] = count + 1
+        capped.append(suggestion)
+    stats["dropped_over_cap"] = dropped
+    retval = (capped, stats)
+    return retval
+
+
+def load_state(state_path):
+    """Load suggestions.json; empty scaffold when missing/corrupt."""
+    retval = {
+        "version": STATE_VERSION,
+        "generated": None,
+        "last_nudged": None,
+        "stats": {},
+        "suggestions": [],
+    }
+    try:
+        with open(state_path, "r") as f:
+            data = json.load(f)
+        if isinstance(data, dict) and isinstance(data.get("suggestions"), list):
+            retval = data
+    except (OSError, ValueError):
+        pass
+    return retval
+
+
+def save_state(state_path, state):
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(state_path, "w") as f:
+        json.dump(state, f, indent=2)
+        f.write("\n")
+
+
+def merge_state(old_state, new_suggestions, stats):
+    """Recompute counts but preserve applied/dismissed status by id.
+    Suggestions that no longer regenerate (rules updated, log rotated
+    out) are dropped."""
+    old_status = {}
+    for suggestion in old_state.get("suggestions", []):
+        sid = suggestion.get("id")
+        status = suggestion.get("status")
+        if sid and status in ("applied", "dismissed"):
+            old_status[sid] = status
+    for suggestion in new_suggestions:
+        preserved = old_status.get(suggestion["id"])
+        if preserved:
+            suggestion["status"] = preserved
+    json_stats = dict(stats)
+    for key in ("first_ts", "last_ts"):
+        if isinstance(json_stats.get(key), datetime.datetime):
+            json_stats[key] = json_stats[key].isoformat()
+    retval = {
+        "version": STATE_VERSION,
+        "generated": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+        "last_nudged": old_state.get("last_nudged"),
+        "stats": json_stats,
+        "suggestions": new_suggestions,
+    }
+    return retval
+
+
+def render_doc(state, log_path, ran_log_path):
+    """Render the human-reviewable markdown doc."""
+    lines = []
+    stats = state.get("stats", {})
+    lines.append("# YOLT review")
+    lines.append("")
+    lines.append(
+        "Generated {} from `{}` ({} records{}) and `{}`."
+        .format(
+            state.get("generated", "?"),
+            log_path,
+            stats.get("records", 0),
+            ", since {}".format(stats["first_ts"]) if stats.get("first_ts") else "",
+            ran_log_path if ran_log_path else "(ran-capture opted out)",
+        )
+    )
+    lines.append("")
+    lines.append(
+        "Apply / dismiss via `/yolt:review`, or by hand: add the pattern to"
+        " `permissions.allow` in `~/.claude/settings.json`, then"
+        " `python3 hooks/yolt_review.py --applied <id>`."
+    )
+    lines.append("")
+    lines.append(
+        "> Privacy: `Examples` lines are raw log data and stay local."
+        " Only the redacted `Shape` line may be used in upstream issues."
+    )
+
+    pending = [s for s in state.get("suggestions", []) if s.get("status") == "pending"]
+    handled = [s for s in state.get("suggestions", []) if s.get("status") != "pending"]
+
+    for kind in KINDS:
+        bucket = [s for s in pending if s.get("kind") == kind]
+        if not bucket:
+            continue
+        lines.append("")
+        lines.append("## {}".format(KIND_TITLES[kind]))
+        for suggestion in bucket:
+            lines.append("")
+            approved_part = ""
+            if kind != KIND_FASTPATH:
+                approved_part = ", {} approved at the prompt".format(
+                    suggestion.get("approved", 0))
+            lines.append("### `{}` — {} fires{} (id: `{}`)".format(
+                suggestion["prefix"], suggestion["fires"], approved_part,
+                suggestion["id"]))
+            lines.append("")
+            if suggestion.get("top_reason"):
+                lines.append("- Reason: {}".format(suggestion["top_reason"]))
+            collisions = suggestion.get("glob_collisions") or []
+            if kind == KIND_FASTPATH:
+                if collisions:
+                    lines.append(
+                        "- DO NOT allowlist `\"{}\"` — that glob would also"
+                        " match these known non-safe commands, silently"
+                        " bypassing YOLT for them:".format(
+                            suggestion["settings_pattern"]))
+                    for collision in collisions:
+                        lines.append("  - Would also allow: `{}`".format(collision))
+                    lines.append(
+                        "  Route this to a `~/.claude/yolt/shell.json` rule"
+                        " instead (issue #45), which keeps the AST walk in"
+                        " the loop.")
+                else:
+                    lines.append(
+                        "- Already auto-allowed by YOLT; `\"{}\"` in"
+                        " `permissions.allow` skips the hook startup entirely"
+                        " (static allows bypass PreToolUse hooks).".format(
+                            suggestion["settings_pattern"]))
+            else:
+                if collisions:
+                    lines.append(
+                        "- DO NOT allowlist `\"{}\"` — that glob would also"
+                        " match known non-safe commands (e.g. `{}`); use a"
+                        " `~/.claude/yolt/shell.json` rule (issue #45).".format(
+                            suggestion["settings_pattern"], collisions[0]))
+                else:
+                    lines.append(
+                        "- settings.json route: `\"{}\"` — only if this command"
+                        " is read-only regardless of flags; a static allow"
+                        " bypasses YOLT's redirect/substitution checks.".format(
+                            suggestion["settings_pattern"]))
+                    lines.append(
+                        "- Override route: `~/.claude/yolt/shell.json` /"
+                        " `rules.json` for flag-conditional or verb-class rules"
+                        " (issue #45).")
+            if suggestion.get("upstream_candidate"):
+                lines.append(
+                    "- Upstream candidate: common CLI fell through to"
+                    " `unknown` — likely a rules gap worth an issue on"
+                    " voitta-ai/voitta-yolt (redacted shape only).")
+            lines.append("- Shape: `{}`".format(suggestion["shape"]))
+            for example in suggestion.get("examples", []):
+                lines.append("  - Example: `{}`".format(example))
+
+    if not pending:
+        lines.append("")
+        lines.append("No pending suggestions.")
+
+    if handled:
+        lines.append("")
+        lines.append("## Previously handled")
+        lines.append("")
+        for suggestion in handled:
+            lines.append("- `{}` ({}) — {} (id: `{}`)".format(
+                suggestion["prefix"], suggestion["kind"],
+                suggestion["status"], suggestion["id"]))
+
+    skipped_parts = []
+    if stats.get("compound_friction"):
+        skipped_parts.append(
+            "{} compound friction commands (prefix globs cannot express"
+            " these; rules / user overrides handle them — issue #45)"
+            .format(stats["compound_friction"]))
+    if stats.get("broken_install"):
+        skipped_parts.append(
+            "{} import-error / rules-validation-error records".format(
+                stats["broken_install"]))
+    if stats.get("dropped_over_cap"):
+        skipped_parts.append(
+            "{} suggestions over the per-bucket cap of {}".format(
+                stats["dropped_over_cap"], MAX_PER_BUCKET))
+    if skipped_parts:
+        lines.append("")
+        lines.append("## Not shown")
+        lines.append("")
+        for part in skipped_parts:
+            lines.append("- {}".format(part))
+
+    lines.append("")
+    retval = "\n".join(lines)
+    return retval
+
+
+def _log_is_stale(log_path, state_path):
+    """True when the doc should be regenerated: the decision log is newer
+    than the last state write, or no state exists yet. Used by
+    --if-stale (SessionEnd) to make the common no-change case a no-op
+    rather than re-parsing the whole log. Errs on the side of
+    regenerating (returns True) when an mtime cannot be read."""
+    retval = True
+    try:
+        state_mtime = state_path.stat().st_mtime
+    except OSError:
+        return retval
+    newest = 0.0
+    found = False
+    for candidate in (log_path, log_path.with_suffix(log_path.suffix + ".old")):
+        try:
+            mtime = candidate.stat().st_mtime
+        except OSError:
+            continue
+        found = True
+        if mtime > newest:
+            newest = mtime
+    if found:
+        retval = newest > state_mtime
+    return retval
+
+
+def cmd_generate(args):
+    log_path = resolve_log_path(args.log)
+    ran_log_path = resolve_ran_log_path(args.ran_log)
+    state_dir = resolve_state_dir(args.state_dir)
+    if log_path is None:
+        if not args.quiet:
+            print("yolt-review: decision logging is opted out; nothing to do")
+        return 0
+    if args.if_stale and not _log_is_stale(log_path, state_dir / STATE_NAME):
+        if not args.quiet:
+            print("yolt-review: log unchanged since last run; skipping")
+        return 0
+    records = read_jsonl(log_path)
+    if not records:
+        if not args.quiet:
+            print("yolt-review: no log records at {}".format(log_path))
+        return 0
+    ran_index = build_ran_index(read_jsonl(ran_log_path))
+    suggestions, stats = build_groups(
+        records, ran_index, args.min_fires, args.min_fires_safe)
+    state_path = state_dir / STATE_NAME
+    state = merge_state(load_state(state_path), suggestions, stats)
+    save_state(state_path, state)
+    doc_path = state_dir / DOC_NAME
+    doc = render_doc(state, log_path, ran_log_path)
+    with open(doc_path, "w") as f:
+        f.write(doc)
+    if not args.quiet:
+        pending = len([s for s in state["suggestions"] if s["status"] == "pending"])
+        print("yolt-review: {} pending suggestion(s); doc: {}".format(
+            pending, doc_path))
+    return 0
+
+
+def cmd_status(args):
+    state_dir = resolve_state_dir(args.state_dir)
+    state = load_state(state_dir / STATE_NAME)
+    pending = len([s for s in state.get("suggestions", [])
+                   if s.get("status") == "pending"])
+    print(json.dumps({
+        "pending": pending,
+        "generated": state.get("generated"),
+        "last_nudged": state.get("last_nudged"),
+        "doc": str(state_dir / DOC_NAME),
+    }))
+    return 0
+
+
+def cmd_nudge(args):
+    """SessionStart helper. Prints additionalContext JSON when there are
+    pending suggestions and the user has not been nudged within
+    NUDGE_INTERVAL_HOURS; silent otherwise."""
+    state_dir = resolve_state_dir(args.state_dir)
+    state_path = state_dir / STATE_NAME
+    state = load_state(state_path)
+    pending = len([s for s in state.get("suggestions", [])
+                   if s.get("status") == "pending"])
+    if pending == 0:
+        return 0
+    now = datetime.datetime.now(datetime.timezone.utc)
+    last_nudged = parse_ts(state.get("last_nudged"))
+    if last_nudged is not None and last_nudged.tzinfo is not None:
+        age = now - last_nudged
+        if age < datetime.timedelta(hours=NUDGE_INTERVAL_HOURS):
+            return 0
+    message = (
+        "YOLT has {} pending allowlist/rule suggestion(s) distilled from"
+        " your recent Bash friction - run /yolt:review to triage them"
+        " (doc: {})."
+    ).format(pending, state_dir / DOC_NAME)
+    print(json.dumps({
+        "hookSpecificOutput": {
+            "hookEventName": "SessionStart",
+            "additionalContext": message,
+        }
+    }))
+    state["last_nudged"] = now.isoformat()
+    try:
+        save_state(state_path, state)
+    except OSError:
+        pass
+    return 0
+
+
+def cmd_list(args):
+    state_dir = resolve_state_dir(args.state_dir)
+    state = load_state(state_dir / STATE_NAME)
+    print(json.dumps(state, indent=2))
+    return 0
+
+
+def cmd_mark(args, status):
+    state_dir = resolve_state_dir(args.state_dir)
+    state_path = state_dir / STATE_NAME
+    state = load_state(state_path)
+    by_id = {s.get("id"): s for s in state.get("suggestions", [])}
+    missing = []
+    for sid in args.ids:
+        suggestion = by_id.get(sid)
+        if suggestion is None:
+            missing.append(sid)
+        else:
+            suggestion["status"] = status
+    save_state(state_path, state)
+    log_path = resolve_log_path(args.log)
+    ran_log_path = resolve_ran_log_path(args.ran_log)
+    doc = render_doc(state, log_path, ran_log_path)
+    with open(state_dir / DOC_NAME, "w") as f:
+        f.write(doc)
+    if missing:
+        print("yolt-review: unknown id(s): {}".format(", ".join(missing)),
+              file=sys.stderr)
+        return 1
+    print("yolt-review: marked {} suggestion(s) {}".format(
+        len(args.ids), status))
+    return 0
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="YOLT self-improvement reviewer (issue #44)")
+    parser.add_argument("--log", help="decision log path override")
+    parser.add_argument("--ran-log", help="ran log path override")
+    parser.add_argument("--state-dir", help="state dir override")
+    parser.add_argument("--min-fires", type=int, default=MIN_FIRES_FRICTION)
+    parser.add_argument("--min-fires-safe", type=int, default=MIN_FIRES_FASTPATH)
+    parser.add_argument(
+        "--if-stale", action="store_true",
+        help="with --generate: no-op when the log is unchanged since the "
+             "last run (SessionEnd auto-regeneration)")
+    parser.add_argument("--quiet", action="store_true")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--generate", action="store_true")
+    group.add_argument("--status", action="store_true")
+    group.add_argument("--nudge", action="store_true")
+    group.add_argument("--list", action="store_true")
+    group.add_argument("--applied", nargs="+", metavar="ID", dest="applied_ids")
+    group.add_argument("--dismiss", nargs="+", metavar="ID", dest="dismiss_ids")
+    args = parser.parse_args()
+
+    retval = 0
+    if args.generate:
+        retval = cmd_generate(args)
+    elif args.status:
+        retval = cmd_status(args)
+    elif args.nudge:
+        retval = cmd_nudge(args)
+    elif args.list:
+        retval = cmd_list(args)
+    elif args.applied_ids:
+        args.ids = args.applied_ids
+        retval = cmd_mark(args, "applied")
+    elif args.dismiss_ids:
+        args.ids = args.dismiss_ids
+        retval = cmd_mark(args, "dismissed")
+    return retval
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/hooks/yolt_review.py
+++ b/hooks/yolt_review.py
@@ -65,6 +65,14 @@ MAX_EXAMPLE_CHARS = 200
 MAX_PER_BUCKET = 20
 NUDGE_INTERVAL_HOURS = 24
 RAN_MATCH_SKEW_SECONDS = 5
+# Upper bound on how long after a prompt a ran-record may still count as
+# that prompt's approval. PostToolUse stamps completion time, so this
+# must cover think-time plus command runtime, but stay well below "a
+# separate later invocation": without it, a run an hour later (e.g. once
+# the command became statically allowed) would back-credit an old denied
+# prompt. Undercounting a genuinely-approved slow command is the safe
+# direction -- better than fabricating an approval.
+RAN_MATCH_WINDOW_SECONDS = 600
 
 KIND_UNSAFE = "friction-unsafe"
 KIND_UNKNOWN = "friction-unknown"
@@ -289,12 +297,20 @@ def correlate_approvals(records, ran_index):
     """Match friction prompt-records to ran-records one-to-one, per command.
 
     A command YOLT returned `ask`/`unknown` on only reaches PostToolUse
-    (and thus the ran log) if the user approved it at the prompt. But a
-    single ran-record must not credit more than one prompt: with prompts
-    at t10 and t20 and a lone ran at t21, only one prompt was actually
-    approved. So for each command we walk its prompts in time order and
-    consume the earliest still-unclaimed ran-record at/after
-    (prompt_ts - skew); each ran-record satisfies at most one prompt.
+    (and thus the ran log) if the user approved it at the prompt. Two
+    constraints keep the correlation honest:
+
+    - One-to-one: a single ran-record must not credit more than one
+      prompt. With prompts at t10 and t20 and a lone ran at t21, only one
+      prompt was actually approved.
+    - Bounded: a ran-record only counts for a prompt if it lands in
+      `[prompt_ts - skew, prompt_ts + window]`. Without the upper bound a
+      run long after the prompt (e.g. once the command became statically
+      allowed) would back-credit an old denied prompt.
+
+    For each command we walk prompts in time order and consume the
+    earliest still-unclaimed ran-record inside that window; a ran-record
+    beyond a prompt's window is left for a later prompt.
 
     Returns the set of record indices (into `records`) that were
     approved."""
@@ -309,6 +325,7 @@ def correlate_approvals(records, ran_index):
         by_command.setdefault(command, []).append((ts, index))
 
     skew = datetime.timedelta(seconds=RAN_MATCH_SKEW_SECONDS)
+    window = datetime.timedelta(seconds=RAN_MATCH_WINDOW_SECONDS)
     approved = set()
     for command, prompts in by_command.items():
         rans = ran_index.get(command)
@@ -318,17 +335,23 @@ def correlate_approvals(records, ran_index):
         ran_pos = 0
         count = len(rans)
         for prompt_ts, index in prompts:
-            cutoff = prompt_ts - skew
-            # Advance past ran-records that cannot satisfy this prompt:
-            # already too early, or tz-incomparable (hand-edited lines).
-            # The tz check short-circuits before the order comparison so
+            low = prompt_ts - skew
+            high = prompt_ts + window
+            # Advance past ran-records that can help neither this prompt
+            # nor any later one: those before `low` (later prompts have a
+            # larger low), or tz-incomparable (hand-edited lines). The tz
+            # check short-circuits before the order comparison so
             # aware/naive values are never compared.
             while ran_pos < count and (
-                (rans[ran_pos].tzinfo is None) != (cutoff.tzinfo is None)
-                or rans[ran_pos] < cutoff
+                (rans[ran_pos].tzinfo is None) != (low.tzinfo is None)
+                or rans[ran_pos] < low
             ):
                 ran_pos += 1
-            if ran_pos < count:
+            # The earliest in-range ran approves this prompt and is
+            # consumed. If it sits beyond `high`, leave it for a later
+            # prompt (whose window extends further) -- this prompt is
+            # unapproved.
+            if ran_pos < count and rans[ran_pos] <= high:
                 approved.add(index)
                 ran_pos += 1
     return approved

--- a/hooks/yolt_review.py
+++ b/hooks/yolt_review.py
@@ -285,28 +285,59 @@ def build_ran_index(ran_records):
     return retval
 
 
-def was_approved(record_ts, command, ran_index):
-    """A ran-record at/after the decision timestamp means the user said
-    yes at the prompt (a denied command never reaches PostToolUse)."""
-    retval = False
-    timestamps = ran_index.get(command)
-    if timestamps and record_ts is not None:
-        skew = datetime.timedelta(seconds=RAN_MATCH_SKEW_SECONDS)
-        cutoff = record_ts - skew
-        for ts in timestamps:
-            # Compare only tz-aware with tz-aware; log writers always
-            # stamp UTC, but guard against hand-edited lines.
-            if (ts.tzinfo is None) != (cutoff.tzinfo is None):
-                continue
-            if ts >= cutoff:
-                retval = True
-                break
-    return retval
+def correlate_approvals(records, ran_index):
+    """Match friction prompt-records to ran-records one-to-one, per command.
+
+    A command YOLT returned `ask`/`unknown` on only reaches PostToolUse
+    (and thus the ran log) if the user approved it at the prompt. But a
+    single ran-record must not credit more than one prompt: with prompts
+    at t10 and t20 and a lone ran at t21, only one prompt was actually
+    approved. So for each command we walk its prompts in time order and
+    consume the earliest still-unclaimed ran-record at/after
+    (prompt_ts - skew); each ran-record satisfies at most one prompt.
+
+    Returns the set of record indices (into `records`) that were
+    approved."""
+    by_command = {}
+    for index, record in enumerate(records):
+        if record.get("decision") not in ("unsafe", "unknown"):
+            continue
+        command = (record.get("command") or "").strip()
+        ts = parse_ts(record.get("ts"))
+        if not command or ts is None:
+            continue
+        by_command.setdefault(command, []).append((ts, index))
+
+    skew = datetime.timedelta(seconds=RAN_MATCH_SKEW_SECONDS)
+    approved = set()
+    for command, prompts in by_command.items():
+        rans = ran_index.get(command)
+        if not rans:
+            continue
+        prompts.sort(key=lambda p: p[0])
+        ran_pos = 0
+        count = len(rans)
+        for prompt_ts, index in prompts:
+            cutoff = prompt_ts - skew
+            # Advance past ran-records that cannot satisfy this prompt:
+            # already too early, or tz-incomparable (hand-edited lines).
+            # The tz check short-circuits before the order comparison so
+            # aware/naive values are never compared.
+            while ran_pos < count and (
+                (rans[ran_pos].tzinfo is None) != (cutoff.tzinfo is None)
+                or rans[ran_pos] < cutoff
+            ):
+                ran_pos += 1
+            if ran_pos < count:
+                approved.add(index)
+                ran_pos += 1
+    return approved
 
 
-def annotate_glob_collisions(suggestion, nonsafe_commands):
+def annotate_glob_collisions(suggestion, nonsafe_commands, own_commands=None):
     """Record any known-unsafe/unknown command that the suggestion's
-    `Bash(prefix*)` glob would ALSO match.
+    `Bash(prefix*)` glob would ALSO match -- excluding the suggestion's
+    own group commands.
 
     This is the safety gate for fast-path suggestions: `gh api` is
     read-only but `gh api -X POST` is not, and both match `gh api*`.
@@ -315,10 +346,21 @@ def annotate_glob_collisions(suggestion, nonsafe_commands):
     Matching uses fnmatch against the real glob, so the warning reflects
     exactly what Claude Code's matcher would allow. `gh pr view*` does
     NOT collide with `gh pr merge`, so partially-overlapping namespaces
-    stay suggestable."""
+    stay suggestable.
+
+    `own_commands` are the (stripped) commands that formed THIS group; a
+    friction suggestion's own examples live in `nonsafe_commands`, and a
+    glob trivially matches the very commands it was derived from. Counting
+    those as collisions would veto every `friction-unsafe` /
+    `friction-unknown` suggestion against itself, so they are excluded:
+    only a genuinely different non-safe command swept in by the glob is a
+    collision."""
+    own = own_commands or set()
     pattern = suggestion["prefix"] + "*"
     collisions = []
     for command in nonsafe_commands:
+        if command in own:
+            continue
         if fnmatch(command, pattern):
             collisions.append(command[:MAX_EXAMPLE_CHARS])
             if len(collisions) >= MAX_EXAMPLES:
@@ -348,7 +390,8 @@ def build_groups(records, ran_index, min_fires, min_fires_safe):
         "first_ts": None,
         "last_ts": None,
     }
-    for record in records:
+    approved_indices = correlate_approvals(records, ran_index)
+    for index, record in enumerate(records):
         decision = record.get("decision")
         command = record.get("command") or ""
         ts = parse_ts(record.get("ts"))
@@ -382,9 +425,11 @@ def build_groups(records, ran_index, min_fires, min_fires_safe):
                 "last_ts": None,
                 "examples": [],
                 "reasons": {},
+                "commands": set(),
             }
             groups[key] = group
         group["fires"] += 1
+        group["commands"].add(command.strip())
         if ts is not None:
             if group["first_ts"] is None or ts < group["first_ts"]:
                 group["first_ts"] = ts
@@ -393,9 +438,8 @@ def build_groups(records, ran_index, min_fires, min_fires_safe):
         reason = record.get("reason") or ""
         if reason:
             group["reasons"][reason] = group["reasons"].get(reason, 0) + 1
-        if kind in (KIND_UNSAFE, KIND_UNKNOWN):
-            if was_approved(ts, command, ran_index):
-                group["approved"] += 1
+        if index in approved_indices:
+            group["approved"] += 1
         example = command[:MAX_EXAMPLE_CHARS]
         if example not in group["examples"] and len(group["examples"]) < MAX_EXAMPLES:
             group["examples"].append(example)
@@ -426,7 +470,8 @@ def build_groups(records, ran_index, min_fires, min_fires_safe):
             "glob_collisions": [],
             "status": "pending",
         }
-        annotate_glob_collisions(suggestion, nonsafe_commands)
+        annotate_glob_collisions(suggestion, nonsafe_commands,
+                                 own_commands=group["commands"])
         suggestions.append(suggestion)
 
     suggestions.sort(key=lambda s: (KINDS.index(s["kind"]), -s["fires"], s["prefix"]))

--- a/tests/test_yolt_review.py
+++ b/tests/test_yolt_review.py
@@ -37,6 +37,7 @@ from yolt_review import (  # noqa: E402
     annotate_glob_collisions,
     build_groups,
     build_ran_index,
+    correlate_approvals,
     group_key,
     is_compound,
     load_state,
@@ -44,7 +45,6 @@ from yolt_review import (  # noqa: E402
     redact_command,
     split_tokens,
     suggestion_id,
-    was_approved,
 )
 
 
@@ -166,6 +166,22 @@ class TestGlobCollisionGate(unittest.TestCase):
         annotate_glob_collisions(suggestion, set())
         self.assertEqual(suggestion["glob_collisions"], [])
 
+    def test_own_group_commands_do_not_self_collide(self):
+        # A friction suggestion's own examples are in the nonsafe set; the
+        # glob trivially matches them. They must not count as collisions.
+        suggestion = {"prefix": "kubectl get pods"}
+        annotate_glob_collisions(suggestion, {"kubectl get pods foo"},
+                                 own_commands={"kubectl get pods foo"})
+        self.assertEqual(suggestion["glob_collisions"], [])
+
+    def test_distinct_command_still_collides_despite_own(self):
+        # Excluding own commands must not hide a genuinely different
+        # non-safe command the glob would sweep in.
+        suggestion = {"prefix": "foo"}
+        annotate_glob_collisions(suggestion, {"foo", "foo bar baz"},
+                                 own_commands={"foo"})
+        self.assertEqual(suggestion["glob_collisions"], ["foo bar baz"])
+
     def test_collisions_are_capped(self):
         suggestion = {"prefix": "gh api"}
         nonsafe = {"gh api -X POST /{}".format(i) for i in range(10)}
@@ -193,21 +209,51 @@ class TestApprovalCorrelation(unittest.TestCase):
         index = build_ran_index(records)
         self.assertEqual(list(index.keys()), ["ok"])
 
-    def test_ran_after_decision_counts_as_approved(self):
-        index = {"git push": [_ts(11)]}
-        self.assertTrue(was_approved(_ts(10), "git push", index))
+    def test_one_ran_record_approves_only_one_prompt(self):
+        # Regression (PR #47 review): two prompts for the same command, a
+        # single later ran-record. Exactly one prompt is approved, not
+        # both -- a lone PostToolUse event cannot credit every prior ask.
+        records = [_rec("unsafe", "git push", _ts(10)),
+                   _rec("unsafe", "git push", _ts(20))]
+        ran_index = build_ran_index(
+            [{"command": "git push", "ts": _ts(21).isoformat()}])
+        approved = correlate_approvals(records, ran_index)
+        self.assertEqual(len(approved), 1)
 
-    def test_ran_within_skew_before_decision_counts_as_approved(self):
-        # cutoff = decision - 5s; a ran 3s earlier still correlates.
-        index = {"git push": [_ts(7)]}
-        self.assertTrue(was_approved(_ts(10), "git push", index))
+    def test_a_ran_per_prompt_approves_each(self):
+        records = [_rec("unsafe", "git push", _ts(10)),
+                   _rec("unsafe", "git push", _ts(20))]
+        ran_index = build_ran_index([
+            {"command": "git push", "ts": _ts(11).isoformat()},
+            {"command": "git push", "ts": _ts(21).isoformat()},
+        ])
+        approved = correlate_approvals(records, ran_index)
+        self.assertEqual(approved, {0, 1})
 
-    def test_ran_well_before_decision_is_not_approved(self):
-        index = {"git push": [_ts(1)]}
-        self.assertFalse(was_approved(_ts(10), "git push", index))
+    def test_ran_within_skew_before_prompt_counts(self):
+        # cutoff = prompt - 5s; a ran 3s earlier still correlates.
+        records = [_rec("unknown", "git push", _ts(10))]
+        ran_index = build_ran_index(
+            [{"command": "git push", "ts": _ts(7).isoformat()}])
+        self.assertEqual(correlate_approvals(records, ran_index), {0})
+
+    def test_ran_well_before_prompt_is_not_approved(self):
+        records = [_rec("unsafe", "git push", _ts(10))]
+        ran_index = build_ran_index(
+            [{"command": "git push", "ts": _ts(1).isoformat()}])
+        self.assertEqual(correlate_approvals(records, ran_index), set())
 
     def test_no_ran_record_is_not_approved(self):
-        self.assertFalse(was_approved(_ts(10), "git push", {}))
+        records = [_rec("unsafe", "git push", _ts(10))]
+        self.assertEqual(correlate_approvals(records, {}), set())
+
+    def test_safe_records_are_never_approval_candidates(self):
+        # `safe` is auto-allowed (no prompt); its ran-record must not be
+        # mistaken for prompt approval.
+        records = [_rec("safe", "ls here", _ts(10))]
+        ran_index = build_ran_index(
+            [{"command": "ls here", "ts": _ts(11).isoformat()}])
+        self.assertEqual(correlate_approvals(records, ran_index), set())
 
 
 class TestBuildGroups(unittest.TestCase):
@@ -274,6 +320,17 @@ class TestBuildGroups(unittest.TestCase):
         self.assertEqual(fastpath[0]["prefix"], "gh api")
         self.assertIn("gh api -X POST /repos/x",
                       fastpath[0]["glob_collisions"])
+
+    def test_friction_unknown_readonly_does_not_self_collide(self):
+        # Regression (PR #47 review): a repeated read-only `unknown`
+        # command must keep its settings.json route. Its examples are in
+        # the nonsafe set, but they are this group's own commands, so the
+        # glob must not veto itself.
+        records = [_rec("unknown", "kubectl get pods foo", _ts(i))
+                   for i in range(3)]
+        suggestions, _ = self._build(records)
+        self.assertEqual(len(suggestions), 1)
+        self.assertEqual(suggestions[0]["glob_collisions"], [])
 
     def test_compound_friction_is_counted_not_suggested(self):
         records = [_rec("unsafe", "cat x | grep y", _ts(i)) for i in range(3)]

--- a/tests/test_yolt_review.py
+++ b/tests/test_yolt_review.py
@@ -1,0 +1,354 @@
+"""Unit tests for hooks/yolt_review.py (issue #44).
+
+Covers the load-bearing pure functions of the self-improvement reviewer:
+
+- grouping (`group_key` / `is_compound` / `split_tokens`),
+- redaction to a shareable shape (`redact_command`),
+- the glob-collision safety gate (`annotate_glob_collisions`) that stops
+  the reviewer from recommending a `settings.json` allow glob which would
+  also match a known non-safe command,
+- approval correlation between the decision log and the ran log
+  (`build_ran_index` / `was_approved`),
+- end-to-end aggregation (`build_groups`),
+- status-preserving regeneration (`merge_state` / `load_state`).
+
+Runs with stdlib unittest only - no tree-sitter dependency:
+
+    python3 -m unittest discover -v tests
+"""
+
+import datetime
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+HOOKS_DIR = REPO_ROOT / "hooks"
+sys.path.insert(0, str(HOOKS_DIR))
+
+from yolt_review import (  # noqa: E402
+    KIND_FASTPATH,
+    KIND_UNSAFE,
+    MAX_EXAMPLES,
+    MAX_PER_BUCKET,
+    STATE_VERSION,
+    annotate_glob_collisions,
+    build_groups,
+    build_ran_index,
+    group_key,
+    is_compound,
+    load_state,
+    merge_state,
+    redact_command,
+    split_tokens,
+    suggestion_id,
+    was_approved,
+)
+
+
+def _ts(second):
+    """A fixed tz-aware UTC timestamp varying only by second."""
+    retval = datetime.datetime(
+        2024, 1, 1, 12, 0, second, tzinfo=datetime.timezone.utc)
+    return retval
+
+
+def _rec(decision, command, ts=None, reason=None):
+    """Build a decision-log record dict the way yolt_analyzer writes it."""
+    retval = {"decision": decision, "command": command}
+    if ts is not None:
+        retval["ts"] = ts.isoformat()
+    if reason is not None:
+        retval["reason"] = reason
+    return retval
+
+
+class TestGrouping(unittest.TestCase):
+
+    def test_simple_command_groups_to_argv0_plus_subcommands(self):
+        self.assertEqual(group_key("kubectl delete pod x"),
+                         "kubectl delete pod")
+
+    def test_grouping_stops_at_first_flag(self):
+        self.assertEqual(group_key("gh api -X POST /repos"), "gh api")
+
+    def test_grouping_stops_at_slash_token(self):
+        self.assertEqual(group_key("gh api /repos/x"), "gh api")
+
+    def test_grouping_respects_max_depth(self):
+        # argv0 + 2 subcommands = depth 3; the 4th token is dropped.
+        self.assertEqual(group_key("a b c d"), "a b c")
+
+    def test_leading_env_assignment_is_dropped(self):
+        self.assertEqual(group_key("FOO=bar kubectl get pods"),
+                         "kubectl get pods")
+
+    def test_compound_command_has_no_group(self):
+        self.assertIsNone(group_key("cat x | grep y"))
+        self.assertIsNone(group_key("a && b"))
+        self.assertIsNone(group_key("echo `whoami`"))
+
+    def test_empty_command_has_no_group(self):
+        self.assertIsNone(group_key(""))
+        self.assertIsNone(group_key("   "))
+
+    def test_is_compound_detects_metacharacters(self):
+        for command in ("a | b", "a; b", "a & b", "a > f", "a < f",
+                        "a `b`", "a $(b)", "a\nb"):
+            self.assertTrue(is_compound(command), command)
+
+    def test_is_compound_false_for_plain_command(self):
+        self.assertFalse(is_compound("kubectl get pods -n default"))
+
+    def test_split_tokens_falls_back_on_unbalanced_quote(self):
+        # Unterminated quote: shlex raises, whitespace split is used.
+        self.assertEqual(split_tokens('echo "open'), ["echo", '"open'])
+
+
+class TestRedaction(unittest.TestCase):
+
+    def test_values_become_placeholder_flag_names_kept(self):
+        # Each positional value redacts to its own placeholder, so the
+        # shape preserves argument count without leaking values.
+        shape = redact_command("kubectl get pods -n prod my-pod")
+        self.assertEqual(shape, "kubectl get pods -n <...> <...>")
+
+    def test_equals_flag_value_is_stripped(self):
+        shape = redact_command("aws s3 ls --profile secret")
+        self.assertEqual(shape, "aws s3 ls --profile <...>")
+
+    def test_equals_inline_flag_value_is_stripped(self):
+        shape = redact_command("tool run --token=abc123")
+        self.assertEqual(shape, "tool run --token=<...>")
+
+    def test_compound_command_is_opaque(self):
+        self.assertEqual(redact_command("cat x | grep secret"),
+                         "(compound command)")
+
+
+class TestSuggestionId(unittest.TestCase):
+
+    def test_id_is_stable_and_twelve_hex(self):
+        first = suggestion_id(KIND_FASTPATH, "gh api")
+        second = suggestion_id(KIND_FASTPATH, "gh api")
+        self.assertEqual(first, second)
+        self.assertEqual(len(first), 12)
+        int(first, 16)  # raises if not hex
+
+    def test_id_varies_by_kind_and_prefix(self):
+        self.assertNotEqual(suggestion_id(KIND_FASTPATH, "gh api"),
+                            suggestion_id(KIND_UNSAFE, "gh api"))
+        self.assertNotEqual(suggestion_id(KIND_FASTPATH, "gh api"),
+                            suggestion_id(KIND_FASTPATH, "gh pr"))
+
+
+class TestGlobCollisionGate(unittest.TestCase):
+    """The safety-critical gate: a `Bash(prefix*)` allow glob must be
+    flagged when it would also match a known non-safe command."""
+
+    def test_collision_is_recorded(self):
+        suggestion = {"prefix": "gh api"}
+        nonsafe = {"gh api -X POST /repos/x", "gh pr merge 5"}
+        annotate_glob_collisions(suggestion, nonsafe)
+        self.assertEqual(suggestion["glob_collisions"],
+                         ["gh api -X POST /repos/x"])
+
+    def test_partially_overlapping_namespace_does_not_collide(self):
+        # `gh pr view*` must NOT be vetoed by `gh pr merge`.
+        suggestion = {"prefix": "gh pr view"}
+        annotate_glob_collisions(suggestion, {"gh pr merge 5"})
+        self.assertEqual(suggestion["glob_collisions"], [])
+
+    def test_no_collision_yields_empty_list(self):
+        suggestion = {"prefix": "ls"}
+        annotate_glob_collisions(suggestion, set())
+        self.assertEqual(suggestion["glob_collisions"], [])
+
+    def test_collisions_are_capped(self):
+        suggestion = {"prefix": "gh api"}
+        nonsafe = {"gh api -X POST /{}".format(i) for i in range(10)}
+        annotate_glob_collisions(suggestion, nonsafe)
+        self.assertEqual(len(suggestion["glob_collisions"]), MAX_EXAMPLES)
+
+
+class TestApprovalCorrelation(unittest.TestCase):
+
+    def test_build_ran_index_groups_and_sorts(self):
+        records = [
+            {"command": "git push", "ts": _ts(30).isoformat()},
+            {"command": "git push", "ts": _ts(10).isoformat()},
+            {"command": "git push", "ts": _ts(20).isoformat()},
+        ]
+        index = build_ran_index(records)
+        self.assertEqual(index["git push"], [_ts(10), _ts(20), _ts(30)])
+
+    def test_build_ran_index_skips_incomplete_records(self):
+        records = [
+            {"command": "git push"},          # no ts
+            {"ts": _ts(10).isoformat()},      # no command
+            {"command": "ok", "ts": _ts(5).isoformat()},
+        ]
+        index = build_ran_index(records)
+        self.assertEqual(list(index.keys()), ["ok"])
+
+    def test_ran_after_decision_counts_as_approved(self):
+        index = {"git push": [_ts(11)]}
+        self.assertTrue(was_approved(_ts(10), "git push", index))
+
+    def test_ran_within_skew_before_decision_counts_as_approved(self):
+        # cutoff = decision - 5s; a ran 3s earlier still correlates.
+        index = {"git push": [_ts(7)]}
+        self.assertTrue(was_approved(_ts(10), "git push", index))
+
+    def test_ran_well_before_decision_is_not_approved(self):
+        index = {"git push": [_ts(1)]}
+        self.assertFalse(was_approved(_ts(10), "git push", index))
+
+    def test_no_ran_record_is_not_approved(self):
+        self.assertFalse(was_approved(_ts(10), "git push", {}))
+
+
+class TestBuildGroups(unittest.TestCase):
+
+    def _build(self, records, ran_index=None, min_fires=3, min_fires_safe=10):
+        retval = build_groups(records, ran_index or {}, min_fires,
+                              min_fires_safe)
+        return retval
+
+    def test_decision_maps_to_bucket_and_respects_friction_threshold(self):
+        records = [_rec("unsafe", "rm thing", _ts(i)) for i in range(3)]
+        suggestions, _ = self._build(records)
+        self.assertEqual(len(suggestions), 1)
+        self.assertEqual(suggestions[0]["kind"], KIND_UNSAFE)
+        self.assertEqual(suggestions[0]["fires"], 3)
+
+    def test_below_threshold_is_dropped(self):
+        records = [_rec("unsafe", "rm thing", _ts(i)) for i in range(2)]
+        suggestions, _ = self._build(records)
+        self.assertEqual(suggestions, [])
+
+    def test_fastpath_uses_higher_threshold(self):
+        records = [_rec("safe", "ls here", _ts(i)) for i in range(9)]
+        suggestions, _ = self._build(records)
+        self.assertEqual(suggestions, [])
+        records.append(_rec("safe", "ls here", _ts(9)))
+        suggestions, _ = self._build(records)
+        self.assertEqual(len(suggestions), 1)
+        self.assertEqual(suggestions[0]["kind"], KIND_FASTPATH)
+
+    def test_approved_count_is_correlated(self):
+        records = [_rec("unsafe", "kubectl delete pod x", _ts(s))
+                   for s in (10, 20, 30)]
+        ran_index = build_ran_index([
+            {"command": "kubectl delete pod x", "ts": _ts(11).isoformat()},
+            {"command": "kubectl delete pod x", "ts": _ts(21).isoformat()},
+        ])
+        suggestions, _ = self._build(records, ran_index)
+        self.assertEqual(suggestions[0]["fires"], 3)
+        self.assertEqual(suggestions[0]["approved"], 2)
+
+    def test_unknown_on_known_cli_is_upstream_candidate(self):
+        records = [_rec("unknown", "kubectl rollout status x", _ts(i))
+                   for i in range(3)]
+        suggestions, _ = self._build(records)
+        self.assertTrue(suggestions[0]["upstream_candidate"])
+
+    def test_unknown_on_personal_tool_is_not_upstream_candidate(self):
+        records = [_rec("unknown", "myinternaltool sync now", _ts(i))
+                   for i in range(3)]
+        suggestions, _ = self._build(records)
+        self.assertFalse(suggestions[0]["upstream_candidate"])
+
+    def test_fastpath_collision_sourced_from_other_buckets(self):
+        # A safe `gh api ...` and an unsafe `gh api -X POST ...` both group
+        # under prefix "gh api". The fastpath suggestion must carry the
+        # collision so it is never written to settings.json.
+        records = [_rec("safe", "gh api /repos/x", _ts(i)) for i in range(10)]
+        records += [_rec("unsafe", "gh api -X POST /repos/x", _ts(20 + i))
+                    for i in range(3)]
+        suggestions, _ = self._build(records)
+        fastpath = [s for s in suggestions if s["kind"] == KIND_FASTPATH]
+        self.assertEqual(len(fastpath), 1)
+        self.assertEqual(fastpath[0]["prefix"], "gh api")
+        self.assertIn("gh api -X POST /repos/x",
+                      fastpath[0]["glob_collisions"])
+
+    def test_compound_friction_is_counted_not_suggested(self):
+        records = [_rec("unsafe", "cat x | grep y", _ts(i)) for i in range(3)]
+        suggestions, stats = self._build(records)
+        self.assertEqual(suggestions, [])
+        self.assertEqual(stats["compound_friction"], 3)
+
+    def test_broken_install_records_are_tallied(self):
+        records = [_rec("import-error", ""), _rec("rules-validation-error", "")]
+        suggestions, stats = self._build(records)
+        self.assertEqual(suggestions, [])
+        self.assertEqual(stats["broken_install"], 2)
+
+    def test_per_bucket_cap_is_enforced(self):
+        records = []
+        for n in range(MAX_PER_BUCKET + 2):
+            command = "cli{} go".format(n)
+            records += [_rec("safe", command, _ts(0)) for _ in range(10)]
+        suggestions, stats = self._build(records)
+        fastpath = [s for s in suggestions if s["kind"] == KIND_FASTPATH]
+        self.assertEqual(len(fastpath), MAX_PER_BUCKET)
+        self.assertEqual(stats["dropped_over_cap"], 2)
+
+
+class TestStateMerge(unittest.TestCase):
+
+    def test_applied_and_dismissed_status_survive_regeneration(self):
+        old_state = {
+            "suggestions": [
+                {"id": "aaa", "status": "dismissed"},
+                {"id": "bbb", "status": "applied"},
+                {"id": "ccc", "status": "pending"},
+            ],
+        }
+        new_suggestions = [
+            {"id": "aaa", "status": "pending"},
+            {"id": "bbb", "status": "pending"},
+            {"id": "ddd", "status": "pending"},
+        ]
+        merged = merge_state(old_state, new_suggestions, {"records": 5})
+        by_id = {s["id"]: s["status"] for s in merged["suggestions"]}
+        self.assertEqual(by_id["aaa"], "dismissed")
+        self.assertEqual(by_id["bbb"], "applied")
+        self.assertEqual(by_id["ddd"], "pending")
+        # A suggestion that no longer regenerates is dropped.
+        self.assertNotIn("ccc", by_id)
+        self.assertEqual(merged["version"], STATE_VERSION)
+        self.assertIsNotNone(merged["generated"])
+
+    def test_merge_serializes_datetime_stats(self):
+        merged = merge_state({}, [], {"first_ts": _ts(0), "records": 1})
+        self.assertEqual(merged["stats"]["first_ts"], _ts(0).isoformat())
+
+    def test_load_state_missing_returns_scaffold(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            state = load_state(Path(tmp) / "absent.json")
+        self.assertEqual(state["version"], STATE_VERSION)
+        self.assertEqual(state["suggestions"], [])
+
+    def test_load_state_corrupt_returns_scaffold(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "suggestions.json"
+            path.write_text("{ not valid json", encoding="utf-8")
+            state = load_state(path)
+        self.assertEqual(state["suggestions"], [])
+
+    def test_load_state_valid_round_trips(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "suggestions.json"
+            payload = {"version": STATE_VERSION, "suggestions":
+                       [{"id": "x", "status": "applied"}]}
+            path.write_text(json.dumps(payload), encoding="utf-8")
+            state = load_state(path)
+        self.assertEqual(state["suggestions"][0]["id"], "x")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_yolt_review.py
+++ b/tests/test_yolt_review.py
@@ -55,6 +55,13 @@ def _ts(second):
     return retval
 
 
+def _ts_at(minute=0, second=0):
+    """A fixed tz-aware UTC timestamp at an offset minute/second."""
+    retval = datetime.datetime(
+        2024, 1, 1, 12, minute, second, tzinfo=datetime.timezone.utc)
+    return retval
+
+
 def _rec(decision, command, ts=None, reason=None):
     """Build a decision-log record dict the way yolt_analyzer writes it."""
     retval = {"decision": decision, "command": command}
@@ -246,6 +253,23 @@ class TestApprovalCorrelation(unittest.TestCase):
     def test_no_ran_record_is_not_approved(self):
         records = [_rec("unsafe", "git push", _ts(10))]
         self.assertEqual(correlate_approvals(records, {}), set())
+
+    def test_far_future_ran_does_not_backcredit_old_prompt(self):
+        # Regression (PR #47 re-review): a denied prompt at t=0 and a run
+        # 30 min later (command became statically allowed, bypassing the
+        # prompt) must NOT mark the old prompt approved -- the match is
+        # bounded above by RAN_MATCH_WINDOW_SECONDS.
+        records = [_rec("unsafe", "git push", _ts_at(0, 0))]
+        ran_index = build_ran_index(
+            [{"command": "git push", "ts": _ts_at(30, 0).isoformat()}])
+        self.assertEqual(correlate_approvals(records, ran_index), set())
+
+    def test_ran_inside_window_approves(self):
+        # A run a few seconds after the prompt is within the window.
+        records = [_rec("unsafe", "git push", _ts_at(0, 0))]
+        ran_index = build_ran_index(
+            [{"command": "git push", "ts": _ts_at(0, 30).isoformat()}])
+        self.assertEqual(correlate_approvals(records, ran_index), {0})
 
     def test_safe_records_are_never_approval_candidates(self):
         # `safe` is auto-allowed (no prompt); its ran-record must not be


### PR DESCRIPTION
## What

Self-improvement loop for YOLT (issue #44): mine the decision log for
recurring Bash friction and surface it as a reviewable doc with routed
remediations.

## Why

The dogfood log already records where YOLT got in the way. This turns
that record into action: which prefixes to allowlist, which need a local
rule, and which point at an upstream rules gap — without ever
recommending something that defeats YOLT.

## How

- **`hooks/yolt_review.py`** (stdlib only — works even when the
  tree-sitter bootstrap failed). Groups repeated commands to a
  conservative prefix and sorts them into three buckets:
  - `friction-unsafe` — YOLT returned `ask` repeatedly.
  - `friction-unknown` — fell through to Claude Code's default prompt.
  - `fastpath` — auto-allowed at high frequency (a `settings.json` glob
    would skip the hook startup).

  Writes `~/.claude/yolt/review.md` + `suggestions.json`;
  applied/dismissed status survives regeneration by suggestion id.

- **Glob-collision veto (safety-critical).** Before recommending any
  `Bash(prefix*)` allow glob, fnmatch it against every command YOLT did
  *not* classify safe. `gh api` is read-only but `gh api -X POST` is not,
  and both match `Bash(gh api*)` — promoting that glob would silently
  bypass YOLT for the POST. Any hit re-routes the suggestion to a
  `shell.json` rule (#45). Partially-overlapping namespaces stay
  suggestable (`gh pr view*` does not collide with `gh pr merge`).

- **Approval correlation.** A PostToolUse hook (`yolt_analyzer
  --ran-hook` -> `~/.claude/yolt-ran.log`) records commands that actually
  ran. A command YOLT said `ask` on only reaches PostToolUse if the user
  approved, so each friction suggestion carries an `approved` count.

- **Surfacing.** SessionStart prints a throttled (24h) nudge toward
  `/yolt:review`; SessionEnd regenerates with `--if-stale` (mtime-guarded
  no-op on quiet sessions). `/yolt:review` slash command triages and
  applies, honoring the routing above with user confirmation.

- **README** "Self-improvement loop" section; **41 stdlib-unittest
  tests** covering grouping, redaction, the collision gate, approval
  correlation, `build_groups`, and status-preserving regeneration.

## Testing

`python3 -m unittest discover tests` — all green under an isolated
`HOME`. (In a live shell, the 16 pre-existing end-to-end failures are the
real `~/.claude/settings.json` allowlist leaking into the hook tests, not
a regression here.)

## Privacy

Only the redacted `shape` field (argv head + flag names, values stripped)
may leave the machine in an upstream issue draft; raw `examples` stay
local.

Closes #44.
Refs #45 (write user overrides), #46 (Codex parity).
