### PR TITLE
Rename allowlist terminology to whitelist

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -119,7 +119,7 @@ In a fresh Claude Code session (after `/plugin install yolt@voitta-yolt`):
 ## Known limitations
 
 - **Plugin install does not auto-install Python deps.** Until the bootstrap PR lands, users must manually `pip install -r requirements.txt` after `/plugin install yolt@voitta-yolt`. Without it, the hook silently no-ops (visible only in the log as `import-error`).
-- **`python3 -m <mod>` is not first-class.** Falls through to `unknown` unless allowlisted. `python3 -m json.tool` is benign but YOLT can't tell.
+- **`python3 -m <mod>` is not first-class.** Falls through to `unknown` unless whitelisted. `python3 -m json.tool` is benign but YOLT can't tell.
 - **Argv reconstruction for deeply-nested `bash -c` keeps literal escape sequences.** E.g. `bash -c "ls; bash -c \"rm\""` may not classify the deepest `rm` correctly because `\"` survives in argv. Real-world `bash -c` rarely nests this deep.
 - **Log grows unbounded.** No rotation. Truncate manually if it gets uncomfortable.
 - **Tree-sitter parse errors → unknown.** Conservative; some malformed-but-clearly-safe commands (e.g. unterminated quotes) won't auto-allow. Acceptable bias.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
   - [Updating](#updating)
   - [Migrating from manual to plugin install](#migrating-from-manual-to-plugin-install)
   - [Manual install (without the plugin system)](#manual-install-without-the-plugin-system)
-- [User allowlist as a secondary upgrade pass](#user-allowlist-as-a-secondary-upgrade-pass)
+- [User whitelist as a secondary upgrade pass](#user-whitelist-as-a-secondary-upgrade-pass)
 - [Dependencies](#dependencies)
 - [What the grammar classifier handles](#what-the-grammar-classifier-handles)
 - [SQL CLIs](#sql-clis)
@@ -37,16 +37,16 @@ A Claude Code hook that statically analyzes script invocations before
 execution, auto-allowing read-only ones and flagging mutating ones for
 review.
 
-YOLT closes two gaps in Claude Code's built-in allowlist matcher:
+YOLT closes two gaps in Claude Code's built-in whitelist matcher:
 
 1. **Arbitrary-execution wrappers.** Interpreters (`bash`, `python3`,
    `node`, ...) and dual-use CLIs (`gh api`, `curl`, `kubectl`, ...) can't
-   be allowlisted with a wildcard without granting arbitrary execution,
+   be whitelisted with a wildcard without granting arbitrary execution,
    so a long tail of clearly read-only invocations prompt every time.
 2. **Compound shell commands.** The built-in matcher sees the outer wrapper
    (`for`, `while`, `bash -c "..."`, `$(...)`), not the inner commands it
    runs, so loops and command substitutions prompt even when every inner
-   command would be allowlisted on its own.
+   command would be whitelisted on its own.
 
 The hook entry is one piece, with two specialized followers:
 
@@ -192,14 +192,14 @@ Add to `~/.claude/settings.json`:
 ```
 
 > **Important:** A static allow rule in `settings.json` / `settings.local.json`
-> bypasses `PreToolUse` hooks. Do not allowlist `Bash(python3:*)`,
+> bypasses `PreToolUse` hooks. Do not whitelist `Bash(python3:*)`,
 > `Bash(aws:*)`, `Bash(gh:*)`, etc. with wildcards - YOLT's classifier
 > will never fire and mutating invocations will run without review. Narrow
-> allowlist patterns that don't cover mutating operations (e.g.
+> whitelist patterns that don't cover mutating operations (e.g.
 > `Bash(aws ecs list-services*)`) are fine; they just short-circuit YOLT
 > for the matching subset.
 
-## User allowlist as a secondary upgrade pass
+## User whitelist as a secondary upgrade pass
 
 YOLT reads your `permissions.allow` Bash() entries from
 `~/.claude/settings.json`, the project's `.claude/settings.json`, and
@@ -210,8 +210,8 @@ of those patterns.
 
 This earns its keep on compound forms. The built-in matcher only sees
 the outer wrapper, so a `for ... do CMD; done` whose `CMD` you've
-already allowlisted (`Bash(mycli list*)`) still prompts. YOLT walks
-into the loop body and matches each command against the allowlist.
+already whitelisted (`Bash(mycli list*)`) still prompts. YOLT walks
+into the loop body and matches each command against the whitelist.
 
 Two rules apply:
 
@@ -567,7 +567,7 @@ silently bypass YOLT for the POST too. Before recommending any
 `settings.json` glob, the reviewer fnmatches it against every command
 YOLT did *not* classify safe; any hit is recorded as a collision and the
 suggestion is re-routed to a `shell.json` rule instead, never the
-allowlist. Partially-overlapping namespaces stay suggestable —
+whitelist. Partially-overlapping namespaces stay suggestable —
 `gh pr view*` does not collide with `gh pr merge`.
 
 Only the redacted `shape` field (argv head plus flag names, every value

--- a/commands/review.md
+++ b/commands/review.md
@@ -1,5 +1,5 @@
 ---
-description: Triage YOLT friction into settings.json allowlist entries, local rule overrides, or upstream issues
+description: Triage YOLT friction into settings.json whitelist entries, local rule overrides, or upstream issues
 ---
 
 # /yolt:review
@@ -27,7 +27,7 @@ them. Do NOT re-derive suggestions by reading the raw log yourself.
    stop.
 
 2. **Present pending suggestions, grouped by bucket**, in this order:
-   - `fastpath` — already auto-allowed; an allowlist entry only saves
+   - `fastpath` — already auto-allowed; an whitelist entry only saves
      hook startup.
    - `friction-unsafe` — YOLT prompted (`ask`). Sort the user's attention
      by `approved` (how many times they approved at the prompt anyway):

--- a/hooks/post-tool-use.sh
+++ b/hooks/post-tool-use.sh
@@ -5,7 +5,7 @@
 # Paired with the PreToolUse decision log (~/.claude/yolt.log), this lets
 # the self-improvement reviewer (hooks/yolt_review.py, issue #44) tell
 # "YOLT prompted and the user approved anyway" (friction worth an
-# allowlist/rule) apart from "YOLT prompted and the user declined"
+# whitelist/rule) apart from "YOLT prompted and the user declined"
 # (working as intended): a command that was denied at the prompt never
 # reaches PostToolUse, so its absence here is the signal.
 #

--- a/hooks/rule_classifier.py
+++ b/hooks/rule_classifier.py
@@ -345,7 +345,7 @@ def _path_matches_safe_write_targets(target, safe_write_targets):
     fnmatch semantics. Mirrors the redirect-target check that
     `grammar_classifier._target_is_safe_write` runs against `> file`
     redirects, so flag-value writes (e.g. `find -fprint FILE`) and
-    redirect writes use the same allow list."""
+    redirect writes use the same white list."""
     if not safe_write_targets:
         return False
     expanded = _expand_home(target)
@@ -376,7 +376,7 @@ def check_unsafe_flags(cmd_args, spec, safe_write_targets=None):
     - `write_flag_value_targets`: list of flags whose immediately
       following value is a file path the command will write to
       (`find -fprint FILE`). The path is checked against the top-level
-      `safe_write_targets` allow list; a non-matching path makes the
+      `safe_write_targets` white list; a non-matching path makes the
       call unsafe. Requires `safe_write_targets` to be passed in.
     """
     unsafe_flag_values = spec.get("unsafe_flag_values", {})

--- a/hooks/yolt_review.py
+++ b/hooks/yolt_review.py
@@ -622,7 +622,7 @@ def render_doc(state, log_path, ran_log_path):
             if kind == KIND_FASTPATH:
                 if collisions:
                     lines.append(
-                        "- DO NOT allowlist `\"{}\"` — that glob would also"
+                        "- DO NOT whitelist `\"{}\"` — that glob would also"
                         " match these known non-safe commands, silently"
                         " bypassing YOLT for them:".format(
                             suggestion["settings_pattern"]))
@@ -641,7 +641,7 @@ def render_doc(state, log_path, ran_log_path):
             else:
                 if collisions:
                     lines.append(
-                        "- DO NOT allowlist `\"{}\"` — that glob would also"
+                        "- DO NOT whitelist `\"{}\"` — that glob would also"
                         " match known non-safe commands (e.g. `{}`); use a"
                         " `~/.claude/yolt/shell.json` rule (issue #45).".format(
                             suggestion["settings_pattern"], collisions[0]))
@@ -795,7 +795,7 @@ def cmd_nudge(args):
         if age < datetime.timedelta(hours=NUDGE_INTERVAL_HOURS):
             return 0
     message = (
-        "YOLT has {} pending allowlist/rule suggestion(s) distilled from"
+        "YOLT has {} pending whitelist/rule suggestion(s) distilled from"
         " your recent Bash friction - run /yolt:review to triage them"
         " (doc: {})."
     ).format(pending, state_dir / DOC_NAME)

--- a/tests/test_adversarial_regressions.py
+++ b/tests/test_adversarial_regressions.py
@@ -29,7 +29,7 @@ Catalogue layout:
 - `TestIssue27FindWriteFlags` -- `find -fprint / -fprintf / -fls /
   -fls0 FILE` repros (closes #27). Path argument was unchecked, so
   writes outside `safe_write_targets` classified safe. The fix
-  routes the path through the same allow list redirects use.
+  routes the path through the same white list redirects use.
 
 Run with:
 
@@ -299,7 +299,7 @@ class TestIssue27FindWriteFlags(unittest.TestCase):
     argument (`-fprint`, `-fprintf`, `-fls`, `-fls0`) classified `safe`
     before this fix because their path argument bypassed the redirect-
     based `safe_write_targets` check. After the fix the path argument
-    routes through the same allow list, so writes to `/tmp/...` stay
+    routes through the same white list, so writes to `/tmp/...` stay
     safe but writes to `/etc/profile` / `/var/log/...` ask."""
 
     def test_fprint_to_etc_is_unsafe(self):

--- a/tests/test_grammar_classifier.py
+++ b/tests/test_grammar_classifier.py
@@ -10,7 +10,7 @@ calls in production. Coverage targets:
   - Quoting: bash `'\\''` close-escape-open idiom, `$'...'` ANSI-C strings,
     concatenated strings.
   - Heredocs (with python body), redirects, process substitution.
-  - User allowlist upgrade, including explicit overrides of unsafe atoms.
+  - User whitelist upgrade, including explicit overrides of unsafe atoms.
 
 Runs with stdlib unittest plus tree-sitter / tree-sitter-bash:
 
@@ -707,7 +707,7 @@ class TestSafeWriteTargets(unittest.TestCase):
 
 
 class TestClassifierAllowPatterns(unittest.TestCase):
-    """Allowlist upgrades unknown and unsafe matches to safe."""
+    """Whitelist upgrades unknown and unsafe matches to safe."""
 
     def test_unknown_command_upgraded_to_safe(self):
         clf = _make_classifier(allow_patterns=["mycli *"])
@@ -720,7 +720,7 @@ class TestClassifierAllowPatterns(unittest.TestCase):
         d, _ = clf.classify("aws ec2 weird-op --flag")
         self.assertEqual(d, DECISION_SAFE)
 
-    def test_unsafe_overridden_by_allowlist(self):
+    def test_unsafe_overridden_by_whitelist(self):
         clf = _make_classifier(allow_patterns=["aws *"])
         d, _ = clf.classify("aws iam delete-user --user-name foo")
         self.assertEqual(d, DECISION_SAFE)
@@ -730,19 +730,19 @@ class TestClassifierAllowPatterns(unittest.TestCase):
         d, _ = clf.classify("aws s3 ls && rm -rf /etc")
         self.assertEqual(d, DECISION_SAFE)
 
-    def test_no_allowlist_match_stays_unknown(self):
+    def test_no_whitelist_match_stays_unknown(self):
         clf = _make_classifier(allow_patterns=["aws *"])
         d, _ = clf.classify("somecommand_unknown")
         self.assertEqual(d, DECISION_UNKNOWN)
 
-    def test_decomposed_atoms_match_allowlist(self):
+    def test_decomposed_atoms_match_whitelist(self):
         # The outer `for` wrapper would not match `Bash(aws s3 ls*)`, but
         # the grammar walker classifies each iteration body separately.
         clf = _make_classifier(allow_patterns=["aws s3 ls*"])
         d, _ = clf.classify("for b in foo bar; do aws s3 ls s3://$b/; done")
         self.assertEqual(d, DECISION_SAFE)
 
-    def test_writes_to_file_upgraded_when_allowlisted(self):
+    def test_writes_to_file_upgraded_when_whitelisted(self):
         clf = _make_classifier(allow_patterns=["echo *"])
         d, _ = clf.classify("echo x > /etc/profile")
         self.assertEqual(d, DECISION_SAFE)

--- a/tests/test_rule_classifier.py
+++ b/tests/test_rule_classifier.py
@@ -112,7 +112,7 @@ class TestCheckUnsafeFlags(unittest.TestCase):
         )
 
     # write_flag_value_targets: flag value is a write-target path,
-    # decision routes through the top-level safe_write_targets allow list.
+    # decision routes through the top-level safe_write_targets white list.
     # Repros from issue #27 (find -fprint / -fprintf / -fls / -fls0).
 
     def test_write_flag_value_targets_unsafe_outside_allow(self):
@@ -151,7 +151,7 @@ class TestCheckUnsafeFlags(unittest.TestCase):
             ["-fprint"], spec, safe_write_targets=["/tmp/*"],
         ))
 
-    def test_write_flag_value_targets_empty_allow_list_blocks_everything(self):
+    def test_write_flag_value_targets_empty_white_list_blocks_everything(self):
         # No safe_write_targets configured -> any value is unsafe.
         spec = {"write_flag_value_targets": ["-fprint"]}
         self.assertIsNotNone(check_unsafe_flags(
@@ -163,7 +163,7 @@ class TestCheckUnsafeFlags(unittest.TestCase):
 
     def test_write_flag_value_targets_home_expansion(self):
         spec = {"write_flag_value_targets": ["-fprint"]}
-        # ~/.cache/* in allow list matches user-supplied ~/.cache/foo.
+        # ~/.cache/* in white list matches user-supplied ~/.cache/foo.
         self.assertIsNone(check_unsafe_flags(
             ["-fprint", "~/.cache/list.txt"], spec,
             safe_write_targets=["~/.cache/*"],

--- a/tests/test_yolt_hook.py
+++ b/tests/test_yolt_hook.py
@@ -205,7 +205,7 @@ class TestHookEndToEnd(unittest.TestCase):
         self.assertIn("Bash(gh issue create*)", reason)
 
 
-class TestHookAllowlistDiscovery(unittest.TestCase):
+class TestHookWhitelistDiscovery(unittest.TestCase):
     """The hook reads the user's settings.json `permissions.allow` Bash()
     entries and uses them as an explicit override for unknown and unsafe
     atoms.
@@ -246,7 +246,7 @@ class TestHookAllowlistDiscovery(unittest.TestCase):
         self._write_settings(["Bash(yolt_test_othertool *)"])
         self.assertIsNone(self._decision("yolt_test_mycli foo bar"))
 
-    def test_allowlist_overrides_unsafe(self):
+    def test_whitelist_overrides_unsafe(self):
         self._write_settings(["Bash(git push origin feature/*)"])
         self.assertEqual(
             self._decision("git push origin feature/issue-35"),


### PR DESCRIPTION
Per request: voitta uses traditional terms, not newspeak.

## Change
Rename `allowlist` family to `whitelist` everywhere in source/docs/tests:

| from | to |
|------|------|
| `allowlist` / `allowlisted` | `whitelist` / `whitelisted` |
| `Allowlist` | `Whitelist` |
| `allow list` | `white list` |
| `allow_list` | `white_list` |

27 occurrences across 7 files (README, HANDOFF, hooks/rule_classifier.py, 4 test files). Symmetric 25/25 diff.

## Notes
- **No `denylist` terms existed** in the repo, so nothing mapped to `blacklist`.
- Functional keys untouched: `safe_write_targets` (the actual mechanism) and `permissions.allow` (Claude Code settings key) are not the term being renamed.
- README TOC anchor + its heading renamed together so the link still resolves.
- **Skipped** `.omx/state/native-stop-state.json` — `allowlist` there sits inside a stored PR-loop fingerprint (runtime change-detection state, not source); editing it would corrupt loop matching.
- Renamed test method/class names are referenced only at their definitions; no cross-file refs.

## Verification
- Isolated `HOME`: `python3 -m unittest discover tests` -> all 382 pass.
- The 16-19 failures under live `$HOME` are pre-existing settings-permission leakage (present on master too), unrelated to this rename.