### PR TITLE
Reviewer writes safe_subcommands overrides for personal CLIs (issue #45)

### DIFF
--- a/README.md
+++ b/README.md
@@ -554,9 +554,11 @@ Each suggestion routes to exactly one of three remediations:
   of flags. Fastest, but a static allow rule bypasses YOLT's hook
   entirely (including its redirect and command-substitution checks).
 - **Local override** — a `~/.claude/yolt/shell.json` rule for anything
-  flag-conditional or verb-class, keeping the AST walk in the loop
-  (generating these directly is issue
-  [#45](https://github.com/voitta-ai/voitta-yolt/issues/45)).
+  flag-conditional or verb-class, keeping the AST walk in the loop. For
+  the narrow, additive case of a personal CLI hitting `unknown` on a
+  subcommand, the reviewer writes the `safe_subcommands` override itself
+  (`--write-override <id>`); deeper rules stay hand-written. See
+  [Writing overrides](#writing-overrides-issue-45).
 - **Upstream issue** — a common CLI repeatedly hitting `unknown` is
   likely a rules gap worth reporting on voitta-ai/voitta-yolt.
 
@@ -595,13 +597,52 @@ python3 hooks/yolt_review.py --status     # {"pending": N, ...}
 python3 hooks/yolt_review.py --list       # full suggestion JSON
 python3 hooks/yolt_review.py --applied <id> [<id> ...]
 python3 hooks/yolt_review.py --dismiss <id> [<id> ...]
+python3 hooks/yolt_review.py --write-override <id> [<id> ...]  # see below
 ```
 
-Override the state directory with `YOLT_STATE_DIR`. The reviewer is
-read-mostly: it only ever writes its own files under `~/.claude/yolt/`;
-all edits to `settings.json` and override files go through you. A Codex
-CLI parity loop is tracked in issue
-[#46](https://github.com/voitta-ai/voitta-yolt/issues/46).
+Override the state directory with `YOLT_STATE_DIR`. The reviewer only
+ever writes under `~/.claude/yolt/`: its own state files, and — via
+`--write-override` — the `shell.json` override the hook reads. Edits to
+`settings.json` go through you. A Codex CLI parity loop is tracked in
+issue [#46](https://github.com/voitta-ai/voitta-yolt/issues/46).
+
+### Writing overrides (issue [#45](https://github.com/voitta-ai/voitta-yolt/issues/45))
+
+`--write-override <id>` turns a `friction-unknown` suggestion into a
+`~/.claude/yolt/shell.json` rule, for the one case the reviewer can infer
+safely: a **personal CLI** (no bundled rule) that fell through to
+`unknown` on a subcommand. It writes a `safe_subcommands` fragment
+asserting that one observed subcommand is read-only —
+
+```json
+{"commands": {"mycli": {"default": "subcommand", "safe_subcommands": ["status"]}}}
+```
+
+— so `mycli status` auto-allows while every other `mycli` subcommand
+still prompts (the assertion is strictly additive; it never marks the
+whole CLI safe, and never flips an existing `unsafe` verdict). A
+`cli group sub` prefix nests under
+`nested_subcommand.<group>.safe_subcommands` instead. Each suggestion's
+`override` field carries `writable`, the `label`, and the exact
+`fragment`.
+
+Three properties make the write safe:
+
+- **Read-modify-write** — overrides merge per top-level key (a `commands`
+  override replaces individual command specs), so the writer reads the
+  existing file and unions the new subcommand in, never clobbering
+  entries you already have.
+- **Validate before write** — the merged result (bundled rules ∪ the
+  override) is checked with `validate_shell_rules`; the writer refuses to
+  write anything that would fail, since a malformed override downgrades
+  the whole hook to `rules-validation-error`.
+- **Personal-CLI only** — a `friction-unknown` on a *bundled* CLI is a
+  rules gap worth an upstream issue, not a local shadow that would freeze
+  a stale copy of the bundled spec. Flag-conditional, verb-class, and
+  `friction-unsafe` overrides stay hand-written.
+
+Override the paths the writer reads/writes with `YOLT_RULES_DIR` (bundled
+rules) and `YOLT_SHELL_OVERRIDE` (the user override file).
 
 ## CLI usage
 

--- a/commands/review.md
+++ b/commands/review.md
@@ -49,8 +49,14 @@ them. Do NOT re-derive suggestions by reading the raw log yourself.
      `~/.claude/settings.json`.
    - A friction suggestion with no collisions that the user confirms is
      read-only regardless of flags → same settings.json route.
-   - A friction suggestion that is flag-conditional or verb-class → a
-     `~/.claude/yolt/shell.json` / `rules.json` override (issue #45).
+   - A `friction-unknown` suggestion whose `override.writable` is `true`
+     (a personal CLI with no bundled rule) → the generator can write the
+     `safe_subcommands` override itself; use `--write-override <id>`
+     (step 4). The suggestion's `override.label` / `override.fragment`
+     show exactly what will be added.
+   - A friction suggestion that is flag-conditional or verb-class (or
+     `override.writable` is `false` for any other reason) → a hand-written
+     `~/.claude/yolt/shell.json` / `rules.json` override.
    - `upstream_candidate: true` → offer to file an issue on
      voitta-ai/voitta-yolt.
 
@@ -58,10 +64,25 @@ them. Do NOT re-derive suggestions by reading the raw log yourself.
    - settings.json: read `~/.claude/settings.json`, add the pattern to
      `permissions.allow` (create the array if absent), write it back.
      Confirm the exact diff with the user before writing.
-   - Local override: edit `~/.claude/yolt/shell.json` per the README's
-     "Shell rules" schema. (Direct generation of these is tracked in
-     issue #45; for now, hand-write the minimal fragment.)
-   - After each accepted suggestion is applied, record it:
+   - Local override (writable): for a `friction-unknown` suggestion with
+     `override.writable: true`, let the generator write it. This
+     read-modify-writes `~/.claude/yolt/shell.json`, validates the merged
+     result against the bundled rules with `validate_shell_rules` (it
+     refuses to write anything that would fail), and marks the suggestion
+     applied — so you do NOT also run `--applied` for these:
+
+     ```bash
+     python3 "${CLAUDE_PLUGIN_ROOT}/hooks/yolt_review.py" --write-override <id> [<id> ...]
+     ```
+
+     Show the user `override.fragment` and confirm before running it.
+   - Local override (hand-written): for flag-conditional / verb-class
+     rules (anything `override.writable` is `false`), edit
+     `~/.claude/yolt/shell.json` by hand per the README's "Shell rules"
+     schema, then record it with `--applied` below.
+   - After each accepted suggestion is applied *by hand* (settings.json or
+     a hand-written override), record it (`--write-override` already does
+     this for the suggestions it writes):
 
      ```bash
      python3 "${CLAUDE_PLUGIN_ROOT}/hooks/yolt_review.py" --applied <id> [<id> ...]
@@ -93,6 +114,9 @@ them. Do NOT re-derive suggestions by reading the raw log yourself.
 - A static allow rule in `settings.json` bypasses YOLT's PreToolUse hook
   entirely (including its redirect and command-substitution checks), so
   keep every pattern narrow. This is exactly why collisions are vetoed.
-- The reviewer is read-mostly: it only writes its own state files under
-  `~/.claude/yolt/`. All edits to `settings.json` and override files go
-  through you, with the user's confirmation.
+- The reviewer only ever writes under `~/.claude/yolt/`: its own state
+  files, and — via `--write-override` — the `shell.json` override the
+  hook reads. That write is validated before it lands, so it can never
+  leave a malformed override that downgrades the hook to
+  `rules-validation-error`. Edits to `settings.json` still go through
+  you. Every write happens only on the user's confirmation.

--- a/hooks/rule_classifier.py
+++ b/hooks/rule_classifier.py
@@ -242,17 +242,33 @@ def load_shell_rules(rules_dir, user_overrides_path=None, validate=True):
     if user_overrides_path and Path(user_overrides_path).exists():
         with open(user_overrides_path, "r") as f:
             overrides = json.load(f)
-        for key, value in overrides.items():
-            if key in rules and isinstance(rules[key], dict) and isinstance(value, dict):
-                rules[key].update(value)
-            else:
-                rules[key] = value
+        merge_shell_overrides(rules, overrides)
 
     if validate:
         errors = validate_shell_rules(rules)
         if errors:
             raise ShellRulesValidationError(default_path, user_overrides_path, errors)
 
+    return rules
+
+
+def merge_shell_overrides(rules, overrides):
+    """Merge a user-override dict into loaded shell rules, one level deep per
+    top-level key — the exact semantics `load_shell_rules` applies to
+    `~/.claude/yolt/shell.json`. A dict value is shallow-`update`d into the
+    existing top-level dict (so a `commands` override adds or replaces
+    individual command specs); any other value replaces wholesale (so an
+    override of `safe_write_targets` replaces the whole list rather than
+    extending it). Mutates and returns `rules`.
+
+    Extracted so the reviewer (`yolt_review.py`) can validate a candidate
+    override against the same merge the hook performs, with no second copy
+    of the merge rule to drift from this one (issue #45)."""
+    for key, value in overrides.items():
+        if key in rules and isinstance(rules[key], dict) and isinstance(value, dict):
+            rules[key].update(value)
+        else:
+            rules[key] = value
     return rules
 
 

--- a/hooks/yolt_review.py
+++ b/hooks/yolt_review.py
@@ -1115,6 +1115,18 @@ def cmd_write_override(args):
         print("yolt-review: existing {} has a non-dict 'commands'; refusing to "
               "edit".format(override_path), file=sys.stderr)
         return 1
+    # Refuse before mutating if any target CLI already has a non-dict spec:
+    # silently replacing it with {} would clobber a (malformed) user entry and
+    # hide it from the post-merge validation, violating the contract that a
+    # malformed preexisting override is refused and left untouched. The user
+    # must fix the file by hand first.
+    clobbered = sorted({cli for cli, _, _ in targets
+                        if cli in commands and not isinstance(commands[cli], dict)})
+    if clobbered:
+        print("yolt-review: refusing to edit {} — existing non-dict command "
+              "spec(s): {} (fix the file by hand first)".format(
+                  override_path, ", ".join(clobbered)), file=sys.stderr)
+        return 1
     for cli, fragment, _ in targets:
         existing_spec = commands.get(cli)
         if not isinstance(existing_spec, dict):

--- a/hooks/yolt_review.py
+++ b/hooks/yolt_review.py
@@ -49,9 +49,33 @@ import sys
 from fnmatch import fnmatch
 from pathlib import Path
 
+# Override writing (issue #45) needs the classifier's merge + validation so a
+# fragment is checked against the same merge the hook performs. The import is
+# guarded: the rest of the reviewer (parse / status / nudge) is stdlib-only and
+# must keep working even if rule_classifier cannot be imported, so a failure
+# here only disables `--write-override`, not the whole tool.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+try:
+    from rule_classifier import (
+        load_shell_rules,
+        merge_shell_overrides,
+        validate_shell_rules,
+    )
+    _RULES_AVAILABLE = True
+except ImportError:
+    load_shell_rules = None
+    merge_shell_overrides = None
+    validate_shell_rules = None
+    _RULES_AVAILABLE = False
+
 DEFAULT_LOG_PATH = Path.home() / ".claude" / "yolt.log"
 DEFAULT_RAN_LOG_PATH = Path.home() / ".claude" / "yolt-ran.log"
 DEFAULT_STATE_DIR = Path.home() / ".claude" / "yolt"
+DEFAULT_RULES_DIR = Path(__file__).resolve().parent.parent / "rules"
+# The shell-override file the classifier loads (grammar_classifier hard-codes
+# this path) and that `--write-override` writes. Kept independent of the state
+# dir so the reviewer writes exactly the file the hook reads.
+DEFAULT_SHELL_OVERRIDE_PATH = Path.home() / ".claude" / "yolt" / "shell.json"
 
 DOC_NAME = "review.md"
 STATE_NAME = "suggestions.json"
@@ -149,6 +173,146 @@ def resolve_state_dir(cli_value):
         else:
             retval = DEFAULT_STATE_DIR
     return retval
+
+
+def resolve_rules_dir(cli_value):
+    """Bundled rules dir: --rules-dir flag > YOLT_RULES_DIR > <plugin>/rules."""
+    retval = None
+    if cli_value:
+        retval = Path(cli_value)
+    else:
+        env_value = os.environ.get("YOLT_RULES_DIR")
+        if env_value:
+            retval = Path(env_value)
+        else:
+            retval = DEFAULT_RULES_DIR
+    return retval
+
+
+def resolve_shell_override_path(cli_value):
+    """User shell-override file the hook reads and `--write-override` writes:
+    --shell-override flag > YOLT_SHELL_OVERRIDE > ~/.claude/yolt/shell.json."""
+    retval = None
+    if cli_value:
+        retval = Path(cli_value)
+    else:
+        env_value = os.environ.get("YOLT_SHELL_OVERRIDE")
+        if env_value:
+            retval = Path(env_value)
+        else:
+            retval = DEFAULT_SHELL_OVERRIDE_PATH
+    return retval
+
+
+def load_known_clis(rules_dir):
+    """Names the bundled shell rules already classify (commands +
+    interpreters + safe builtins, plus the common-CLI backstop). A
+    friction-unknown on one of these is a rules gap worth an upstream issue,
+    not a personal CLI to shadow with a frozen local copy of the bundled
+    spec. Returns None when the rules cannot be loaded (override writing then
+    stays disabled rather than mistaking a bundled CLI for a personal one)."""
+    if not _RULES_AVAILABLE:
+        return None
+    try:
+        rules = load_shell_rules(rules_dir, user_overrides_path=None,
+                                 validate=False)
+    except (OSError, ValueError):
+        return None
+    names = set()
+    names.update(rules.get("commands", {}).keys())
+    names.update(rules.get("interpreters", {}).keys())
+    names.update(rules.get("shell_builtins_safe", []))
+    names.update(UPSTREAM_CLIS)
+    return names
+
+
+def build_override_fragment(subs):
+    """The minimal per-command spec (the value of `commands.<cli>`) asserting
+    the observed subcommand is read-only. One subcommand token -> top-level
+    `safe_subcommands`; two -> `nested_subcommand.<group>.safe_subcommands`
+    (matching the depth-3 grouping a `cli group sub` prefix produces).
+    `default: subcommand` keeps every other subcommand at `unknown` (still
+    prompted), so the assertion is strictly additive — it never marks the
+    whole CLI safe."""
+    if len(subs) == 1:
+        retval = {"default": "subcommand", "safe_subcommands": [subs[0]]}
+    else:
+        group, sub = subs[0], subs[1]
+        retval = {
+            "default": "subcommand",
+            "nested_subcommand": {group: {"safe_subcommands": [sub]}},
+        }
+    return retval
+
+
+def compute_override(prefix, known_clis):
+    """Decide whether the reviewer may write a `safe_subcommands` override for
+    a friction-unknown `prefix`, and with what fragment. Writable only for a
+    personal CLI (no bundled rule) with at least one subcommand token; the
+    fragment asserts that one observed subcommand is read-only. Returns a dict
+    the doc renders and `--write-override` consumes."""
+    parts = prefix.split(" ")
+    cli = parts[0]
+    subs = parts[1:]
+    if not subs:
+        retval = {
+            "writable": False,
+            "reason": "no subcommand to scope safe; only mark the whole "
+                      "command safe by hand if it is read-only regardless of "
+                      "arguments",
+        }
+        return retval
+    if known_clis is None:
+        retval = {
+            "writable": False,
+            "reason": "default rules unavailable; cannot confirm this is a "
+                      "personal CLI",
+        }
+        return retval
+    if cli in known_clis:
+        retval = {
+            "writable": False,
+            "reason": "{} has bundled rules; a gap here is upstream-worthy (a "
+                      "local override would freeze a copy of the bundled "
+                      "spec)".format(cli),
+        }
+        return retval
+    fragment = build_override_fragment(subs)
+    label = "commands.{}".format(cli)
+    if len(subs) > 1:
+        label = "commands.{}.nested_subcommand.{}".format(cli, subs[0])
+    retval = {"writable": True, "cli": cli, "fragment": fragment, "label": label}
+    return retval
+
+
+def merge_command_fragment(existing_spec, fragment):
+    """Union our minimal fragment shape (default + safe_subcommands and/or
+    nested_subcommand.<group>.safe_subcommands) into an existing per-command
+    spec, preserving everything already there. Never removes a subcommand; it
+    only adds the observed read-only one, so re-running is idempotent and an
+    existing user spec is never clobbered."""
+    spec = json.loads(json.dumps(existing_spec))  # deep copy; don't mutate caller
+    spec.setdefault("default", fragment.get("default", "subcommand"))
+    for sub in fragment.get("safe_subcommands", []):
+        bucket = spec.setdefault("safe_subcommands", [])
+        if sub not in bucket:
+            bucket.append(sub)
+    nested = fragment.get("nested_subcommand")
+    if nested:
+        dst_nested = spec.setdefault("nested_subcommand", {})
+        if not isinstance(dst_nested, dict):
+            dst_nested = {}
+            spec["nested_subcommand"] = dst_nested
+        for group, group_spec in nested.items():
+            dst_group = dst_nested.setdefault(group, {})
+            if not isinstance(dst_group, dict):
+                dst_group = {}
+                dst_nested[group] = dst_group
+            bucket = dst_group.setdefault("safe_subcommands", [])
+            for sub in group_spec.get("safe_subcommands", []):
+                if sub not in bucket:
+                    bucket.append(sub)
+    return spec
 
 
 def read_jsonl(path):
@@ -392,9 +556,12 @@ def annotate_glob_collisions(suggestion, nonsafe_commands, own_commands=None):
     return suggestion
 
 
-def build_groups(records, ran_index, min_fires, min_fires_safe):
+def build_groups(records, ran_index, min_fires, min_fires_safe, known_clis=None):
     """Aggregate log records into suggestion groups. Returns
-    (suggestions, stats)."""
+    (suggestions, stats). `known_clis` is the set of CLIs the bundled rules
+    already classify (None when unavailable); it gates whether a
+    friction-unknown suggestion can carry a writable `safe_subcommands`
+    override (issue #45)."""
     decision_to_kind = {
         "unsafe": KIND_UNSAFE,
         "unknown": KIND_UNKNOWN,
@@ -495,6 +662,8 @@ def build_groups(records, ran_index, min_fires, min_fires_safe):
         }
         annotate_glob_collisions(suggestion, nonsafe_commands,
                                  own_commands=group["commands"])
+        if kind == KIND_UNKNOWN:
+            suggestion["override"] = compute_override(prefix, known_clis)
         suggestions.append(suggestion)
 
     suggestions.sort(key=lambda s: (KINDS.index(s["kind"]), -s["fires"], s["prefix"]))
@@ -639,6 +808,7 @@ def render_doc(state, log_path, ran_log_path):
                         " (static allows bypass PreToolUse hooks).".format(
                             suggestion["settings_pattern"]))
             else:
+                override = suggestion.get("override") or {}
                 if collisions:
                     lines.append(
                         "- DO NOT whitelist `\"{}\"` — that glob would also"
@@ -651,6 +821,21 @@ def render_doc(state, log_path, ran_log_path):
                         " is read-only regardless of flags; a static allow"
                         " bypasses YOLT's redirect/substitution checks.".format(
                             suggestion["settings_pattern"]))
+                if override.get("writable"):
+                    lines.append(
+                        "- Override route (recommended): `python3"
+                        " hooks/yolt_review.py --write-override {}` writes `{}`"
+                        " to `~/.claude/yolt/shell.json` (validated before"
+                        " write; keeps the AST walk in the loop).".format(
+                            suggestion["id"], override["label"]))
+                    fragment = {"commands": {override["cli"]: override["fragment"]}}
+                    lines.append("  - Fragment: `{}`".format(json.dumps(fragment)))
+                elif override.get("reason"):
+                    lines.append(
+                        "- Override route: {} — hand-write a"
+                        " `~/.claude/yolt/shell.json` rule (issue #45).".format(
+                            override["reason"]))
+                else:
                     lines.append(
                         "- Override route: `~/.claude/yolt/shell.json` /"
                         " `rules.json` for flag-conditional or verb-class rules"
@@ -747,8 +932,10 @@ def cmd_generate(args):
             print("yolt-review: no log records at {}".format(log_path))
         return 0
     ran_index = build_ran_index(read_jsonl(ran_log_path))
+    known_clis = load_known_clis(resolve_rules_dir(args.rules_dir))
     suggestions, stats = build_groups(
-        records, ran_index, args.min_fires, args.min_fires_safe)
+        records, ran_index, args.min_fires, args.min_fires_safe,
+        known_clis=known_clis)
     state_path = state_dir / STATE_NAME
     state = merge_state(load_state(state_path), suggestions, stats)
     save_state(state_path, state)
@@ -847,12 +1034,139 @@ def cmd_mark(args, status):
     return 0
 
 
+def _load_json_obj(path):
+    """Load a JSON object from `path`; {} when missing. Raises ValueError on
+    corrupt content or a non-object so the writer refuses rather than
+    clobbering a file it cannot parse."""
+    retval = {}
+    if path.exists():
+        with open(path, "r") as f:
+            data = json.load(f)
+        if not isinstance(data, dict):
+            raise ValueError("{} is not a JSON object".format(path))
+        retval = data
+    return retval
+
+
+def _atomic_write_json(path, obj):
+    """Write `obj` as pretty JSON to `path` via a temp file + os.replace, so a
+    crash mid-write cannot leave a half-written shell.json that bricks the
+    classifier."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(path.name + ".tmp")
+    with open(tmp, "w") as f:
+        json.dump(obj, f, indent=2)
+        f.write("\n")
+    os.replace(tmp, path)
+
+
+def cmd_write_override(args):
+    """Write `safe_subcommands` overrides for the given suggestion ids to the
+    user shell-override file (issue #45). Reads the existing file, merges each
+    writable fragment in (read-modify-write, never clobbering existing
+    entries), validates the result against the bundled rules with
+    `validate_shell_rules`, and only then writes — a malformed override would
+    downgrade the whole hook to `rules-validation-error`. Marks the written
+    suggestions applied and regenerates the doc."""
+    if not _RULES_AVAILABLE:
+        print("yolt-review: rule_classifier unavailable; cannot validate or "
+              "write overrides", file=sys.stderr)
+        return 1
+
+    state_dir = resolve_state_dir(args.state_dir)
+    state_path = state_dir / STATE_NAME
+    state = load_state(state_path)
+    by_id = {s.get("id"): s for s in state.get("suggestions", [])}
+
+    missing = []
+    not_writable = []
+    targets = []  # (cli, fragment, suggestion)
+    for sid in args.ids:
+        suggestion = by_id.get(sid)
+        if suggestion is None:
+            missing.append(sid)
+            continue
+        override = suggestion.get("override") or {}
+        if not override.get("writable"):
+            not_writable.append(
+                (sid, override.get("reason", "not an override-writable suggestion")))
+            continue
+        targets.append((override["cli"], override["fragment"], suggestion))
+
+    for sid in missing:
+        print("yolt-review: unknown id: {}".format(sid), file=sys.stderr)
+    for sid, reason in not_writable:
+        print("yolt-review: {} is not override-writable: {}".format(sid, reason),
+              file=sys.stderr)
+    if not targets:
+        print("yolt-review: nothing to write", file=sys.stderr)
+        return 1
+
+    override_path = resolve_shell_override_path(args.shell_override)
+    try:
+        user_override = _load_json_obj(override_path)
+    except (OSError, ValueError) as e:
+        print("yolt-review: cannot read existing override {}: {}".format(
+            override_path, e), file=sys.stderr)
+        return 1
+
+    commands = user_override.setdefault("commands", {})
+    if not isinstance(commands, dict):
+        print("yolt-review: existing {} has a non-dict 'commands'; refusing to "
+              "edit".format(override_path), file=sys.stderr)
+        return 1
+    for cli, fragment, _ in targets:
+        existing_spec = commands.get(cli)
+        if not isinstance(existing_spec, dict):
+            existing_spec = {}
+        commands[cli] = merge_command_fragment(existing_spec, fragment)
+
+    # Validate the merged-with-defaults result before writing: the hook loads
+    # default rules ∪ this override and a single bad key downgrades it all to
+    # rules-validation-error. Reuse merge_shell_overrides so this check runs
+    # the exact merge the hook performs.
+    rules_dir = resolve_rules_dir(args.rules_dir)
+    try:
+        default_rules = load_shell_rules(rules_dir, user_overrides_path=None,
+                                         validate=False)
+    except (OSError, ValueError) as e:
+        print("yolt-review: cannot load default rules from {}: {}".format(
+            rules_dir, e), file=sys.stderr)
+        return 1
+    merged = json.loads(json.dumps(default_rules))  # deep copy
+    merge_shell_overrides(merged, user_override)
+    errors = validate_shell_rules(merged)
+    if errors:
+        print("yolt-review: refusing to write {} — merged rules fail "
+              "validation:".format(override_path), file=sys.stderr)
+        for err in errors:
+            print("  - {}".format(err), file=sys.stderr)
+        return 1
+
+    _atomic_write_json(override_path, user_override)
+
+    for _, _, suggestion in targets:
+        suggestion["status"] = "applied"
+    save_state(state_path, state)
+    doc = render_doc(state, resolve_log_path(args.log),
+                     resolve_ran_log_path(args.ran_log))
+    with open(state_dir / DOC_NAME, "w") as f:
+        f.write(doc)
+
+    print("yolt-review: wrote {} override(s) to {}; marked {} applied".format(
+        len(targets), override_path, len(targets)))
+    return 0
+
+
 def main():
     parser = argparse.ArgumentParser(
         description="YOLT self-improvement reviewer (issue #44)")
     parser.add_argument("--log", help="decision log path override")
     parser.add_argument("--ran-log", help="ran log path override")
     parser.add_argument("--state-dir", help="state dir override")
+    parser.add_argument("--rules-dir", help="bundled rules dir override")
+    parser.add_argument("--shell-override",
+                        help="user shell-override file path override")
     parser.add_argument("--min-fires", type=int, default=MIN_FIRES_FRICTION)
     parser.add_argument("--min-fires-safe", type=int, default=MIN_FIRES_FASTPATH)
     parser.add_argument(
@@ -867,6 +1181,10 @@ def main():
     group.add_argument("--list", action="store_true")
     group.add_argument("--applied", nargs="+", metavar="ID", dest="applied_ids")
     group.add_argument("--dismiss", nargs="+", metavar="ID", dest="dismiss_ids")
+    group.add_argument("--write-override", nargs="+", metavar="ID",
+                       dest="write_override_ids",
+                       help="write safe_subcommands override(s) for the given "
+                            "suggestion id(s) to ~/.claude/yolt/shell.json")
     args = parser.parse_args()
 
     retval = 0
@@ -884,6 +1202,9 @@ def main():
     elif args.dismiss_ids:
         args.ids = args.dismiss_ids
         retval = cmd_mark(args, "dismissed")
+    elif args.write_override_ids:
+        args.ids = args.write_override_ids
+        retval = cmd_write_override(args)
     return retval
 
 

--- a/tests/test_yolt_review.py
+++ b/tests/test_yolt_review.py
@@ -698,6 +698,30 @@ class TestWriteOverride(unittest.TestCase):
             state = load_state(state_dir / STATE_NAME)
             self.assertEqual(state["suggestions"][0]["status"], "pending")
 
+    def test_non_dict_existing_command_spec_is_refused_untouched(self):
+        # Regression (PR #49 [codex] review): a non-dict existing
+        # commands.<cli> must NOT be silently overwritten with {} before
+        # validation. The whole write is refused and the file is untouched,
+        # honoring the never-clobber contract.
+        known = load_known_clis(RULES_DIR)
+        with tempfile.TemporaryDirectory() as tmp:
+            state_dir = Path(tmp) / "state"
+            state_dir.mkdir()
+            shell_override = Path(tmp) / "shell.json"
+            payload = {"commands": {"mycli": "not-a-dict"}}
+            shell_override.write_text(json.dumps(payload))
+            sug = _writable_suggestion("mycli status", known)
+            _seed_state(state_dir, [sug])
+
+            rc, err = _run_write(
+                _write_args([sug["id"]], tmp, state_dir, shell_override))
+
+            self.assertEqual(rc, 1)
+            self.assertIn("non-dict command spec", err)
+            self.assertEqual(json.loads(shell_override.read_text()), payload)
+            state = load_state(state_dir / STATE_NAME)
+            self.assertEqual(state["suggestions"][0]["status"], "pending")
+
     def test_not_writable_id_is_refused(self):
         with tempfile.TemporaryDirectory() as tmp:
             state_dir = Path(tmp) / "state"

--- a/tests/test_yolt_review.py
+++ b/tests/test_yolt_review.py
@@ -17,32 +17,44 @@ Runs with stdlib unittest only - no tree-sitter dependency:
     python3 -m unittest discover -v tests
 """
 
+import contextlib
 import datetime
+import io
 import json
 import sys
 import tempfile
 import unittest
 from pathlib import Path
+from types import SimpleNamespace
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 HOOKS_DIR = REPO_ROOT / "hooks"
+RULES_DIR = REPO_ROOT / "rules"
 sys.path.insert(0, str(HOOKS_DIR))
 
 from yolt_review import (  # noqa: E402
     KIND_FASTPATH,
+    KIND_UNKNOWN,
     KIND_UNSAFE,
     MAX_EXAMPLES,
     MAX_PER_BUCKET,
+    STATE_NAME,
     STATE_VERSION,
     annotate_glob_collisions,
     build_groups,
+    build_override_fragment,
     build_ran_index,
+    cmd_write_override,
+    compute_override,
     correlate_approvals,
     group_key,
     is_compound,
+    load_known_clis,
     load_state,
+    merge_command_fragment,
     merge_state,
     redact_command,
+    save_state,
     split_tokens,
     suggestion_id,
 )
@@ -429,6 +441,312 @@ class TestStateMerge(unittest.TestCase):
             path.write_text(json.dumps(payload), encoding="utf-8")
             state = load_state(path)
         self.assertEqual(state["suggestions"][0]["id"], "x")
+
+
+class TestOverrideFragment(unittest.TestCase):
+    """The minimal `commands.<cli>` spec the writer derives (issue #45)."""
+
+    def test_single_subcommand_is_top_level_safe(self):
+        self.assertEqual(
+            build_override_fragment(["status"]),
+            {"default": "subcommand", "safe_subcommands": ["status"]})
+
+    def test_two_subcommands_nest_under_the_group(self):
+        self.assertEqual(
+            build_override_fragment(["db", "status"]),
+            {"default": "subcommand",
+             "nested_subcommand": {"db": {"safe_subcommands": ["status"]}}})
+
+
+class TestComputeOverride(unittest.TestCase):
+    """Eligibility: only a personal CLI with a subcommand is writable."""
+
+    KNOWN = {"git", "kubectl", "aws"}
+
+    def test_personal_cli_with_subcommand_is_writable(self):
+        override = compute_override("mycli status", self.KNOWN)
+        self.assertTrue(override["writable"])
+        self.assertEqual(override["cli"], "mycli")
+        self.assertEqual(override["label"], "commands.mycli")
+        self.assertEqual(override["fragment"],
+                         {"default": "subcommand", "safe_subcommands": ["status"]})
+
+    def test_personal_cli_nested_label_and_fragment(self):
+        override = compute_override("mytool db status", self.KNOWN)
+        self.assertTrue(override["writable"])
+        self.assertEqual(override["label"],
+                         "commands.mytool.nested_subcommand.db")
+        self.assertEqual(
+            override["fragment"],
+            {"default": "subcommand",
+             "nested_subcommand": {"db": {"safe_subcommands": ["status"]}}})
+
+    def test_known_cli_is_not_writable_and_says_why(self):
+        override = compute_override("git frobnicate", self.KNOWN)
+        self.assertFalse(override["writable"])
+        self.assertIn("bundled rules", override["reason"])
+
+    def test_bare_command_without_subcommand_is_not_writable(self):
+        override = compute_override("mycli", self.KNOWN)
+        self.assertFalse(override["writable"])
+        self.assertIn("no subcommand", override["reason"])
+
+    def test_none_known_clis_disables_writability(self):
+        # Rules unavailable: cannot confirm personal-ness, so never offer to
+        # write (a bundled CLI must not be mistaken for a personal one).
+        override = compute_override("mycli status", None)
+        self.assertFalse(override["writable"])
+
+    def test_load_known_clis_includes_bundled_commands(self):
+        known = load_known_clis(RULES_DIR)
+        self.assertIsNotNone(known)
+        for name in ("git", "gh", "aws", "python3"):
+            self.assertIn(name, known)
+
+
+class TestMergeCommandFragment(unittest.TestCase):
+
+    def test_into_empty_spec(self):
+        merged = merge_command_fragment(
+            {}, {"default": "subcommand", "safe_subcommands": ["status"]})
+        self.assertEqual(
+            merged, {"default": "subcommand", "safe_subcommands": ["status"]})
+
+    def test_unions_without_dropping_existing_subcommands(self):
+        merged = merge_command_fragment(
+            {"default": "subcommand", "safe_subcommands": ["show"]},
+            {"default": "subcommand", "safe_subcommands": ["status"]})
+        self.assertEqual(merged["safe_subcommands"], ["show", "status"])
+
+    def test_is_idempotent(self):
+        existing = {"default": "subcommand", "safe_subcommands": ["status"]}
+        merged = merge_command_fragment(
+            existing, {"default": "subcommand", "safe_subcommands": ["status"]})
+        self.assertEqual(merged["safe_subcommands"], ["status"])
+
+    def test_preserves_unrelated_keys(self):
+        merged = merge_command_fragment(
+            {"default": "subcommand", "unsafe_subcommands": ["apply"]},
+            {"default": "subcommand", "safe_subcommands": ["status"]})
+        self.assertEqual(merged["unsafe_subcommands"], ["apply"])
+        self.assertEqual(merged["safe_subcommands"], ["status"])
+
+    def test_nested_union_preserves_other_groups(self):
+        existing = {
+            "default": "subcommand",
+            "nested_subcommand": {"vol": {"safe_subcommands": ["ls"]}}}
+        merged = merge_command_fragment(
+            existing,
+            {"default": "subcommand",
+             "nested_subcommand": {"db": {"safe_subcommands": ["status"]}}})
+        self.assertEqual(merged["nested_subcommand"]["vol"]["safe_subcommands"],
+                         ["ls"])
+        self.assertEqual(merged["nested_subcommand"]["db"]["safe_subcommands"],
+                         ["status"])
+
+    def test_does_not_mutate_caller(self):
+        existing = {"default": "subcommand", "safe_subcommands": ["show"]}
+        merge_command_fragment(
+            existing, {"default": "subcommand", "safe_subcommands": ["status"]})
+        self.assertEqual(existing["safe_subcommands"], ["show"])
+
+
+class TestBuildGroupsOverride(unittest.TestCase):
+    """friction-unknown suggestions carry the override-routing decision."""
+
+    def test_personal_cli_unknown_is_override_writable(self):
+        records = [_rec("unknown", "mycli status now", _ts(i)) for i in range(3)]
+        suggestions, _ = build_groups(records, {}, 3, 10, known_clis={"git"})
+        unknown = [s for s in suggestions if s["kind"] == KIND_UNKNOWN]
+        self.assertEqual(len(unknown), 1)
+        self.assertTrue(unknown[0]["override"]["writable"])
+        self.assertEqual(unknown[0]["override"]["cli"], "mycli")
+
+    def test_known_cli_unknown_is_not_override_writable(self):
+        records = [_rec("unknown", "kubectl rollout status x", _ts(i))
+                   for i in range(3)]
+        suggestions, _ = build_groups(records, {}, 3, 10,
+                                      known_clis={"kubectl"})
+        unknown = [s for s in suggestions if s["kind"] == KIND_UNKNOWN]
+        self.assertFalse(unknown[0]["override"]["writable"])
+
+    def test_non_unknown_buckets_have_no_override(self):
+        records = [_rec("unsafe", "rm thing", _ts(i)) for i in range(3)]
+        suggestions, _ = build_groups(records, {}, 3, 10, known_clis=set())
+        self.assertNotIn("override", suggestions[0])
+
+
+def _seed_state(state_dir, suggestions):
+    state = {
+        "version": STATE_VERSION, "generated": None, "last_nudged": None,
+        "stats": {}, "suggestions": suggestions,
+    }
+    save_state(Path(state_dir) / STATE_NAME, state)
+
+
+def _write_args(ids, tmp, state_dir, shell_override):
+    return SimpleNamespace(
+        ids=list(ids), state_dir=str(state_dir),
+        shell_override=str(shell_override), rules_dir=str(RULES_DIR),
+        log=str(Path(tmp) / "yolt.log"), ran_log=str(Path(tmp) / "ran.log"))
+
+
+def _run_write(args):
+    """Call cmd_write_override capturing its stdout/stderr so the test log
+    stays clean. Returns (rc, stderr_text)."""
+    out, err = io.StringIO(), io.StringIO()
+    with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+        rc = cmd_write_override(args)
+    return rc, err.getvalue()
+
+
+def _writable_suggestion(prefix, known):
+    sid = suggestion_id(KIND_UNKNOWN, prefix)
+    return {
+        "id": sid, "kind": KIND_UNKNOWN, "prefix": prefix, "fires": 4,
+        "approved": 0, "status": "pending",
+        "settings_pattern": "Bash({}*)".format(prefix),
+        "glob_collisions": [], "examples": ["{} --json".format(prefix)],
+        "override": compute_override(prefix, known),
+    }
+
+
+class TestWriteOverride(unittest.TestCase):
+    """End-to-end `--write-override`: read-modify-write + validate-before-write
+    against the real bundled rules (issue #45)."""
+
+    def test_writes_fragment_and_marks_applied(self):
+        known = load_known_clis(RULES_DIR)
+        with tempfile.TemporaryDirectory() as tmp:
+            state_dir = Path(tmp) / "state"
+            state_dir.mkdir()
+            shell_override = Path(tmp) / "shell.json"
+            sug = _writable_suggestion("mycli status", known)
+            _seed_state(state_dir, [sug])
+
+            rc, _ = _run_write(
+                _write_args([sug["id"]], tmp, state_dir, shell_override))
+
+            self.assertEqual(rc, 0)
+            written = json.loads(shell_override.read_text())
+            self.assertEqual(
+                written["commands"]["mycli"],
+                {"default": "subcommand", "safe_subcommands": ["status"]})
+            state = load_state(state_dir / STATE_NAME)
+            self.assertEqual(state["suggestions"][0]["status"], "applied")
+
+    def test_written_override_loads_and_classifies_via_hook(self):
+        # The whole point: the written file must validate and take effect when
+        # the classifier loads default rules ∪ this override.
+        from grammar_classifier import classify_command  # noqa: E402
+        from rule_classifier import load_shell_rules  # noqa: E402
+        known = load_known_clis(RULES_DIR)
+        with tempfile.TemporaryDirectory() as tmp:
+            state_dir = Path(tmp) / "state"
+            state_dir.mkdir()
+            shell_override = Path(tmp) / "shell.json"
+            sug = _writable_suggestion("mycli status", known)
+            _seed_state(state_dir, [sug])
+            _run_write(
+                _write_args([sug["id"]], tmp, state_dir, shell_override))
+
+            rules = load_shell_rules(RULES_DIR,
+                                     user_overrides_path=shell_override,
+                                     validate=True)
+            decision, _ = classify_command("mycli status", rules)
+            self.assertEqual(decision, "safe")
+            other, _ = classify_command("mycli apply", rules)
+            self.assertEqual(other, "unknown")  # additive: apply still prompts
+
+    def test_preserves_existing_unrelated_commands(self):
+        known = load_known_clis(RULES_DIR)
+        with tempfile.TemporaryDirectory() as tmp:
+            state_dir = Path(tmp) / "state"
+            state_dir.mkdir()
+            shell_override = Path(tmp) / "shell.json"
+            shell_override.write_text(json.dumps(
+                {"commands": {"othertool": {"default": "safe"}}}))
+            sug = _writable_suggestion("mycli status", known)
+            _seed_state(state_dir, [sug])
+
+            _run_write(
+                _write_args([sug["id"]], tmp, state_dir, shell_override))
+
+            written = json.loads(shell_override.read_text())
+            self.assertEqual(written["commands"]["othertool"],
+                             {"default": "safe"})
+            self.assertIn("mycli", written["commands"])
+
+    def test_invalid_preexisting_override_is_refused_untouched(self):
+        known = load_known_clis(RULES_DIR)
+        with tempfile.TemporaryDirectory() as tmp:
+            state_dir = Path(tmp) / "state"
+            state_dir.mkdir()
+            shell_override = Path(tmp) / "shell.json"
+            payload = {"totally_bogus_key": 1}
+            shell_override.write_text(json.dumps(payload))
+            sug = _writable_suggestion("mycli status", known)
+            _seed_state(state_dir, [sug])
+
+            rc, err = _run_write(
+                _write_args([sug["id"]], tmp, state_dir, shell_override))
+
+            self.assertEqual(rc, 1)
+            self.assertIn("fail validation", err)
+            # File untouched and suggestion not marked applied.
+            self.assertEqual(json.loads(shell_override.read_text()), payload)
+            state = load_state(state_dir / STATE_NAME)
+            self.assertEqual(state["suggestions"][0]["status"], "pending")
+
+    def test_not_writable_id_is_refused(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            state_dir = Path(tmp) / "state"
+            state_dir.mkdir()
+            shell_override = Path(tmp) / "shell.json"
+            sug = _writable_suggestion("git frobnicate", {"git"})
+            self.assertFalse(sug["override"]["writable"])
+            _seed_state(state_dir, [sug])
+
+            rc, err = _run_write(
+                _write_args([sug["id"]], tmp, state_dir, shell_override))
+
+            self.assertEqual(rc, 1)
+            self.assertIn("not override-writable", err)
+            self.assertFalse(shell_override.exists())
+
+    def test_unknown_id_is_refused(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            state_dir = Path(tmp) / "state"
+            state_dir.mkdir()
+            shell_override = Path(tmp) / "shell.json"
+            _seed_state(state_dir, [])
+
+            rc, err = _run_write(
+                _write_args(["deadbeef"], tmp, state_dir, shell_override))
+
+            self.assertEqual(rc, 1)
+            self.assertIn("unknown id", err)
+            self.assertFalse(shell_override.exists())
+
+    def test_two_ids_same_cli_union_into_one_spec(self):
+        known = load_known_clis(RULES_DIR)
+        with tempfile.TemporaryDirectory() as tmp:
+            state_dir = Path(tmp) / "state"
+            state_dir.mkdir()
+            shell_override = Path(tmp) / "shell.json"
+            s1 = _writable_suggestion("mycli status", known)
+            s2 = _writable_suggestion("mycli show", known)
+            _seed_state(state_dir, [s1, s2])
+
+            rc, _ = _run_write(
+                _write_args([s1["id"], s2["id"]], tmp, state_dir,
+                            shell_override))
+
+            self.assertEqual(rc, 0)
+            written = json.loads(shell_override.read_text())
+            self.assertEqual(
+                sorted(written["commands"]["mycli"]["safe_subcommands"]),
+                ["show", "status"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Makes the `/yolt:review` reviewer **write** `~/.claude/yolt/shell.json`
overrides directly, instead of leaving every override as a manual
hand-edit. Split out of #44.

Adds a `--write-override <id>` subcommand to `hooks/yolt_review.py` that
writes the one fragment the reviewer can infer safely: a
`safe_subcommands` rule for a **personal CLI** (no bundled rule) that
repeatedly fell through to `unknown` on a subcommand.

```json
{"commands": {"mycli": {"default": "subcommand", "safe_subcommands": ["status"]}}}
```

`mycli status` then auto-allows while every other `mycli` subcommand
still prompts — the assertion is strictly additive and never flips an
existing `unsafe` verdict.

## What it does

- `build_groups` attaches an `override` decision to each
  `friction-unknown` suggestion (`writable` + `cli` + `fragment` +
  `label`, or a `reason`). Writable only for a personal CLI with a
  subcommand token; a `cli group sub` prefix nests under
  `nested_subcommand.<group>.safe_subcommands`.
- `--write-override` **read-modify-writes** the override file (unions the
  new subcommand, never clobbering existing entries), **validates** the
  merged result (bundled rules ∪ override) with `validate_shell_rules`,
  and only then writes via atomic temp+replace. A malformed merge is
  refused, so the writer can never downgrade the hook to
  `rules-validation-error`. Written suggestions are marked applied and
  the doc is regenerated.
- The override merge is extracted from `load_shell_rules` into
  `rule_classifier.merge_shell_overrides`, so the writer's validation
  runs the **exact** merge the hook performs (one source of truth).
- `review.md` / `README` document the route; the review doc now prints
  the concrete `--write-override` command and fragment.

## Decided scope (issue's "inference depth")

- **Personal-CLI only.** A `friction-unknown` on a *bundled* CLI is a
  rules gap worth an upstream issue, not a local shadow that freezes a
  stale copy of the bundled spec.
- **`safe_subcommands` only.** `friction-unsafe`, flag-conditional, and
  verb-class overrides stay human-authored — auto-flipping `unsafe`→`safe`
  is a security-regression vector the issue says must stay
  human-confirmed.

## Tests

`tests/test_yolt_review.py`: override eligibility (personal / nested /
bundled / bare / rules-unavailable), fragment shapes, merge
union/idempotence/no-clobber, and end-to-end `--write-override` including
validate-before-write refusal (file untouched), unknown / not-writable
id refusal, multi-id union, and a round-trip that loads the written
override through the real classifier. Full suite green under a clean
HOME (454 tests).

Closes #45
