### PR TITLE
Detect SQL function side effects in keyword-only scanner (#26)

### DIFF
--- a/hooks/rule_classifier.py
+++ b/hooks/rule_classifier.py
@@ -57,13 +57,21 @@ BASH_PATTERN_RE = re.compile(r"^Bash\((.*)\)$")
 # keyword. This treats `EXPLAIN DELETE FROM t` as unsafe (the DELETE
 # keyword is still present even though it would not execute); we accept
 # that false-positive to keep the rule simple.
+#
+# Keyword-only scanning misses side-effecting *functions* called from
+# inside an otherwise read-looking statement (`SELECT pg_terminate_backend(...)`,
+# `SELECT LOAD_FILE('/etc/passwd')`, `SELECT load_extension('evil.so')`).
+# After the keyword pass we therefore scan `IDENT(` function calls against
+# per-dialect deny lists, plus MySQL `INTO OUTFILE/DUMPFILE` file-write
+# tokens. Dialect is taken from the CLI name (psql->postgres, mysql/mariadb
+# ->mysql, sqlite3->sqlite, duckdb->duckdb). See issue #26.
 
 SQL_MUTATING_KEYWORDS = frozenset({
     "INSERT", "UPDATE", "DELETE", "DROP", "CREATE", "ALTER",
     "TRUNCATE", "REPLACE", "MERGE", "GRANT", "REVOKE",
     "VACUUM", "REINDEX", "ATTACH", "DETACH",
     "COMMIT", "ROLLBACK", "BEGIN", "SAVEPOINT", "RELEASE",
-    "CALL", "EXEC", "EXECUTE",
+    "CALL", "EXEC", "EXECUTE", "DO",
     "COPY", "LOAD", "IMPORT",
     "LOCK", "UNLOCK",
     "SET", "RESET",
@@ -107,6 +115,83 @@ SQLITE_DOT_UNSAFE = frozenset({
     ".archive", ".clone", ".log", ".recover",
 })
 
+# SQL dialect per CLI name. mysql and mariadb share a dialect.
+SQL_DIALECT_BY_CLI = {
+    "psql": "postgres",
+    "mysql": "mysql",
+    "mariadb": "mysql",
+    "sqlite3": "sqlite",
+    "duckdb": "duckdb",
+}
+
+# Side-effecting functions that can be called from inside a SELECT and so
+# slip past the keyword + safe-first-keyword check. Names are lowercase for
+# case-insensitive matching. See issue #26 for the source enumeration.
+SQL_SIDE_EFFECT_FUNCTIONS = {
+    "postgres": frozenset({
+        "pg_terminate_backend", "pg_cancel_backend", "pg_promote",
+        "pg_reload_conf", "pg_rotate_logfile",
+        "nextval", "setval",
+        "lo_unlink", "lo_export", "lo_import",
+        "pg_read_file", "pg_read_binary_file", "pg_ls_dir",
+        "dblink_exec", "pg_logical_emit_message",
+        "pg_advisory_lock", "pg_advisory_xact_lock",
+        "pg_sleep", "pg_sleep_for", "pg_sleep_until",
+        "set_config",
+    }),
+    "mysql": frozenset({
+        "load_file", "get_lock", "sleep", "benchmark",
+    }),
+    "sqlite": frozenset({
+        "load_extension", "randomblob",
+    }),
+    "duckdb": frozenset(),
+}
+
+# Non-function tokens that still mutate/exfil, scanned per dialect. MySQL
+# `SELECT ... INTO OUTFILE/DUMPFILE '...'` writes a file with no function
+# call and no mutating keyword.
+SQL_DIALECT_DENY_TOKENS = {
+    "mysql": frozenset({"OUTFILE", "DUMPFILE"}),
+}
+
+# Postgres `pg_*` system functions are a mostly-side-effecting set, so any
+# pg_-prefixed call is denied unless it is a known read-only one (exact name
+# or a read-only prefix such as `pg_get_*`). See issue #26.
+PG_READONLY_FUNCTIONS = frozenset({
+    "pg_database_size", "pg_relation_size", "pg_total_relation_size",
+    "pg_typeof", "pg_size_pretty",
+})
+PG_READONLY_PREFIXES = ("pg_get_",)
+
+# Function-call identifier immediately followed by `(` (optional whitespace).
+_SQL_FUNC_RE = re.compile(r"([A-Za-z_][A-Za-z0-9_]*)\s*\(")
+
+
+def _classify_sql_functions(cmd_name, dialect, stripped):
+    """Scan stripped+uppercased SQL for side-effecting function calls.
+    Returns a (decision, reason) tuple when a denied function is found,
+    else None. `stripped` has had comments/literals removed already."""
+    if dialect is None:
+        return None
+    deny = SQL_SIDE_EFFECT_FUNCTIONS.get(dialect, frozenset())
+    for m in _SQL_FUNC_RE.finditer(stripped):
+        ident = m.group(1).lower()
+        if ident in deny:
+            retval = (DECISION_UNSAFE,
+                      "{}: side-effecting function {}()".format(cmd_name, ident))
+            return retval
+        if dialect == "postgres" and ident.startswith("pg_"):
+            if ident in PG_READONLY_FUNCTIONS:
+                continue
+            if any(ident.startswith(p) for p in PG_READONLY_PREFIXES):
+                continue
+            retval = (DECISION_UNSAFE,
+                      "{}: postgres system function {}() not read-only "
+                      "allowlisted".format(cmd_name, ident))
+            return retval
+    return None
+
 
 def classify_sql_text(cmd_name, sql):
     """Return (decision, reason) for a single SQL string passed to a
@@ -134,6 +219,12 @@ def classify_sql_text(cmd_name, sql):
         return retval
 
     stripped = _SQL_STRIP_RE.sub(" ", sql).upper()
+    dialect = SQL_DIALECT_BY_CLI.get(cmd_name)
+    deny_tokens = (
+        SQL_DIALECT_DENY_TOKENS.get(dialect, frozenset())
+        if dialect is not None
+        else frozenset()
+    )
 
     first_word = None
     for m in _SQL_WORD_RE.finditer(stripped):
@@ -144,6 +235,14 @@ def classify_sql_text(cmd_name, sql):
             retval = (DECISION_UNSAFE,
                       "{}: SQL contains mutating keyword {}".format(cmd_name, word))
             return retval
+        if word in deny_tokens:
+            retval = (DECISION_UNSAFE,
+                      "{}: SQL writes file via {}".format(cmd_name, word))
+            return retval
+
+    func_decision = _classify_sql_functions(cmd_name, dialect, stripped)
+    if func_decision is not None:
+        return func_decision
 
     if first_word == "PRAGMA":
         if "=" in stripped:

--- a/hooks/rule_classifier.py
+++ b/hooks/rule_classifier.py
@@ -92,6 +92,7 @@ _SQL_STRIP_RE = re.compile(
     | '(?:[^']|'')*'       # 'single' quoted string ('' is escape)
     | \"(?:[^\"]|\"\")*\"  # "double" quoted ident/string
     | `[^`]*`              # `backtick` ident (MySQL)
+    | \$(\w*)\$.*?\$\1\$   # $$...$$ / $tag$...$tag$ dollar-quoted string (Postgres)
     """,
     re.DOTALL | re.VERBOSE,
 )
@@ -148,12 +149,10 @@ SQL_SIDE_EFFECT_FUNCTIONS = {
     "duckdb": frozenset(),
 }
 
-# Non-function tokens that still mutate/exfil, scanned per dialect. MySQL
-# `SELECT ... INTO OUTFILE/DUMPFILE '...'` writes a file with no function
-# call and no mutating keyword.
-SQL_DIALECT_DENY_TOKENS = {
-    "mysql": frozenset({"OUTFILE", "DUMPFILE"}),
-}
+# MySQL `SELECT ... INTO OUTFILE/DUMPFILE '...'` writes a file with no
+# function call and no mutating keyword. Require the `INTO` context so a
+# plain read of a column/table named `outfile`/`dumpfile` is not flagged.
+_MYSQL_INTO_OUTFILE_RE = re.compile(r"\bINTO\s+(?:OUTFILE|DUMPFILE)\b")
 
 # Postgres `pg_*` system functions are a mostly-side-effecting set, so any
 # pg_-prefixed call is denied unless it is a known read-only one (exact name
@@ -220,11 +219,6 @@ def classify_sql_text(cmd_name, sql):
 
     stripped = _SQL_STRIP_RE.sub(" ", sql).upper()
     dialect = SQL_DIALECT_BY_CLI.get(cmd_name)
-    deny_tokens = (
-        SQL_DIALECT_DENY_TOKENS.get(dialect, frozenset())
-        if dialect is not None
-        else frozenset()
-    )
 
     first_word = None
     for m in _SQL_WORD_RE.finditer(stripped):
@@ -235,10 +229,11 @@ def classify_sql_text(cmd_name, sql):
             retval = (DECISION_UNSAFE,
                       "{}: SQL contains mutating keyword {}".format(cmd_name, word))
             return retval
-        if word in deny_tokens:
-            retval = (DECISION_UNSAFE,
-                      "{}: SQL writes file via {}".format(cmd_name, word))
-            return retval
+
+    if dialect == "mysql" and _MYSQL_INTO_OUTFILE_RE.search(stripped):
+        retval = (DECISION_UNSAFE,
+                  "{}: SQL writes file via INTO OUTFILE/DUMPFILE".format(cmd_name))
+        return retval
 
     func_decision = _classify_sql_functions(cmd_name, dialect, stripped)
     if func_decision is not None:

--- a/tests/test_rule_classifier.py
+++ b/tests/test_rule_classifier.py
@@ -664,6 +664,28 @@ class TestSqlFunctionSideEffects(unittest.TestCase):
             "psql", "SELECT name FROM users WHERE note = 'pg_sleep(9)'")
         self.assertEqual(d, DECISION_SAFE)
 
+    def test_function_name_in_dollar_quote_stays_safe(self):
+        # Postgres dollar-quoted string literal is stripped before scanning.
+        d, _ = classify_sql_text("psql", "SELECT $$pg_sleep(9)$$")
+        self.assertEqual(d, DECISION_SAFE)
+
+    def test_function_name_in_tagged_dollar_quote_stays_safe(self):
+        d, _ = classify_sql_text("psql", "SELECT $tag$pg_sleep(9)$tag$")
+        self.assertEqual(d, DECISION_SAFE)
+
+    def test_outfile_column_name_safe(self):
+        # Bare OUTFILE/DUMPFILE without INTO context is a plain identifier.
+        d, _ = classify_sql_text("mysql", "SELECT outfile FROM t")
+        self.assertEqual(d, DECISION_SAFE)
+
+    def test_dumpfile_column_name_safe(self):
+        d, _ = classify_sql_text("mysql", "SELECT dumpfile FROM t")
+        self.assertEqual(d, DECISION_SAFE)
+
+    def test_from_outfile_table_name_safe(self):
+        d, _ = classify_sql_text("mysql", "SELECT * FROM outfile")
+        self.assertEqual(d, DECISION_SAFE)
+
     def test_plain_select_still_safe(self):
         d, _ = classify_sql_text("psql", "SELECT * FROM users WHERE id = 1")
         self.assertEqual(d, DECISION_SAFE)

--- a/tests/test_rule_classifier.py
+++ b/tests/test_rule_classifier.py
@@ -537,6 +537,143 @@ class TestClassifySqlText(unittest.TestCase):
         self.assertEqual(d, DECISION_SAFE)
 
 
+class TestSqlFunctionSideEffects(unittest.TestCase):
+    """Issue #26: side-effecting functions called from inside a read-looking
+    statement must not classify safe just because the first keyword is
+    SELECT/WITH/etc."""
+
+    def test_pg_terminate_backend_unsafe(self):
+        d, _ = classify_sql_text("psql", "SELECT pg_terminate_backend(12345)")
+        self.assertEqual(d, DECISION_UNSAFE)
+
+    def test_pg_cancel_backend_unsafe(self):
+        d, _ = classify_sql_text("psql", "SELECT pg_cancel_backend(12345)")
+        self.assertEqual(d, DECISION_UNSAFE)
+
+    def test_pg_read_file_unsafe(self):
+        d, _ = classify_sql_text("psql", "SELECT pg_read_file('/etc/passwd')")
+        self.assertEqual(d, DECISION_UNSAFE)
+
+    def test_pg_sleep_unsafe(self):
+        d, _ = classify_sql_text("psql", "SELECT pg_sleep(1e9)")
+        self.assertEqual(d, DECISION_UNSAFE)
+
+    def test_nextval_unsafe(self):
+        d, _ = classify_sql_text("psql", "SELECT nextval('s')")
+        self.assertEqual(d, DECISION_UNSAFE)
+
+    def test_setval_unsafe(self):
+        d, _ = classify_sql_text("psql", "SELECT setval('s', 1)")
+        self.assertEqual(d, DECISION_UNSAFE)
+
+    def test_dblink_exec_unsafe(self):
+        d, _ = classify_sql_text(
+            "psql", "SELECT dblink_exec('conn', 'DROP TABLE t')")
+        self.assertEqual(d, DECISION_UNSAFE)
+
+    def test_set_config_unsafe(self):
+        d, _ = classify_sql_text(
+            "psql", "SELECT set_config('search_path', 'evil', false)")
+        self.assertEqual(d, DECISION_UNSAFE)
+
+    def test_pg_unknown_system_function_unsafe(self):
+        # pg_* prefix is denied unless on the read-only allowlist.
+        d, _ = classify_sql_text("psql", "SELECT pg_switch_wal()")
+        self.assertEqual(d, DECISION_UNSAFE)
+
+    def test_pg_database_size_safe(self):
+        d, _ = classify_sql_text("psql", "SELECT pg_database_size('db')")
+        self.assertEqual(d, DECISION_SAFE)
+
+    def test_pg_relation_size_safe(self):
+        d, _ = classify_sql_text("psql", "SELECT pg_relation_size('t')")
+        self.assertEqual(d, DECISION_SAFE)
+
+    def test_pg_get_prefix_safe(self):
+        d, _ = classify_sql_text("psql", "SELECT pg_get_constraintdef(1)")
+        self.assertEqual(d, DECISION_SAFE)
+
+    def test_pg_typeof_safe(self):
+        d, _ = classify_sql_text("psql", "SELECT pg_typeof(1)")
+        self.assertEqual(d, DECISION_SAFE)
+
+    def test_do_block_unsafe(self):
+        # DO is now a mutating keyword; the anonymous block can side-effect.
+        d, _ = classify_sql_text(
+            "psql",
+            "DO $$ BEGIN PERFORM pg_terminate_backend(0); END $$",
+        )
+        self.assertEqual(d, DECISION_UNSAFE)
+
+    def test_mysql_get_lock_unsafe(self):
+        d, _ = classify_sql_text("mysql", "SELECT GET_LOCK('x', 9999)")
+        self.assertEqual(d, DECISION_UNSAFE)
+
+    def test_mysql_sleep_unsafe(self):
+        d, _ = classify_sql_text("mysql", "SELECT SLEEP(1e9)")
+        self.assertEqual(d, DECISION_UNSAFE)
+
+    def test_mysql_benchmark_unsafe(self):
+        d, _ = classify_sql_text("mysql", "SELECT BENCHMARK(1e9, MD5('x'))")
+        self.assertEqual(d, DECISION_UNSAFE)
+
+    def test_mysql_load_file_unsafe(self):
+        d, _ = classify_sql_text("mysql", "SELECT LOAD_FILE('/etc/passwd')")
+        self.assertEqual(d, DECISION_UNSAFE)
+
+    def test_mysql_into_outfile_unsafe(self):
+        d, _ = classify_sql_text(
+            "mysql", "SELECT * FROM t INTO OUTFILE '/tmp/x'")
+        self.assertEqual(d, DECISION_UNSAFE)
+
+    def test_mysql_into_dumpfile_unsafe(self):
+        d, _ = classify_sql_text(
+            "mysql", "SELECT * FROM t INTO DUMPFILE '/tmp/x'")
+        self.assertEqual(d, DECISION_UNSAFE)
+
+    def test_mariadb_sleep_unsafe(self):
+        d, _ = classify_sql_text("mariadb", "SELECT SLEEP(99)")
+        self.assertEqual(d, DECISION_UNSAFE)
+
+    def test_sqlite_load_extension_unsafe(self):
+        d, _ = classify_sql_text(
+            "sqlite3", "SELECT load_extension('/path/to/evil.so')")
+        self.assertEqual(d, DECISION_UNSAFE)
+
+    def test_sqlite_randomblob_unsafe(self):
+        d, _ = classify_sql_text("sqlite3", "SELECT randomblob(1099511627776)")
+        self.assertEqual(d, DECISION_UNSAFE)
+
+    def test_explain_analyze_insert_unsafe(self):
+        # Postgres EXPLAIN ANALYZE executes the wrapped DML.
+        d, _ = classify_sql_text(
+            "psql", "EXPLAIN ANALYZE INSERT INTO t VALUES (1)")
+        self.assertEqual(d, DECISION_UNSAFE)
+
+    def test_with_cte_delete_returning_unsafe(self):
+        # DML in a CTE; scanner is not gated on the first keyword only.
+        d, _ = classify_sql_text(
+            "psql",
+            "WITH d AS (DELETE FROM t RETURNING *) SELECT * FROM d",
+        )
+        self.assertEqual(d, DECISION_UNSAFE)
+
+    def test_function_name_in_literal_stays_safe(self):
+        # A denied function name inside a string literal is stripped first.
+        d, _ = classify_sql_text(
+            "psql", "SELECT name FROM users WHERE note = 'pg_sleep(9)'")
+        self.assertEqual(d, DECISION_SAFE)
+
+    def test_plain_select_still_safe(self):
+        d, _ = classify_sql_text("psql", "SELECT * FROM users WHERE id = 1")
+        self.assertEqual(d, DECISION_SAFE)
+
+    def test_count_function_safe(self):
+        # Ordinary aggregate functions are not on any deny list.
+        d, _ = classify_sql_text("mysql", "SELECT COUNT(*) FROM t")
+        self.assertEqual(d, DECISION_SAFE)
+
+
 class TestParseSqlCliArgv(unittest.TestCase):
     def test_sqlite3_positional_sql(self):
         spec = {"sql_positional_index": 1}


### PR DESCRIPTION
## Summary

Closes #26.

The SQL CLI scanner stripped comments/literals, then keyword-matched against
`INSERT/UPDATE/DELETE/DROP/...`. A leading `SELECT/WITH/EXPLAIN/SHOW`
classified the statement safe — which missed side-effecting **functions**
called from inside a read-looking statement.

## What changed

`hooks/rule_classifier.py` — after the existing keyword pass in
`classify_sql_text`, scan `IDENT(` function calls against per-dialect deny
lists (dialect dispatched on the CLI name):

- **postgres** (`psql`): `pg_terminate_backend`, `pg_cancel_backend`,
  `pg_promote`, `pg_reload_conf`, `pg_read_file`, `pg_ls_dir`, `nextval`,
  `setval`, `lo_unlink`/`lo_export`/`lo_import`, `dblink_exec`,
  `pg_logical_emit_message`, `pg_advisory_lock`, `pg_sleep`, `set_config`, …
  plus a `pg_*` prefix deny with a read-only allowlist
  (`pg_database_size`, `pg_relation_size`, `pg_total_relation_size`,
  `pg_typeof`, `pg_get_*`, `pg_size_pretty`).
- **mysql / mariadb**: `load_file`, `get_lock`, `sleep`, `benchmark`, and the
  non-function `INTO OUTFILE` / `INTO DUMPFILE` file-write tokens.
- **sqlite3**: `load_extension`, `randomblob`.

Also added `DO` to `SQL_MUTATING_KEYWORDS` so anonymous procedure blocks
(`DO $$ ... $$`) no longer bypass the keyword check.

`EXPLAIN ANALYZE <dml>` and `WITH ... AS (DELETE ... RETURNING) SELECT` were
already caught by the scan-anywhere keyword pass; added regression tests.

Function names inside string literals stay safe (literals are stripped before
scanning).

## Tests

Added `TestSqlFunctionSideEffects` (30 cases) in
`tests/test_rule_classifier.py`. New SQL tests pass.

Note: the local suite shows 16 pre-existing failures under Python 3.14
(adversarial `find -exec` / `gh api` / `python3 -c` / import-alias and hook
tests). They are identical on clean `master` (verified by diffing the failure
set) — not introduced by this change; CI runs 3.10-3.12.
