### PR TITLE
Recurse SQL scanner into cloud-CLI SQL flags (#29)

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,37 @@ are classified separately by name — `.tables` / `.schema` / `.headers`
 are safe; `.import` / `.load` / `.read` / `.shell` / `.backup` are
 unsafe.
 
+### SQL carried in cloud-CLI flags
+
+Several AWS CLIs take a SQL string as a flag value (`aws athena
+start-query-execution --query-string`, `aws rds-data execute-statement
+--sql`, `aws timestream-query query --query-string`, `aws redshift-data
+execute-statement --sql`). The `aws` rule names these in a
+`sql_payload_flags` registry keyed by `"<service> <operation>"`; each
+entry gives the SQL-carrying `flag` and a `dialect`. When the operation
+matches, the flag value is pulled and run through the same SQL scanner
+described above.
+
+The verb decision is a **floor**, so payload scanning never weakens a
+mutating operation on its own:
+
+- A write verb (`start-*`, `execute-*`) stays `unsafe` regardless of
+  payload. Reading the SQL only helps once the user has explicitly
+  marked the operation safe — e.g. an `extra_safe_patterns` override
+  for `start-query-execution`. After that, the payload governs:
+  read-only `SELECT` → `safe`, destructive SQL → `unsafe`, unclassified
+  SQL → `unknown`. This is the point of the registry: an override that
+  used to blanket-allow every query now keeps destructive ones flagged.
+- `aws timestream-query query` matches no verb pattern (so it was
+  `unknown` and prompted every time); its payload now refines it to
+  `safe` / `unsafe` out of the box.
+
+`dialect` feeds the per-dialect function-side-effect scanner (see issue
+#26). `presto` / `timestream` / `redshift` / `varies` have no function
+deny-set yet, so only the dialect-agnostic keyword scan applies to them
+today; the field is recorded so adding a deny-set later lights up
+function detection for those services with no further wiring.
+
 ## Python rules (interpreter delegate)
 
 When the grammar walker hands a Python source body to the analyzer

--- a/hooks/rule_classifier.py
+++ b/hooks/rule_classifier.py
@@ -1190,9 +1190,15 @@ class RuleClassifier:
         flag = entry.get("flag")
         sql = extract_flag_value(cmd_args, flag)
         if sql is None:
-            retval = (verb_decision,
-                      "{}; {}: no {} value to scan".format(
-                          verb_reason, label, flag))
+            # The operation is registered as SQL-bearing but the payload is
+            # not on the expected flag — absent, interactive, or supplied via
+            # an alternate input form such as `--cli-input-json`. The scanner
+            # cannot inspect it, so a verb-safe override must NOT blanket-allow
+            # the call; downgrade to unknown so Claude Code prompts. (A verb
+            # already classified unsafe returned above.)
+            retval = (DECISION_UNKNOWN,
+                      "{}: registered SQL op but no {} payload to scan; "
+                      "not certifying safe".format(label, flag))
             return retval
 
         dialect = entry.get("dialect")

--- a/hooks/rule_classifier.py
+++ b/hooks/rule_classifier.py
@@ -192,10 +192,16 @@ def _classify_sql_functions(cmd_name, dialect, stripped):
     return None
 
 
-def classify_sql_text(cmd_name, sql):
+def classify_sql_text(cmd_name, sql, dialect=None):
     """Return (decision, reason) for a single SQL string passed to a
     SQL CLI. Handles sqlite3 dot-commands too — they're not SQL but they
-    arrive through the same channel (positional / -cmd / -e)."""
+    arrive through the same channel (positional / -cmd / -e).
+
+    `dialect` overrides the CLI→dialect lookup. SQL CLIs leave it None and
+    the dialect is derived from `cmd_name`; payload scanning of cloud-API
+    flags (see `classify_aws`) passes it explicitly because the synthetic
+    `cmd_name` (e.g. "aws athena start-query-execution") is not a known
+    SQL CLI."""
     sql = sql.strip()
     if not sql:
         retval = (DECISION_SAFE, "{}: empty SQL".format(cmd_name))
@@ -218,7 +224,8 @@ def classify_sql_text(cmd_name, sql):
         return retval
 
     stripped = _SQL_STRIP_RE.sub(" ", sql).upper()
-    dialect = SQL_DIALECT_BY_CLI.get(cmd_name)
+    if dialect is None:
+        dialect = SQL_DIALECT_BY_CLI.get(cmd_name)
 
     first_word = None
     for m in _SQL_WORD_RE.finditer(stripped):
@@ -629,7 +636,10 @@ _ALLOWED_COMMAND_KEYS = frozenset({
     "service_overrides",
     "safe_operation_patterns", "unsafe_operation_patterns",
     "sql_flags", "sql_file_flags", "sql_positional_index",
+    "sql_payload_flags",
 })
+
+_ALLOWED_SQL_PAYLOAD_FLAG_KEYS = frozenset({"flag", "dialect"})
 
 _ALLOWED_EMPTY_DECISIONS = frozenset({"safe", "unsafe"})
 
@@ -769,6 +779,23 @@ def _validate_command_spec(path, spec, errors):
                         .format(path, svc, key)
                     )
 
+    payload_flags = spec.get("sql_payload_flags", {})
+    if isinstance(payload_flags, dict):
+        for op_key, entry in payload_flags.items():
+            if op_key.startswith("_"):
+                continue
+            entry_path = "{}.sql_payload_flags.{}".format(path, op_key)
+            if not isinstance(entry, dict):
+                errors.append("{}: must be a dict".format(entry_path))
+                continue
+            for key in entry:
+                if key not in _ALLOWED_SQL_PAYLOAD_FLAG_KEYS:
+                    errors.append(
+                        "{}: unknown key '{}'".format(entry_path, key)
+                    )
+            if not entry.get("flag"):
+                errors.append("{}: missing 'flag'".format(entry_path))
+
 
 def parse_aws_positionals(cmd_args):
     """Walk aws CLI args skipping flags. Return (service, operation, trailing)."""
@@ -804,6 +831,26 @@ def parse_aws_positionals(cmd_args):
         i += 1
 
     return (service, operation, trailing)
+
+
+def extract_flag_value(cmd_args, flag):
+    """Return the value passed to `flag` in cmd_args, or None if the flag is
+    absent (or present with no following value). Handles both `--flag value`
+    and `--flag=value` forms."""
+    retval = None
+    eq_prefix = flag + "="
+    i = 0
+    while i < len(cmd_args):
+        tok = cmd_args[i]
+        if tok == flag:
+            if i + 1 < len(cmd_args):
+                retval = cmd_args[i + 1]
+            break
+        if tok.startswith(eq_prefix):
+            retval = tok[len(eq_prefix):]
+            break
+        i += 1
+    return retval
 
 
 class RuleClassifier:
@@ -1109,6 +1156,55 @@ class RuleClassifier:
         if operation is None:
             return (DECISION_UNKNOWN, "aws {}: no operation".format(service))
 
+        verb_decision, verb_reason = self._classify_aws_verb(
+            service, operation, spec
+        )
+
+        payload_flags = spec.get("sql_payload_flags", {})
+        entry = payload_flags.get("{} {}".format(service, operation))
+        if entry is None:
+            return (verb_decision, verb_reason)
+
+        retval = self._scan_aws_sql_payload(
+            cmd_args, service, operation, entry, verb_decision, verb_reason
+        )
+        return retval
+
+    def _scan_aws_sql_payload(self, cmd_args, service, operation, entry,
+                              verb_decision, verb_reason):
+        """Refine an aws decision by scanning the SQL string the operation
+        carries in a flag (e.g. athena `--query-string`, rds-data `--sql`).
+
+        A write verb is a hard floor: `start-*` / `execute-*` stay unsafe
+        regardless of payload, so payload scanning cannot weaken an
+        un-overridden mutating operation. Below that floor the SQL governs,
+        which (a) refines an unknown verb such as `timestream-query query`
+        to safe/unsafe by its payload, and (b) lets a user who has marked
+        the operation safe (via an `extra_safe_patterns` override) still get
+        destructive SQL flagged instead of blanket-allowed."""
+        label = "aws {} {}".format(service, operation)
+        if verb_decision == DECISION_UNSAFE:
+            retval = (verb_decision, verb_reason)
+            return retval
+
+        flag = entry.get("flag")
+        sql = extract_flag_value(cmd_args, flag)
+        if sql is None:
+            retval = (verb_decision,
+                      "{}; {}: no {} value to scan".format(
+                          verb_reason, label, flag))
+            return retval
+
+        dialect = entry.get("dialect")
+        payload_decision, payload_reason = classify_sql_text(
+            label, sql, dialect=dialect
+        )
+        retval = (payload_decision,
+                  "{} (payload scan; verb: {})".format(
+                      payload_reason, verb_decision))
+        return retval
+
+    def _classify_aws_verb(self, service, operation, spec):
         service_overrides = spec.get("service_overrides", {})
         per_service = service_overrides.get(service, {})
 

--- a/rules/shell.json
+++ b/rules/shell.json
@@ -538,6 +538,13 @@
           "extra_safe_patterns": ["filter-log-events", "start-query", "get-query-results", "stop-query", "tail"],
           "_note": "Logs service has some 'start-*' operations that are actually read-only queries (start-query). Explicit overrides."
         }
+      },
+      "sql_payload_flags": {
+        "athena start-query-execution":     {"flag": "--query-string", "dialect": "presto"},
+        "rds-data execute-statement":       {"flag": "--sql",          "dialect": "varies"},
+        "timestream-query query":           {"flag": "--query-string", "dialect": "timestream"},
+        "redshift-data execute-statement":  {"flag": "--sql",          "dialect": "redshift"},
+        "_note": "(service operation) -> SQL-carrying flag. The verb decision is a floor: start-*/execute-* stay unsafe unless the user marks the op safe via an override, after which the SQL payload governs (read-only SELECT -> safe, destructive -> unsafe). 'timestream-query query' (verb -> unknown) is refined to safe/unsafe by its payload out of the box. dialect feeds the per-dialect function scanner (issue #26); presto/timestream/redshift/varies have no function set yet, so only the dialect-agnostic keyword scan applies to them today."
       }
     },
 

--- a/tests/test_grammar_classifier.py
+++ b/tests/test_grammar_classifier.py
@@ -86,6 +86,14 @@ class TestClassifyScenarios(unittest.TestCase):
             DECISION_SAFE,
         )
 
+    def test_aws_timestream_query_select_is_payload_safe(self):
+        # Issue #29: verb `query` matches no pattern (-> unknown); the SQL
+        # payload refines it to safe.
+        self.assertDecision(
+            'aws timestream-query query --query-string "SELECT * FROM db.t"',
+            DECISION_SAFE,
+        )
+
     def test_compound_for_loop_all_reads(self):
         self.assertDecision(
             'for svc in $(aws ecs list-services --cluster X); do '
@@ -183,6 +191,21 @@ class TestClassifyScenarios(unittest.TestCase):
 
     def test_aws_s3_rm_unsafe(self):
         self.assertDecision("aws s3 rm s3://bucket/key", DECISION_UNSAFE)
+
+    def test_aws_timestream_query_delete_is_payload_unsafe(self):
+        # Issue #29: the SQL payload escalates an otherwise-unknown verb.
+        self.assertDecision(
+            'aws timestream-query query --query-string "DELETE FROM db.t"',
+            DECISION_UNSAFE,
+        )
+
+    def test_aws_athena_start_query_select_stays_unsafe_floor(self):
+        # Issue #29: start-* is a write verb; with no user override the SQL
+        # payload cannot weaken it, so a read-only query still asks.
+        self.assertDecision(
+            'aws athena start-query-execution --query-string "SELECT 1"',
+            DECISION_UNSAFE,
+        )
 
     def test_gh_api_post_unsafe(self):
         self.assertDecision(

--- a/tests/test_rule_classifier.py
+++ b/tests/test_rule_classifier.py
@@ -400,6 +400,26 @@ class TestAwsSqlPayloadFlags(unittest.TestCase):
         )
         self.assertEqual(d, DECISION_UNKNOWN)
 
+    def test_athena_missing_flag_with_safe_override_is_unknown(self):
+        # A registered SQL op with a safe override but no --query-string must
+        # NOT inherit the blanket-safe verb decision: the payload is
+        # unscannable, so it downgrades to unknown rather than safe.
+        d, _ = self.clf_override.classify_aws(
+            ["athena", "start-query-execution"],
+            self.spec_override,
+        )
+        self.assertEqual(d, DECISION_UNKNOWN)
+
+    def test_athena_cli_input_json_with_safe_override_is_unknown(self):
+        # Alternate input form (--cli-input-json) carries the SQL off the
+        # scanned flag; a safe override must not blanket-allow it.
+        d, _ = self.clf_override.classify_aws(
+            ["athena", "start-query-execution",
+             "--cli-input-json", '{"QueryString": "DROP TABLE t"}'],
+            self.spec_override,
+        )
+        self.assertEqual(d, DECISION_UNKNOWN)
+
     def test_unregistered_operation_untouched(self):
         # An aws op with no registry entry keeps its plain verb decision.
         d, _ = self.clf.classify_aws(

--- a/tests/test_rule_classifier.py
+++ b/tests/test_rule_classifier.py
@@ -23,9 +23,11 @@ from rule_classifier import (  # noqa: E402
     DECISION_SAFE,
     DECISION_UNKNOWN,
     DECISION_UNSAFE,
+    RuleClassifier,
     aggregate_decisions,
     check_unsafe_flags,
     classify_sql_text,
+    extract_flag_value,
     load_allow_patterns,
     load_shell_rules,
     match_allow_patterns,
@@ -286,6 +288,124 @@ class TestParseAwsPositionals(unittest.TestCase):
     def test_no_cli_pager_is_valueless(self):
         svc, op, _ = parse_aws_positionals(["--no-cli-pager", "s3", "ls"])
         self.assertEqual((svc, op), ("s3", "ls"))
+
+
+class TestExtractFlagValue(unittest.TestCase):
+    def test_space_form(self):
+        v = extract_flag_value(["--sql", "SELECT 1", "--db", "x"], "--sql")
+        self.assertEqual(v, "SELECT 1")
+
+    def test_equals_form(self):
+        v = extract_flag_value(["--query-string=SELECT 1"], "--query-string")
+        self.assertEqual(v, "SELECT 1")
+
+    def test_equals_form_value_with_equals(self):
+        v = extract_flag_value(["--sql=SET x = 1"], "--sql")
+        self.assertEqual(v, "SET x = 1")
+
+    def test_absent(self):
+        self.assertIsNone(extract_flag_value(["--db", "x"], "--sql"))
+
+    def test_flag_last_token_no_value(self):
+        self.assertIsNone(extract_flag_value(["--db", "x", "--sql"], "--sql"))
+
+
+class TestAwsSqlPayloadFlags(unittest.TestCase):
+    """Payload scanning of SQL-carrying aws flags (issue #29). The verb
+    decision is a floor: start-*/execute-* stay unsafe unless an override
+    marks the op safe, after which the SQL governs. timestream-query query
+    (verb -> unknown) is refined by its payload out of the box."""
+
+    @classmethod
+    def setUpClass(cls):
+        rules = load_shell_rules(REPO_ROOT / "rules")
+        cls.clf = RuleClassifier(rules)
+        cls.spec = rules["commands"]["aws"]
+
+        # A second classifier whose rules mark athena start-query-execution
+        # safe (the override the issue's narrowing use case relies on).
+        ov_rules = json.loads(json.dumps(rules))
+        ov_aws = ov_rules["commands"]["aws"]
+        ov_aws["service_overrides"].setdefault("athena", {})[
+            "extra_safe_patterns"
+        ] = ["start-query-execution"]
+        cls.clf_override = RuleClassifier(ov_rules)
+        cls.spec_override = ov_aws
+
+    def test_timestream_select_safe(self):
+        d, _ = self.clf.classify_aws(
+            ["timestream-query", "query", "--query-string", "SELECT * FROM t"],
+            self.spec,
+        )
+        self.assertEqual(d, DECISION_SAFE)
+
+    def test_timestream_delete_unsafe(self):
+        d, _ = self.clf.classify_aws(
+            ["timestream-query", "query", "--query-string", "DELETE FROM t"],
+            self.spec,
+        )
+        self.assertEqual(d, DECISION_UNSAFE)
+
+    def test_timestream_missing_flag_unknown(self):
+        # verb -> unknown and no payload to scan -> stays unknown.
+        d, _ = self.clf.classify_aws(
+            ["timestream-query", "query"], self.spec,
+        )
+        self.assertEqual(d, DECISION_UNKNOWN)
+
+    def test_athena_select_no_override_is_unsafe_floor(self):
+        # start-* is a write verb; without an override the payload cannot
+        # weaken it.
+        d, _ = self.clf.classify_aws(
+            ["athena", "start-query-execution", "--query-string", "SELECT 1"],
+            self.spec,
+        )
+        self.assertEqual(d, DECISION_UNSAFE)
+
+    def test_rds_data_select_no_override_is_unsafe_floor(self):
+        d, _ = self.clf.classify_aws(
+            ["rds-data", "execute-statement", "--sql", "SELECT 1"],
+            self.spec,
+        )
+        self.assertEqual(d, DECISION_UNSAFE)
+
+    def test_redshift_data_equals_form_select_no_override_unsafe(self):
+        d, _ = self.clf.classify_aws(
+            ["redshift-data", "execute-statement", "--sql=SELECT 1"],
+            self.spec,
+        )
+        self.assertEqual(d, DECISION_UNSAFE)
+
+    def test_athena_select_with_safe_override_is_safe(self):
+        d, _ = self.clf_override.classify_aws(
+            ["athena", "start-query-execution", "--query-string", "SELECT 1"],
+            self.spec_override,
+        )
+        self.assertEqual(d, DECISION_SAFE)
+
+    def test_athena_drop_with_safe_override_still_unsafe(self):
+        d, _ = self.clf_override.classify_aws(
+            ["athena", "start-query-execution",
+             "--query-string", "DROP TABLE t"],
+            self.spec_override,
+        )
+        self.assertEqual(d, DECISION_UNSAFE)
+
+    def test_athena_unclassifiable_with_safe_override_is_unknown(self):
+        # A safe override does not blanket-allow SQL the scanner cannot read.
+        d, _ = self.clf_override.classify_aws(
+            ["athena", "start-query-execution",
+             "--query-string", "FROBNICATE x"],
+            self.spec_override,
+        )
+        self.assertEqual(d, DECISION_UNKNOWN)
+
+    def test_unregistered_operation_untouched(self):
+        # An aws op with no registry entry keeps its plain verb decision.
+        d, _ = self.clf.classify_aws(
+            ["ec2", "describe-instances"], self.spec,
+        )
+        self.assertEqual(d, DECISION_SAFE)
 
 
 class TestAggregateDecisions(unittest.TestCase):
@@ -695,6 +815,21 @@ class TestSqlFunctionSideEffects(unittest.TestCase):
         d, _ = classify_sql_text("mysql", "SELECT COUNT(*) FROM t")
         self.assertEqual(d, DECISION_SAFE)
 
+    def test_dialect_param_overrides_cli_lookup(self):
+        # A synthetic cmd_name (payload scanning of cloud-API flags) is not a
+        # known SQL CLI, so the explicit dialect routes function detection.
+        cmd = "aws athena start-query-execution"
+        d, _ = classify_sql_text(
+            cmd, "SELECT load_extension('x')", dialect="sqlite")
+        self.assertEqual(d, DECISION_UNSAFE)
+
+    def test_dialect_none_skips_function_scan(self):
+        # Without a resolvable dialect the function scanner is a no-op, so a
+        # SELECT-shaped statement classifies safe on the keyword scan alone.
+        cmd = "aws athena start-query-execution"
+        d, _ = classify_sql_text(cmd, "SELECT load_extension('x')")
+        self.assertEqual(d, DECISION_SAFE)
+
 
 class TestParseSqlCliArgv(unittest.TestCase):
     def test_sqlite3_positional_sql(self):
@@ -809,6 +944,51 @@ class TestValidateShellRules(unittest.TestCase):
             },
         })
         self.assertTrue(any("bogus" in e for e in errors), errors)
+
+    def test_unknown_sql_payload_flag_key_flagged(self):
+        errors = validate_shell_rules({
+            "commands": {
+                "aws": {
+                    "default": "aws_cli",
+                    "sql_payload_flags": {
+                        "athena start-query-execution": {
+                            "flag": "--query-string", "ghost": 1,
+                        },
+                    },
+                },
+            },
+        })
+        self.assertTrue(any("ghost" in e for e in errors), errors)
+
+    def test_sql_payload_flag_missing_flag_flagged(self):
+        errors = validate_shell_rules({
+            "commands": {
+                "aws": {
+                    "default": "aws_cli",
+                    "sql_payload_flags": {
+                        "athena start-query-execution": {"dialect": "presto"},
+                    },
+                },
+            },
+        })
+        self.assertTrue(any("missing 'flag'" in e for e in errors), errors)
+
+    def test_sql_payload_flag_note_key_allowed(self):
+        # Underscore-prefixed meta keys are skipped, not treated as entries.
+        errors = validate_shell_rules({
+            "commands": {
+                "aws": {
+                    "default": "aws_cli",
+                    "sql_payload_flags": {
+                        "_note": "doc string, not an entry",
+                        "athena start-query-execution": {
+                            "flag": "--query-string",
+                        },
+                    },
+                },
+            },
+        })
+        self.assertEqual(errors, [])
 
     def test_unknown_interpreter_key_flagged(self):
         errors = validate_shell_rules({


### PR DESCRIPTION
## Summary

Recurse the existing SQL scanner into AWS CLI flags that carry a SQL
string, so the safe/unsafe call reflects the payload — not just the
verb. Adds a `sql_payload_flags` registry to the `aws` rule:

```json
"sql_payload_flags": {
  "athena start-query-execution":    {"flag": "--query-string", "dialect": "presto"},
  "rds-data execute-statement":      {"flag": "--sql",          "dialect": "varies"},
  "timestream-query query":          {"flag": "--query-string", "dialect": "timestream"},
  "redshift-data execute-statement": {"flag": "--sql",          "dialect": "redshift"}
}
```

When an aws operation matches, the flag value is pulled and run through
`classify_sql_text`.

## Decision precedence (the floor model)

The verb decision is a **floor** — payload scanning can only escalate or
refine, never weaken a mutating op on its own:

| verb decision | + payload | result |
| --- | --- | --- |
| `unsafe` (start-*, execute-*) | anything | `unsafe` |
| `safe` (via user override) | `safe` | `safe` |
| `safe` (via user override) | `unsafe` | `unsafe` |
| `safe` (via user override) | unclassified | `unknown` |
| `unknown` (timestream `query`) | payload | payload result |

This reconciles the two goals in the issue:

- **Out of the box**, only `aws timestream-query query` changes: verb
  `query` matched no pattern (→ `unknown`, prompted every time), and its
  payload now refines it to `safe`/`unsafe`.
- The `start-*`/`execute-*` ops stay `unsafe` by default. The narrowing
  use case ("I trust read-only Athena queries but want destructive ones
  blocked") is unlocked by the user adding an `extra_safe_patterns`
  override for the op — payload scanning then keeps destructive SQL
  flagged instead of the override blanket-allowing everything. That is
  risk #1 in the issue, now mitigated.

## Notes / scope decisions

- `classify_sql_text` gains an optional `dialect=` override (backward
  compatible) so the synthetic `cmd_name` used for payload scanning can
  still route the per-dialect function-side-effect scan from #26.
  `presto`/`timestream`/`redshift`/`varies` have no function deny-set
  yet, so only the dialect-agnostic keyword scan applies to them today;
  the field is recorded so a future deny-set lights up for free.
- `gh api graphql` is **not** added — its mutation/POST path is already
  `unsafe` via `-X POST`, as the issue notes; the proposed registry was
  aws-only.
- Validator learns `sql_payload_flags` (keys `flag`/`dialect`, `flag`
  required, underscore-prefixed meta keys skipped) so rule drift still
  fails at load time.

## Tests

+23 tests, all green; full suite has no new failures vs. the base
(the 16 pre-existing failures are the known Python-3.14-only phantom
set, green on CI 3.10-3.12).

- `extract_flag_value`: space / equals / value-with-equals / absent /
  flag-last forms.
- combine matrix: timestream SELECT→safe, DELETE→unsafe, missing
  flag→unknown; write-verb floor for athena/rds-data/redshift-data with
  no override; override + SELECT→safe, DROP→unsafe, unclassified→unknown;
  unregistered op untouched.
- dialect-param routing (sqlite deny-set via explicit dialect vs. no-op
  when None).
- validator drift (unknown key, missing flag, `_note` allowed).
- e2e through the grammar classifier (timestream safe/unsafe, athena
  floor).

Closes #29
