### PR TITLE
Add scripts/release.sh: version bump + tag for marketplace releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 - [How it works](#how-it-works)
 - [Install](#install)
   - [Updating](#updating)
+  - [Releasing (maintainers)](#releasing-maintainers)
   - [Migrating from manual to plugin install](#migrating-from-manual-to-plugin-install)
   - [Manual install (without the plugin system)](#manual-install-without-the-plugin-system)
 - [User whitelist as a secondary upgrade pass](#user-whitelist-as-a-secondary-upgrade-pass)
@@ -163,6 +164,23 @@ The plugin's `hooks/hooks.json` registers the `PreToolUse` hook on
   hook script in your `settings.json` already points at
   `<clone>/hooks/pre-tool-use.sh`, so the next Bash invocation picks up
   the new code without further action.
+
+### Releasing (maintainers)
+
+To publish a new version to either marketplace (this repo's own
+marketplace, or the official Anthropic one), cut a release with:
+
+```
+scripts/release.sh 0.2.0
+```
+
+That bumps the `version` field in `.claude-plugin/plugin.json` — the
+single source of truth both marketplaces read — commits `Release v0.2.0`,
+and tags `v0.2.0`. The marketplace pins on that version string, so a
+bump is required on every release: pushing commits without one leaves
+existing users on the cached copy. The script does not push; review the
+commit and tag, then run the `git push origin master --follow-tags`
+command it prints.
 
 ### Migrating from manual to plugin install
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+#
+# Cut a yolt plugin release: bump the version, commit, and tag.
+#
+# Usage: scripts/release.sh <new-version>      # e.g. scripts/release.sh 0.2.0
+#
+# Updates the "version" field in .claude-plugin/plugin.json -- the single
+# source of truth the marketplace reads -- then commits "Release v<version>"
+# and creates an annotated tag v<version>.
+#
+# The marketplace pins on this version string: pushing commits WITHOUT a
+# bump leaves existing users on the cached copy. That is the whole reason
+# this script exists.
+#
+# It does NOT push. Review the commit and tag, then run the printed
+# `git push` command to publish.
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+manifest="$repo_root/.claude-plugin/plugin.json"
+
+new_version="${1:-}"
+if [[ -z "$new_version" ]]; then
+    echo "usage: scripts/release.sh <new-version>   (e.g. 0.2.0)" >&2
+    exit 2
+fi
+
+# Validate the new version, ensure it advances past the current one, and
+# rewrite only the plugin.json version field. python3 is already a project
+# dependency, so use it for a robust JSON edit instead of sed-on-JSON.
+python3 - "$manifest" "$new_version" <<'PY'
+import json
+import re
+import sys
+
+manifest_path, new_version = sys.argv[1], sys.argv[2]
+
+if not re.fullmatch(r"\d+\.\d+\.\d+", new_version):
+    sys.exit(f"error: version must be semver X.Y.Z, got {new_version!r}")
+
+with open(manifest_path) as fh:
+    data = json.load(fh)
+
+current = data.get("version", "0.0.0")
+
+
+def as_tuple(version):
+    retval = tuple(int(part) for part in version.split("."))
+    return retval
+
+
+if as_tuple(new_version) <= as_tuple(current):
+    sys.exit(
+        f"error: new version {new_version} must be greater than current {current}"
+    )
+
+data["version"] = new_version
+with open(manifest_path, "w") as fh:
+    json.dump(data, fh, indent=2)
+    fh.write("\n")
+
+print(f"plugin.json: {current} -> {new_version}")
+PY
+
+cd "$repo_root"
+# Commit only the manifest, regardless of anything else already staged.
+git commit -m "Release v${new_version}" -- .claude-plugin/plugin.json
+git tag -a "v${new_version}" -m "Release v${new_version}"
+
+echo
+echo "Tagged v${new_version}. Review, then publish with:"
+echo "    git push origin master --follow-tags"


### PR DESCRIPTION
## What

Adds `scripts/release.sh`, a one-command release step for the yolt plugin, plus a README **Releasing (maintainers)** subsection.

```
scripts/release.sh 0.2.0
```

- Bumps `version` in `.claude-plugin/plugin.json` — the single source of truth both marketplaces read.
- Commits `Release v0.2.0` and creates annotated tag `v0.2.0`.
- Does **not** push; prints the `git push origin master --follow-tags` command for review-then-publish.

## Why

Follow-on to #39 (submit to the official marketplace). Both this repo's own marketplace and the official Anthropic one **pin on the `version` string** — pushing commits without bumping it leaves existing users on the cached copy. This makes the bump a deliberate, validated step.

## Guards

- Rejects non-semver input (`X.Y.Z` required).
- Rejects a new version that does not advance past the current one (equal or lower).
- Commits only `plugin.json` (pathspec-scoped), ignoring anything else staged.
- `rules/*.json` `_meta.version` are schema versions and are intentionally left untouched.

Validator logic smoke-tested against a temp manifest for the bump / equal / downgrade / bad-format cases.

Relates to #39.
