### PR TITLE
Add .codex-plugin/plugin.json manifest for Codex CLI

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "yolt",
+  "version": "0.1.0",
+  "description": "Static safety analyzer for Bash invocations - auto-allows read-only commands and prompts for mutating ones, plus a Python AST analyzer for python3 / python3 -c / heredoc invocations.",
+  "author": {
+    "name": "voitta-ai"
+  },
+  "homepage": "https://github.com/voitta-ai/voitta-yolt",
+  "repository": "https://github.com/voitta-ai/voitta-yolt",
+  "license": "MIT",
+  "keywords": ["bash", "safety", "security", "static-analysis", "hook"]
+}


### PR DESCRIPTION
## What

Adds `.codex-plugin/plugin.json` — the OpenAI Codex CLI plugin manifest for yolt, mirroring the existing `.claude-plugin/plugin.json`.

Metadata only (name, version, description, author, homepage, repository, license, keywords). Schema follows Codex's [official build-plugins manifest](https://developers.openai.com/codex/plugins/build) (`version` after `name`; `author`/`homepage`/`repository`/`license`/`keywords` as public metadata).

## Why

Codex CLI gained a plugin system (~v0.117) that closely mirrors Claude Code's: a `.codex-plugin/plugin.json` manifest, `marketplace.json` distribution, version-pinned install cache (`~/.codex/plugins/cache/$MARKETPLACE/$PLUGIN/$VERSION/`), and `codex plugin add/list`. This scaffolds yolt's presence in that ecosystem.

## Scope — manifest only, no component pointers

No `hooks` / `skills` / `mcpServers` / `apps` pointers yet. Wiring the hook is deliberately a **follow-up**, not this PR, because yolt's `hooks/hooks.json` is Claude-specific:

- It references `${CLAUDE_PLUGIN_ROOT}`; Codex sets a different plugin-root variable.
- Codex's hook **registration** shape matches Claude Code (`PreToolUse` + `matcher: "Bash"` + `type: command`), but the runtime **protocol** (stdin event JSON + the permission/decision output contract) is unverified against Codex.

So a working Codex hook needs a Codex-specific hooks file + protocol verification — tracked separately.

## Release coupling (follow-up)

Once Codex distribution goes live, `scripts/release.sh` (added in #54) should bump **both** `.claude-plugin/plugin.json` and `.codex-plugin/plugin.json` in lockstep. Left as-is for now since Codex distribution is not yet active.

Relates to #39.
