### PR TITLE
Document Anthropic community marketplace submission in Releasing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,20 +167,45 @@ The plugin's `hooks/hooks.json` registers the `PreToolUse` hook on
 
 ### Releasing (maintainers)
 
-To publish a new version to either marketplace (this repo's own
-marketplace, or the official Anthropic one), cut a release with:
+YOLT publishes to two marketplaces off the same repo:
+
+- **This repo's own marketplace (`voitta-yolt`)** — the repo IS the
+  marketplace, so there is nothing to onboard; a pushed release is live.
+- **Anthropic's community marketplace (`claude-plugins-community`)** —
+  Anthropic-hosted and submission-gated; needs a one-time submission
+  (below). The curated `claude-plugins-official` is invite-only, with no
+  submission path.
+
+**Every release — bump the version and tag:**
 
 ```
 scripts/release.sh 0.2.0
 ```
 
-That bumps the `version` field in `.claude-plugin/plugin.json` — the
-single source of truth both marketplaces read — commits `Release v0.2.0`,
-and tags `v0.2.0`. The marketplace pins on that version string, so a
-bump is required on every release: pushing commits without one leaves
+That rewrites the `version` field in `.claude-plugin/plugin.json` — the
+single source of truth for the plugin version — commits `Release v0.2.0`,
+and tags `v0.2.0`. The repo's own marketplace pins on that version string,
+so a bump is required on every release: pushing commits without one leaves
 existing users on the cached copy. The script does not push; review the
-commit and tag, then run the `git push origin master --follow-tags`
-command it prints.
+commit and tag, then run the `git push origin master --follow-tags` command
+it prints.
+
+**One-time — to list on Anthropic's community marketplace.** Validate
+(the same check Anthropic runs on submit), then submit the repo once:
+
+```
+claude plugin validate . --strict
+claude plugin validate .claude-plugin/plugin.json --strict
+```
+
+Submit through the plugin form — [Console](https://platform.claude.com/plugins/submit),
+or [claude.ai](https://claude.ai/admin-settings/directory/submissions/plugins/new)
+for Team/Enterprise orgs — and pass Anthropic's automated screening. On
+approval the plugin is pinned to a commit SHA in
+[`anthropics/claude-plugins-community`](https://github.com/anthropics/claude-plugins-community);
+the catalog then syncs nightly (~24h) and CI re-pins on later pushes, so
+there is no per-release step beyond the version bump above. Users install
+with `/plugin install yolt@claude-community`.
 
 ### Migrating from manual to plugin install
 


### PR DESCRIPTION
## What

Enhances the `### Releasing (maintainers)` README section (added in #54) to properly document the **Anthropic community marketplace** path, which was previously hand-waved as "the official Anthropic one."

## Why

The prior text implied a `scripts/release.sh` version bump alone publishes to Anthropic's marketplace. It does not — the Anthropic community marketplace requires a **one-time submission + review**, then pins on **commit SHA** (not the plugin.json version string) and auto-re-pins on later pushes. The version-string pin claim is true only for this repo's own self-hosted marketplace.

## Changes

- Split the section into the two distinct targets:
  - **`voitta-yolt`** (self-hosted) — repo IS the marketplace; pushed release is live; pins on the `plugin.json` version string (existing `release.sh` flow, unchanged).
  - **`claude-plugins-community`** (Anthropic-hosted) — one-time validate + form submission + automated screening; pins on commit SHA; nightly catalog sync; CI re-pins on pushes. Notes that curated `claude-plugins-official` is invite-only.
- Add pre-submission `claude plugin validate . --strict` / `claude plugin validate .claude-plugin/plugin.json --strict` commands (both verified passing against the current manifests).
- Add the `/plugin install yolt@claude-community` install command.

Docs-only. No code or manifest changes.