### PR TITLE
feat: generic alias command rule (doubledoor-git-safe -> git)

### DIFF
--- a/README.md
+++ b/README.md
@@ -518,6 +518,11 @@ name rather than guessed.
       "default": "subcommand",
       "safe_subcommands": ["status", "show"],
       "unsafe_subcommands": ["apply", "reset"]
+    },
+    "doubledoor-git-safe": {
+      "default": "alias",
+      "alias": "git",
+      "skip_value_flags": ["--repo"]
     }
   },
   "shell_builtins_safe": ["my-safe-wrapper"],
@@ -563,6 +568,15 @@ entire list; if you want to add `/scratch/*` while keeping the defaults,
 copy the default list through. `unsafe_write_targets` is checked before
 `safe_write_targets`, so a deny entry wins over a broader safe glob.
 Examples: `examples/user-overrides.json`, `examples/shell-overrides.json`.
+
+A `"default": "alias"` command classifies *exactly* as another command's
+rule — useful for thin wrappers that forward argv to a known CLI. The example
+above makes `doubledoor-git-safe diff` inherit `git`'s read/write
+classification (so `diff`/`status`/`log` are safe and `commit`/`push` ask),
+reusing git's subcommand lists rather than duplicating them. `skip_value_flags`
+lists leading wrapper-only flags (each consuming a value, `--repo X` or
+`--repo=X`) stripped before the target's rule sees the args. An alias whose
+target is not itself a defined command degrades to `unknown` (default prompt).
 
 ## Debug / dogfood log
 

--- a/hooks/rule_classifier.py
+++ b/hooks/rule_classifier.py
@@ -610,7 +610,7 @@ def check_unsafe_flags(cmd_args, spec, safe_write_targets=None,
 
 _ALLOWED_DEFAULTS = frozenset({
     "safe", "unsafe", "ask", "unknown",
-    "subcommand", "delegate_to_argument",
+    "subcommand", "delegate_to_argument", "alias",
     "aws_cli", "gcloud_cli", "az_cli", "sql_cli",
 })
 
@@ -623,6 +623,7 @@ _ALLOWED_TOP_LEVEL_KEYS = frozenset({
 
 _ALLOWED_COMMAND_KEYS = frozenset({
     "default", "_note", "_skip_first_positional",
+    "alias", "skip_value_flags",
     "unsafe_flag_values", "unsafe_flag_any_value",
     "unsafe_flags_without_value", "unsafe_flag_value_prefix",
     "write_flag_value_targets",
@@ -1042,6 +1043,8 @@ class RuleClassifier:
             return self.classify_subcommand(cmd_name, cmd_args, spec, _depth=_depth)
         if default == "delegate_to_argument":
             return self.classify_delegate_to_argument(cmd_name, cmd_args, spec, _depth=_depth)
+        if default == "alias":
+            return self.classify_alias(cmd_name, cmd_args, spec, _depth=_depth)
         if default == "aws_cli":
             return self.classify_aws(cmd_args, spec)
         if default == "gcloud_cli":
@@ -1052,6 +1055,42 @@ class RuleClassifier:
             return self.classify_sql_cli(cmd_name, cmd_args, spec)
 
         return (DECISION_UNKNOWN, "{}: unknown default '{}'".format(cmd_name, default))
+
+    def classify_alias(self, cmd_name, cmd_args, spec, _depth):
+        # Classify this command exactly as another command's rule. Used for thin
+        # wrappers that forward argv to a known CLI (e.g. a `git` wrapper). Optional
+        # `skip_value_flags` are leading wrapper-only flags (each consuming a value)
+        # stripped before the target sees the args. Fail-safe: an unknown alias
+        # target degrades to `unknown` (Claude Code's default prompt) rather than
+        # silently allowing.
+        if _depth >= self.MAX_RECURSION_DEPTH:
+            return (DECISION_UNKNOWN, "{}: alias recursion too deep".format(cmd_name))
+        target = spec.get("alias")
+        if not isinstance(target, str) or target not in self.commands:
+            return (DECISION_UNKNOWN, "{}: alias target '{}' not in rules".format(cmd_name, target))
+        skip_value_flags = set(spec.get("skip_value_flags", []))
+        forwarded = self._strip_leading_value_flags(cmd_args, skip_value_flags)
+        decision, reason = self.classify_known_command(target, forwarded, _depth=_depth + 1)
+        return (decision, "{} -> {}".format(cmd_name, reason))
+
+    @staticmethod
+    def _strip_leading_value_flags(cmd_args, value_flags):
+        # Drop a run of leading flags that each consume a value, supporting both
+        # `--flag value` and `--flag=value` forms. Stops at the first non-matching
+        # token so the wrapped command name / subcommand is preserved.
+        if not value_flags:
+            return list(cmd_args)
+        args = list(cmd_args)
+        while args:
+            head = args[0]
+            if "=" in head and head.split("=", 1)[0] in value_flags:
+                args = args[1:]
+                continue
+            if head in value_flags:
+                args = args[2:] if len(args) >= 2 else args[1:]
+                continue
+            break
+        return args
 
     def classify_subcommand(self, cmd_name, cmd_args, spec, _depth):
         valueless = set(spec.get("valueless_flags", []))

--- a/tests/test_rule_classifier.py
+++ b/tests/test_rule_classifier.py
@@ -1137,5 +1137,53 @@ class TestLoadShellRulesValidation(unittest.TestCase):
         self.assertIn("commands", rules)
 
 
+class TestAliasDefault(unittest.TestCase):
+    def _classifier(self):
+        rules = {
+            "commands": {
+                "git": {
+                    "default": "subcommand",
+                    "safe_subcommands": ["diff", "status", "log"],
+                    "unsafe_subcommands": ["push", "commit"],
+                },
+                "ddgs": {
+                    "default": "alias",
+                    "alias": "git",
+                    "skip_value_flags": ["--repo"],
+                },
+                "badalias": {"default": "alias", "alias": "nope"},
+            }
+        }
+        return RuleClassifier(rules)
+
+    def test_alias_forwards_safe_subcommand(self):
+        decision, _ = self._classifier().classify_tokens(["ddgs", "diff", "--", "f.tsx"])
+        self.assertEqual(decision, DECISION_SAFE)
+
+    def test_alias_forwards_unsafe_subcommand(self):
+        decision, _ = self._classifier().classify_tokens(["ddgs", "push", "origin", "main"])
+        self.assertEqual(decision, DECISION_UNSAFE)
+
+    def test_alias_skips_leading_value_flag_space_form(self):
+        decision, _ = self._classifier().classify_tokens(["ddgs", "--repo", "x", "status"])
+        self.assertEqual(decision, DECISION_SAFE)
+
+    def test_alias_skips_leading_value_flag_equals_form(self):
+        decision, _ = self._classifier().classify_tokens(["ddgs", "--repo=x", "log"])
+        self.assertEqual(decision, DECISION_SAFE)
+
+    def test_alias_skip_flag_does_not_hide_mutating_subcommand(self):
+        decision, _ = self._classifier().classify_tokens(["ddgs", "--repo", "x", "commit"])
+        self.assertEqual(decision, DECISION_UNSAFE)
+
+    def test_alias_missing_target_is_unknown(self):
+        decision, _ = self._classifier().classify_tokens(["badalias", "diff"])
+        self.assertEqual(decision, DECISION_UNKNOWN)
+
+    def test_alias_via_path_basename(self):
+        decision, _ = self._classifier().classify_tokens(["/usr/local/bin/ddgs", "status"])
+        self.assertEqual(decision, DECISION_SAFE)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Adds a generic `"default": "alias"` shell rule: a command classifies *exactly* as another command's rule. For thin wrappers that forward argv to a known CLI.

- `alias`: target command whose rule to reuse (must itself be a defined command; unknown target → `unknown`, fail-safe).
- `skip_value_flags`: leading wrapper-only flags, each consuming a value (`--flag X` and `--flag=X`), stripped before the target's rule sees the args.

Reuses the target's subcommand lists rather than duplicating them.

## Motivation

double-door/doubledoor2026#75 Q2: a `doubledoor-git-safe` wrapper invoked as `[--repo <path|name>] <git-subcommand> ...` was classified `unknown` → approval-gated. Mapping it `alias → git` makes `diff`/`status`/`log` read-only and `commit`/`push` gate. The mapping lives in a per-project `~/.claude/yolt/shell.json` override, so the project name stays out of core rules; only the generic mechanism ships here.

Part of the OpenClaw exec-permissions umbrella (method-and-apparatus/hq#111).

## Changes
- `hooks/rule_classifier.py`: dispatch case + `classify_alias` + `_strip_leading_value_flags`; `alias`/`skip_value_flags` added to schema allow-sets.
- `tests/test_rule_classifier.py`: 7 tests (safe/unsafe forwarding, both flag forms, skip-flag doesn't mask a mutating subcommand, missing-target → unknown, path-basename).
- `README.md`: documents the `alias` default with the doubledoor-git-safe example.

## Verification
`python3 -m unittest discover tests`: new `TestAliasDefault` 7/7 pass; full suite unchanged (same 3 pre-existing env-dependent failures with or without this change). `validate_shell_rules` accepts an alias spec (no errors).
