### PR TITLE
feat: gate destructive Prisma + SQL DDL ops as unsafe (#61)

### DIFF
--- a/rules/shell.json
+++ b/rules/shell.json
@@ -444,6 +444,23 @@
       "_note": "Top-level 'image', 'container', 'volume', 'network', 'system' moved into nested_subcommand with explicit safe/unsafe sub-subcommands. Bare 'docker image' (no further positional) now classifies as unknown instead of silently safe."
     },
 
+    "prisma": {
+      "default": "subcommand",
+      "safe_subcommands": [
+        "generate", "validate", "format", "version", "studio"
+      ],
+      "nested_subcommand": {
+        "db": {
+          "unsafe_subcommands": ["push", "execute", "seed"]
+        },
+        "migrate": {
+          "safe_subcommands": ["status", "diff"],
+          "unsafe_subcommands": ["reset", "deploy", "dev"]
+        }
+      },
+      "_note": "Destructive schema/migration ops (prisma db push/execute/seed, prisma migrate reset/deploy/dev) are gated unsafe; read-only migrate status/diff are safe. Bare 'prisma db' / 'prisma migrate' (no further positional) classify as unknown. Codegen/read-only top-level subcommands (generate, validate, format, version, studio) are safe. See issue #61."
+    },
+
     "kubectl": {
       "default": "subcommand",
       "safe_subcommands": [

--- a/tests/test_grammar_classifier.py
+++ b/tests/test_grammar_classifier.py
@@ -543,6 +543,75 @@ class TestNestedSubcommandPaths(unittest.TestCase):
         self.assertDecision("helm repo remove foo", DECISION_UNSAFE)
 
 
+class TestPrismaDestructiveOps(unittest.TestCase):
+    """Issue #61: gate destructive Prisma schema/DDL/migration ops as unsafe
+    while keeping read-only / codegen subcommands safe. Destructive verbs are
+    nested under 'db' and 'migrate', matching the docker nested_subcommand
+    shape."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.clf = _make_classifier()
+
+    def assertDecision(self, cmd, expected):
+        d, r = self.clf.classify(cmd)
+        self.assertEqual(
+            d, expected,
+            "cmd={!r}: got {}, reason={}".format(cmd, d, r),
+        )
+
+    # --- prisma db: destructive ---
+
+    def test_prisma_db_push_unsafe(self):
+        self.assertDecision("prisma db push", DECISION_UNSAFE)
+
+    def test_prisma_db_execute_unsafe(self):
+        self.assertDecision(
+            "prisma db execute --file ./migration.sql", DECISION_UNSAFE,
+        )
+
+    def test_prisma_db_seed_unsafe(self):
+        self.assertDecision("prisma db seed", DECISION_UNSAFE)
+
+    # --- prisma migrate: destructive vs read-only ---
+
+    def test_prisma_migrate_reset_unsafe(self):
+        self.assertDecision("prisma migrate reset", DECISION_UNSAFE)
+
+    def test_prisma_migrate_deploy_unsafe(self):
+        self.assertDecision("prisma migrate deploy", DECISION_UNSAFE)
+
+    def test_prisma_migrate_dev_unsafe(self):
+        self.assertDecision("prisma migrate dev", DECISION_UNSAFE)
+
+    def test_prisma_migrate_status_safe(self):
+        self.assertDecision("prisma migrate status", DECISION_SAFE)
+
+    def test_prisma_migrate_diff_safe(self):
+        self.assertDecision("prisma migrate diff", DECISION_SAFE)
+
+    # --- top-level read-only / codegen subcommands ---
+
+    def test_prisma_generate_safe(self):
+        self.assertDecision("prisma generate", DECISION_SAFE)
+
+    def test_prisma_validate_safe(self):
+        self.assertDecision("prisma validate", DECISION_SAFE)
+
+    def test_prisma_studio_safe(self):
+        self.assertDecision("prisma studio", DECISION_SAFE)
+
+    # --- partially-modeled namespaces should not auto-allow ---
+
+    def test_bare_prisma_db_not_safe(self):
+        d, _ = self.clf.classify("prisma db")
+        self.assertNotEqual(d, DECISION_SAFE)
+
+    def test_bare_prisma_migrate_not_safe(self):
+        d, _ = self.clf.classify("prisma migrate")
+        self.assertNotEqual(d, DECISION_SAFE)
+
+
 class TestPythonHeredoc(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -1002,6 +1071,27 @@ class TestSqlCli(unittest.TestCase):
         self.assertDecision(
             'mysql --execute=SHOW DATABASES',
             DECISION_SAFE,
+        )
+
+    # --- Issue #61: destructive DDL through a SQL CLI must be unsafe. ---
+
+    def test_psql_alter_table_drop_column_unsafe(self):
+        # ALTER TABLE ... DROP COLUMN is a destructive schema change.
+        self.assertDecision(
+            'psql -c "ALTER TABLE users DROP COLUMN email" mydb',
+            DECISION_UNSAFE,
+        )
+
+    def test_psql_bare_drop_table_unsafe(self):
+        self.assertDecision(
+            'psql -c "DROP TABLE users" mydb',
+            DECISION_UNSAFE,
+        )
+
+    def test_psql_truncate_unsafe(self):
+        self.assertDecision(
+            'psql -c "TRUNCATE TABLE users" mydb',
+            DECISION_UNSAFE,
         )
 
     # SQL injected via $(...) substitution — placeholders preserve safety.

--- a/tests/test_grammar_classifier.py
+++ b/tests/test_grammar_classifier.py
@@ -565,6 +565,13 @@ class TestPrismaDestructiveOps(unittest.TestCase):
     def test_prisma_db_push_unsafe(self):
         self.assertDecision("prisma db push", DECISION_UNSAFE)
 
+    def test_prisma_db_push_accept_data_loss_unsafe(self):
+        # Trailing destructive flags must not downgrade the nested unsafe verb
+        # (this is the data-loss case gate #15 / issue #61 exists for).
+        self.assertDecision(
+            "prisma db push --accept-data-loss", DECISION_UNSAFE,
+        )
+
     def test_prisma_db_execute_unsafe(self):
         self.assertDecision(
             "prisma db execute --file ./migration.sql", DECISION_UNSAFE,


### PR DESCRIPTION
## Summary

Implements issue #61 (group E of the #60 dogfood): gate destructive DB
schema / DDL / migration operations as `unsafe` (always ask a human), while
keeping read-only / codegen operations `safe`.

## Rules added

New `prisma` entry in `rules/shell.json`, modeled on the existing `docker`
`nested_subcommand` shape (destructive verbs are nested under `db` /
`migrate`):

```json
"prisma": {
  "default": "subcommand",
  "safe_subcommands": [
    "generate", "validate", "format", "version", "studio"
  ],
  "nested_subcommand": {
    "db": {
      "unsafe_subcommands": ["push", "execute", "seed"]
    },
    "migrate": {
      "safe_subcommands": ["status", "diff"],
      "unsafe_subcommands": ["reset", "deploy", "dev"]
    }
  }
}
```

Resulting classifications:

| Command | Decision |
| --- | --- |
| `prisma db push` / `db execute` / `db seed` | unsafe |
| `prisma migrate reset` / `deploy` / `dev` | unsafe |
| `prisma migrate status` / `diff` | safe |
| `prisma generate` / `validate` / `format` / `version` / `studio` | safe |
| bare `prisma db` / `prisma migrate` | unknown (no auto-allow) |

Validated against `validate_shell_rules()` (no errors) so the hook does not
hard-fail on load.

## SQL DDL coverage

Confirmed the existing SQL-CLI scanner already gates destructive DDL — no
classifier code change was needed. Added regression tests asserting that a
SQL CLI invocation containing `ALTER TABLE ... DROP COLUMN`, a bare
`DROP TABLE`, and `TRUNCATE` all classify `unsafe`.

## Tests

Added 16 tests:
- `TestPrismaDestructiveOps` (13) in `tests/test_grammar_classifier.py`
- 3 SQL DDL regression tests in `TestSqlCli`

```
Ran 570 tests in 11.029s
FAILED (failures=3)
```

The only 3 failures are pre-existing and unrelated to this change: tests in
`test_yolt_hook.py` that run the hook as a subprocess with a fake `HOME`,
which loses access to the user-site `tree-sitter` install and falls back to
`import-error`. They fail identically on the base commit (`Ran 554 tests ...
FAILED (failures=3)`) before any change in this PR. All 16 new tests pass.

Closes #61
Refs #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)