### PR TITLE
feat(rules): classify istioctl + eksctl read/write subcommands (#63)

### DIFF
--- a/rules/shell.json
+++ b/rules/shell.json
@@ -521,6 +521,38 @@
       "_note": "'repo' moved into nested_subcommand: helm repo list is safe, helm repo add is unsafe."
     },
 
+    "istioctl": {
+      "default": "subcommand",
+      "safe_subcommands": [
+        "proxy-config", "pc", "proxy-status", "ps", "remote-clusters",
+        "version", "analyze", "validate", "describe"
+      ],
+      "unsafe_subcommands": [
+        "install", "uninstall", "upgrade", "kube-inject", "create-remote-secret"
+      ],
+      "nested_subcommand": {
+        "manifest": {
+          "safe_subcommands": ["generate", "diff", "dump"],
+          "unsafe_subcommands": ["install", "apply"]
+        },
+        "tag": {
+          "safe_subcommands": ["list"],
+          "unsafe_subcommands": ["set", "remove"]
+        }
+      },
+      "_note": "Read-only mesh introspection (proxy-config/pc, proxy-status/ps, remote-clusters, analyze, describe) is safe; install/uninstall/upgrade and kube-inject/create-remote-secret (which render credentials/manifests meant to be applied) are unsafe. Unlisted subcommands stay unknown."
+    },
+
+    "eksctl": {
+      "default": "subcommand",
+      "safe_subcommands": ["get", "version", "info"],
+      "unsafe_subcommands": [
+        "create", "delete", "upgrade", "scale", "drain", "update", "set",
+        "associate", "disassociate", "register", "deregister", "enable"
+      ],
+      "_note": "eksctl get/version/info are read-only; everything that provisions or mutates a cluster/nodegroup is unsafe. Bare or unlisted subcommands stay unknown."
+    },
+
     "aws": {
       "default": "aws_cli",
       "_note": "Special-cased. AWS CLI operations are uniformly verb-prefixed: describe-*/list-*/get-*/head-* are read-only; create-*/delete-*/update-*/put-*/terminate-*/start-*/stop-*/run-* are mutating.",

--- a/tests/test_grammar_classifier.py
+++ b/tests/test_grammar_classifier.py
@@ -111,6 +111,27 @@ class TestClassifyScenarios(unittest.TestCase):
     def test_kubectl_get_pods(self):
         self.assertDecision("kubectl get pods -A", DECISION_SAFE)
 
+    def test_istioctl_read_subcommands_safe(self):
+        self.assertDecision(
+            "istioctl proxy-config cluster my-pod -n my-ns", DECISION_SAFE)
+        self.assertDecision("istioctl remote-clusters", DECISION_SAFE)
+        self.assertDecision("istioctl ps", DECISION_SAFE)
+        self.assertDecision("istioctl analyze", DECISION_SAFE)
+
+    def test_istioctl_mutating_subcommands_unsafe(self):
+        self.assertDecision("istioctl install --set x=y", DECISION_UNSAFE)
+        self.assertDecision("istioctl uninstall --purge", DECISION_UNSAFE)
+
+    def test_istioctl_manifest_nested(self):
+        self.assertDecision("istioctl manifest generate", DECISION_SAFE)
+        self.assertDecision("istioctl manifest install", DECISION_UNSAFE)
+
+    def test_eksctl_get_safe_create_unsafe(self):
+        self.assertDecision("eksctl get cluster", DECISION_SAFE)
+        self.assertDecision("eksctl version", DECISION_SAFE)
+        self.assertDecision("eksctl create cluster -f c.yaml", DECISION_UNSAFE)
+        self.assertDecision("eksctl delete nodegroup ng", DECISION_UNSAFE)
+
     def test_python3_c_inline_safe(self):
         self.assertDecision('python3 -c "print(1+1)"', DECISION_SAFE)
 


### PR DESCRIPTION
Closes #63.

Adds `istioctl` + `eksctl` to the grammar classifier (`rules/shell.json`). Before this, both tools had no rule, so read-only introspection prompted every time.

- **istioctl** safe: `proxy-config`/`pc`, `proxy-status`/`ps`, `remote-clusters`, `version`, `analyze`, `validate`, `describe`; nested `manifest` (generate/diff/dump safe, install/apply unsafe) and `tag` (list safe, set/remove unsafe). Unsafe: `install`, `uninstall`, `upgrade`, `kube-inject`, `create-remote-secret`.
- **eksctl** safe: `get`, `version`, `info`. Unsafe: `create`, `delete`, `upgrade`, `scale`, `drain`, `update`, `set`, `associate`/`disassociate`, `register`/`deregister`, `enable`.
- Unlisted subcommands stay `unknown` (conservative default prompt).

Tests: 4 new cases in `test_grammar_classifier.py`; full grammar suite (195) green. The 3 failures under `discover` (log-path + malformed-override logging) pre-exist on master and are unrelated.

Surfaced by a productivity-engineering pass over a real multi-cluster Istio infra run (skillz#94 run #4).
