### PR TITLE
fix(hook): deny instead of ask inside a subagent; log permission_mode/agent_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,14 @@ After visiting, decisions are aggregated with precedence
 `unsafe > unknown > safe`, and the hook emits one of:
 
 - `safe` → `permissionDecision: allow` with a short reason.
-- `unsafe` → `permissionDecision: ask` with the specific reason.
+- `unsafe` → `permissionDecision: ask` with the specific reason — or
+  `deny` when the hook payload carries an `agent_id`, i.e. the call came
+  from a background subagent. No operator is reachable there, so an `ask`
+  dialog never surfaces and never times out: the agent hangs indefinitely.
+  `deny` is strictly more restrictive than `ask`, and it fails in seconds
+  with a reason the agent can report to its orchestrator. The fix is the
+  same either way — add the suggested `permissions.allow` entry, or re-run
+  from the main session.
 - `unknown` → silent exit; Claude Code falls through to its default.
 
 Argv is dispatched per-`command_name`: safe builtins → safe;
@@ -590,7 +597,7 @@ YOLT logs every examined Bash invocation by default to
 `~/.claude/yolt.log`. Each line is a JSON record:
 
 ```json
-{"ts": "2026-05-08T14:00:00.000+00:00", "decision": "safe", "reason": "ls: read-only", "command": "ls /tmp"}
+{"ts": "2026-05-08T14:00:00.000+00:00", "decision": "safe", "reason": "ls: read-only", "command": "ls /tmp", "permission_mode": "default", "agent_id": null}
 ```
 
 `decision` is one of `safe`, `unsafe`, `unknown`, `import-error` (the
@@ -598,8 +605,12 @@ tree-sitter dependency is missing), or `rules-validation-error` (the
 bundled or user-override `shell.json` failed schema validation; the
 `reason` field carries the list of offending keys / defaults so the
 user can fix the override). The `command` field is truncated to 500
-characters. Logging failures are swallowed — the hook never breaks the
-session because of an unwritable log path.
+characters. `permission_mode` and `agent_id` are copied from the hook
+payload: `agent_id` is set only when the call came from a subagent (so
+it doubles as per-agent attribution when several agents run in
+parallel), and `permission_mode` is not observable anywhere else. Both
+are `null` when the payload omits them. Logging failures are swallowed
+— the hook never breaks the session because of an unwritable log path.
 
 ```bash
 tail -f ~/.claude/yolt.log

--- a/hooks/yolt_analyzer.py
+++ b/hooks/yolt_analyzer.py
@@ -842,6 +842,13 @@ def make_hook_response(decision, reason=None):
     return output
 
 
+SUBAGENT_DENY_PREFIX = (
+    "Denied rather than asked: no operator is reachable from a background "
+    "subagent, so an approval prompt would hang forever. Re-run this from "
+    "the main session, or add the allow pattern below.\n\n"
+)
+
+
 def format_unsafe_reason(reason, allow_hint=None):
     from rule_classifier import UNANALYZABLE_INLINE_PYTHON_PREFIX
 
@@ -926,10 +933,17 @@ def _maybe_rotate_log(log_path, max_bytes):
         pass
 
 
-def _log_hook_decision(command, decision, reason):
+def _log_hook_decision(command, decision, reason,
+                       permission_mode=None, agent_id=None):
     """Append a JSON-line record of this hook fire to the resolved log
     path. Logs by default to `~/.claude/yolt.log`; the user can override
     with `YOLT_LOG_FILE=<path>` or opt out with `YOLT_LOG_FILE=""`.
+
+    `permission_mode` and `agent_id` come straight from the hook payload
+    (`agent_id` is present only when the hook fires inside a subagent
+    call). Recording them makes per-agent attribution possible, and the
+    live permission mode is not observable anywhere else. Both are
+    `null` when the payload omits them. See issue #76.
 
     Useful for dogfooding / QA: tail the log to see exactly which
     decision YOLT made on every Bash invocation — including the silent
@@ -954,6 +968,8 @@ def _log_hook_decision(command, decision, reason):
             "decision": decision,
             "reason": reason,
             "command": command[:500] if command else "",
+            "permission_mode": permission_mode,
+            "agent_id": agent_id,
         }
         with open(log_path, "a") as f:
             f.write(json.dumps(record) + "\n")
@@ -1040,7 +1056,10 @@ def run_hook():
          delegates python3 inline / script analysis to SafetyAnalyzer.
       3. Map classifier decision -> hook response:
            safe    -> permissionDecision: allow
-           unsafe  -> permissionDecision: ask (with explanation)
+           unsafe  -> permissionDecision: ask (with explanation), or
+                      deny when the payload carries an `agent_id` (the
+                      hook fired inside a subagent, where no operator
+                      can answer an ask — see issue #76)
            unknown -> exit silently, let Claude Code apply its default.
 
     If tree-sitter-bash is not importable on the host (broken install,
@@ -1063,6 +1082,12 @@ def run_hook():
     if not command.strip():
         sys.exit(0)
 
+    # `agent_id` is present only when the hook fires inside a subagent
+    # call; `permission_mode` is always present. Both are logged, and
+    # `agent_id` also flips `ask` -> `deny` below. See issue #76.
+    permission_mode = hook_input.get("permission_mode")
+    agent_id = hook_input.get("agent_id")
+
     yolt_dir = Path(__file__).resolve().parent.parent
     py_rules = load_rules(
         rules_dir=yolt_dir / "rules",
@@ -1080,7 +1105,8 @@ def run_hook():
             load_allow_patterns, load_shell_rules,
         )
     except ImportError as e:
-        _log_hook_decision(command, "import-error", str(e))
+        _log_hook_decision(command, "import-error", str(e),
+                           permission_mode, agent_id)
         sys.exit(0)
 
     try:
@@ -1089,7 +1115,8 @@ def run_hook():
             user_overrides_path=Path.home() / ".claude" / "yolt" / "shell.json",
         )
     except ShellRulesValidationError as e:
-        _log_hook_decision(command, "rules-validation-error", str(e))
+        _log_hook_decision(command, "rules-validation-error", str(e),
+                           permission_mode, agent_id)
         sys.exit(0)
 
     cwd_str = hook_input.get("cwd") or os.getcwd()
@@ -1109,7 +1136,7 @@ def run_hook():
         allow_patterns=allow_patterns,
     )
     decision, reason = classifier.classify(command)
-    _log_hook_decision(command, decision, reason)
+    _log_hook_decision(command, decision, reason, permission_mode, agent_id)
 
     if decision == DECISION_SAFE:
         response = make_hook_response("allow", "YOLT: {}".format(reason))
@@ -1117,7 +1144,18 @@ def run_hook():
         sys.exit(0)
     if decision == DECISION_UNSAFE:
         allow_hint = classifier.suggest_allow_pattern(command)
-        response = make_hook_response("ask", format_unsafe_reason(reason, allow_hint))
+        message = format_unsafe_reason(reason, allow_hint)
+        if agent_id:
+            # No operator is reachable from a background subagent: the
+            # `ask` dialog never surfaces and nothing times out, so the
+            # agent wedges indefinitely. `deny` is strictly more
+            # restrictive than `ask` and fails in seconds with a reason
+            # the agent can report upward. Issue #76.
+            response = make_hook_response(
+                "deny", SUBAGENT_DENY_PREFIX + message
+            )
+        else:
+            response = make_hook_response("ask", message)
         print(json.dumps(response))
         sys.exit(0)
     # decision == DECISION_UNKNOWN: let Claude Code handle it

--- a/hooks/yolt_analyzer.py
+++ b/hooks/yolt_analyzer.py
@@ -845,7 +845,7 @@ def make_hook_response(decision, reason=None):
 SUBAGENT_DENY_PREFIX = (
     "Denied rather than asked: no operator is reachable from a background "
     "subagent, so an approval prompt would hang forever. Re-run this from "
-    "the main session, or add the allow pattern below.\n\n"
+    "the main session, or add a matching permissions.allow entry.\n\n"
 )
 
 

--- a/tests/test_yolt_hook.py
+++ b/tests/test_yolt_hook.py
@@ -209,6 +209,54 @@ class TestHookEndToEnd(unittest.TestCase):
         self.assertIn("Bash(gh issue create*)", reason)
 
 
+class TestHookSubagentDeny(unittest.TestCase):
+    """Inside a background subagent (payload carries `agent_id`) an `ask`
+    never surfaces a dialog and never times out, so the agent hangs.
+    Unsafe commands are denied there instead. Issue #76."""
+
+    def _run(self, command, **extra):
+        payload = {
+            "tool_name": "Bash",
+            "tool_input": {"command": command},
+        }
+        payload.update(extra)
+        retval = HookSubprocess.response_of(HookSubprocess.run(payload))
+        return retval
+
+    def test_unsafe_in_subagent_returns_deny(self):
+        resp = self._run("rm -rf /tmp/foo", agent_id="agent_abc123")
+        self.assertEqual(
+            resp["hookSpecificOutput"]["permissionDecision"], "deny"
+        )
+
+    def test_deny_reason_explains_and_keeps_allow_hint(self):
+        resp = self._run(
+            "git -C /tmp/wt-76 push origin feature/issue-76",
+            agent_id="agent_abc123",
+        )
+        reason = resp["hookSpecificOutput"]["permissionDecisionReason"]
+        self.assertIn("no operator is reachable", reason)
+        self.assertIn("Bash(git -C * push origin feature/*)", reason)
+
+    def test_unsafe_without_agent_id_still_asks(self):
+        resp = self._run("rm -rf /tmp/foo")
+        self.assertEqual(
+            resp["hookSpecificOutput"]["permissionDecision"], "ask"
+        )
+
+    def test_safe_in_subagent_still_allows(self):
+        resp = self._run("ls /tmp", agent_id="agent_abc123")
+        self.assertEqual(
+            resp["hookSpecificOutput"]["permissionDecision"], "allow"
+        )
+
+    def test_unknown_in_subagent_still_exits_silently(self):
+        resp = self._run(
+            "somecommand_unknown_xyz --flag", agent_id="agent_abc123"
+        )
+        self.assertIsNone(resp)
+
+
 class TestHookWhitelistDiscovery(unittest.TestCase):
     """The hook reads the user's settings.json `permissions.allow` Bash()
     entries and uses them as an explicit override for unknown and unsafe
@@ -331,15 +379,17 @@ class TestHookLogFile(unittest.TestCase):
         import shutil
         shutil.rmtree(self._tmp, ignore_errors=True)
 
-    def _run_with_log(self, command):
+    def _run_with_log(self, command, **extra):
         env = dict(os.environ)
         env["YOLT_LOG_FILE"] = str(self.log_path)
+        payload = {
+            "tool_name": "Bash",
+            "tool_input": {"command": command},
+        }
+        payload.update(extra)
         subprocess.run(
             [sys.executable, str(HOOKS_DIR / "yolt_analyzer.py"), "--hook"],
-            input=json.dumps({
-                "tool_name": "Bash",
-                "tool_input": {"command": command},
-            }),
+            input=json.dumps(payload),
             capture_output=True,
             text=True,
             timeout=30,
@@ -386,6 +436,24 @@ class TestHookLogFile(unittest.TestCase):
         self.assertEqual(len(recs), 3)
         decisions = [r["decision"] for r in recs]
         self.assertEqual(decisions, ["safe", "unsafe", "safe"])
+
+    def test_logs_permission_mode_and_agent_id(self):
+        self._run_with_log(
+            "rm -rf /tmp/foo",
+            permission_mode="acceptEdits",
+            agent_id="agent_abc123",
+        )
+        recs = self._records()
+        self.assertEqual(len(recs), 1)
+        self.assertEqual(recs[0]["permission_mode"], "acceptEdits")
+        self.assertEqual(recs[0]["agent_id"], "agent_abc123")
+
+    def test_permission_mode_and_agent_id_null_when_absent(self):
+        self._run_with_log("ls /tmp")
+        recs = self._records()
+        self.assertEqual(len(recs), 1)
+        self.assertIsNone(recs[0]["permission_mode"])
+        self.assertIsNone(recs[0]["agent_id"])
 
     def test_long_command_is_truncated(self):
         long_cmd = "echo " + ("x" * 1000)


### PR DESCRIPTION
## Summary

Two independent fixes from the #76 investigation.

**1. `ask` from a subagent is a hang — `deny` instead.** YOLT maps `unsafe` → `permissionDecision: ask`, which assumes an operator is reachable. Inside a background subagent there isn't one: the dialog never surfaces, nothing times out, and the agent wedges (voitta-ai/skillz#127). The payload already carries the signal — `agent_id` is present only when the hook fires inside a subagent call — so `run_hook()` now emits `deny` when it is set.

- `deny` is strictly more restrictive than `ask`; it can never allow something `ask` wouldn't.
- The reason reaches the agent, so it fails in seconds with a diagnosis it can report to its orchestrator.
- Trade-off, as stated in the issue: work an operator would have approved now fails — loudly, and the remedy is the one they'd have applied anyway (the suggested `permissions.allow` entry, still appended to the deny reason, or re-run from the main session).

**2. Log `permission_mode` and `agent_id`.** `_log_hook_decision()` now records both. Per-agent attribution stops being guesswork from command text and cwd, and the live permission mode becomes observable at all. Both are `null` when the payload omits them.

## Changes
- `hooks/yolt_analyzer.py`: read `permission_mode` / `agent_id` in `run_hook()`; `SUBAGENT_DENY_PREFIX` + the unsafe-branch `deny` split; two new log-record fields (`_log_hook_decision` signature gains two optional args, threaded through the `import-error` and `rules-validation-error` paths too).
- `tests/test_yolt_hook.py`: `TestHookSubagentDeny` (5 tests — unsafe+`agent_id` → deny, deny reason keeps its allow hint, unsafe without `agent_id` still asks, safe still allows, unknown still exits silently) and 2 log-field tests.
- `README.md`: decision-mapping and log-record sections.

Only the `unsafe` branch changes. `safe` → allow and `unknown` → silent exit behave identically inside a subagent.

## Verification
`python3 -m unittest tests.test_yolt_hook.TestHookSubagentDeny tests.test_yolt_hook.TestHookLogFile`: 18/18 pass.

Full suite from this worktree: 582 tests, 16 failures — byte-identical to the known local Python 3.14 / env-dependent set on clean master (CI on 3.10–3.12 is green). None of the 16 touch this change.

Closes #76
