### PR TITLE
docs: require a version bump on every shipping merge; bump to 0.2.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "yolt",
   "description": "Static safety analyzer for Bash invocations - auto-allows read-only commands and prompts for mutating ones, plus a Python AST analyzer for python3 / python3 -c / heredoc invocations.",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "author": {
     "name": "voitta-ai"
   },

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,83 @@
+# Working in this repo
+
+## Bump the plugin version on every merge that ships
+
+`.claude-plugin/plugin.json#version` is the single source of truth for the
+plugin version, and Claude Code caches an extracted copy of the plugin under
+`~/.claude/plugins/cache/<marketplace>/<plugin>/<version>/`. That path is
+keyed by the version string, so `claude plugin update` compares installed
+version against available version and stops there. **If the version did not
+change, it reports "up to date" and re-extracts nothing — the user keeps
+running the old code no matter how many commits landed on master.**
+
+This is not theoretical: the version sat at `0.1.0` from the initial ship
+until issue #78, and every behavior change in between was invisible to
+installed copies, including the maintainer's own.
+
+So: **any merge to master that changes a file users receive must bump the
+version.** The bump rides in the PR, not in a follow-up commit (see
+"Tagging" below).
+
+Changes that do *not* need their own bump, because users never execute
+them: `tests/`, `.github/`, `HANDOFF.md`, and other maintainer-only files.
+Fold those into whatever the next real bump is.
+
+### Which part to bump
+
+The plugin is pre-1.0, so the compatibility contract being versioned is
+"what does YOLT decide, and how do I configure it" — not a code API.
+
+- **PATCH** (`0.2.0` → `0.2.1`) — nothing a user could observe at a
+  permission prompt. Refactors, docstrings, README edits, log-field
+  additions, reason-string wording. Still required: shipped is shipped.
+- **MINOR** (`0.2.0` → `0.3.0`) — user-visible behavior. A rule that flips
+  a command's classification, new commands or subcommands in
+  `rules/shell.json`, a new default in the Python analyzer, a change to the
+  hook's decision mapping (e.g. #77's ask → deny inside subagents), a new
+  config key or environment variable, a new slash command.
+- **MAJOR** (`0.x` → `1.0.0`) — reserved for two things: declaring the
+  rules-file format stable, and any later break of it. Renaming or removing
+  a documented key in `rules/rules.json` / `rules/shell.json` /
+  `~/.claude/yolt/*.json`, or dropping a documented env var, is a major
+  bump once 1.0 exists. Before then, call it minor and say so in the PR.
+
+When a single PR mixes levels, take the highest one.
+
+### Tagging, and why `scripts/release.sh` only half-fits
+
+`scripts/release.sh <version>` rewrites `plugin.json`, commits
+`Release v<version>`, and tags. The commit-and-tag half does not fit this
+repo: master takes squash merges, so a tag created on a feature branch
+points at a commit that never lands on master.
+
+Sequence that works:
+
+1. Edit `.claude-plugin/plugin.json#version` as part of the PR's own
+   changes. (`scripts/release.sh` is still handy for the rewrite+validation
+   — it refuses a non-semver or non-advancing version — but drop its commit
+   and tag, or just edit the field by hand.)
+2. Merge the PR (squash).
+3. Tag master's squash commit and push:
+
+   ```
+   git tag -a v0.3.0 -m "Release v0.3.0" <squash-sha>
+   git push origin v0.3.0
+   ```
+
+Tagging creates no commit, so this respects the "no direct commits to
+master" rule.
+
+### Verifying an install actually updated
+
+`claude plugin update` printing "up to date" is not evidence. Check the
+cache copy, which is what the hook actually runs:
+
+```
+ls ~/.claude/plugins/cache/voitta-yolt/yolt/
+grep -c "<a symbol from the new code>" \
+  ~/.claude/plugins/cache/voitta-yolt/yolt/<version>/hooks/yolt_analyzer.py
+```
+
+The directory under `.../yolt/` should be named for the new version. The
+clone under `~/.claude/plugins/marketplaces/voitta-yolt/` updating is *not*
+sufficient — that is the fetched source, not the extracted install.

--- a/README.md
+++ b/README.md
@@ -203,19 +203,18 @@ YOLT publishes to two marketplaces off the same repo:
   (below). The curated `claude-plugins-official` is invite-only, with no
   submission path.
 
-**Every release — bump the version and tag:**
+**Every merge that ships — bump the version.** `.claude-plugin/plugin.json`
+holds the version, and Claude Code's plugin cache is keyed by it, so
+`claude plugin update` on an unchanged version reports "up to date" and
+re-extracts nothing: users keep running the old code. Not hypothetical —
+the version sat at `0.1.0` from the initial ship through issue #78 and
+every change in between was invisible to installed copies.
 
-```
-scripts/release.sh 0.2.0
-```
-
-That rewrites the `version` field in `.claude-plugin/plugin.json` — the
-single source of truth for the plugin version — commits `Release v0.2.0`,
-and tags `v0.2.0`. The repo's own marketplace pins on that version string,
-so a bump is required on every release: pushing commits without one leaves
-existing users on the cached copy. The script does not push; review the
-commit and tag, then run the `git push origin master --follow-tags` command
-it prints.
+`CLAUDE.md` has the full convention: which semver part to bump for what,
+and how to tag under this repo's squash-merge policy (edit the version in
+the PR; tag master's squash commit after the merge). `scripts/release.sh
+<version>` rewrites and validates the field, but its commit-and-tag half
+does not fit squash merges — see `CLAUDE.md`.
 
 **One-time — to list on Anthropic's community marketplace.** Validate
 (the same check Anthropic runs on submit), then submit the repo once:


### PR DESCRIPTION
## Summary

The plugin version has said `0.1.0` since `85a8545` ("Ship YOLT as a Claude Code plugin") — the only commit that ever touched `.claude-plugin/plugin.json` — and no tag exists. Claude Code keys its extracted plugin cache by that version string, so `claude plugin update` compares `0.1.0` to `0.1.0`, says "up to date", and re-extracts nothing.

Net effect: installed copies have been running the May 8 build while master moved ~40 commits. #36, #57, #61, #63 and #77 reached nobody, including the maintainer dogfooding it.

Confirmed on this machine after merging #77:

| path | state |
|---|---|
| `~/.claude/plugins/marketplaces/voitta-yolt/` | current, has the new code — the fetch works |
| `~/.claude/plugins/cache/voitta-yolt/yolt/0.1.0/hooks/` | May 8, does not — and its `.in_use/` is stamped with today's session, so this is what actually runs |

The release machinery was never missing: `scripts/release.sh` and the README section have been there since the ship. What was missing is a rule making them non-optional.

## Changes

- **`CLAUDE.md`** (new) — any merge changing a file users receive must bump the version. Includes the semver split, and the tagging sequence.
- **`README.md`** — the Releasing section said "every release"; it now says "every merge that ships", states the cache-key reason, and defers the detail to `CLAUDE.md`.
- **`.claude-plugin/plugin.json`** — `0.1.0` → `0.2.0`.

## Semver split (pre-1.0)

The contract being versioned is "what does YOLT decide, and how do I configure it" — not a code API.

- **patch** — unobservable at a permission prompt: refactors, docs, log fields, reason wording. Still required; shipped is shipped.
- **minor** — user-visible: a rule that flips a classification, new commands in `rules/shell.json`, a changed decision mapping (#77's ask → deny), a new config key or env var.
- **major** — reserved for declaring the rules-file format stable at 1.0, and breaking it thereafter.

`0.2.0` rather than `0.1.1` because #77 changed `ask` to `deny` inside subagents.

## The tagging trap, found the hard way

`scripts/release.sh 0.2.0` was run on the branch and did what it documents — rewrote the field, committed `Release v0.2.0`, and tagged `v0.2.0`. On a squash-merge repo the tag then points at a feature-branch commit that never lands on master. The commit and tag were dropped; the bump rides in this PR's own commit instead.

`CLAUDE.md` records the working sequence: bump in the PR → squash-merge → `git tag -a v0.2.0 <squash-sha>` on master → push the tag. Tagging creates no commit, so the no-direct-commits-to-master rule holds. `scripts/release.sh` is left alone — its rewrite-and-validate half is still useful (it rejects non-semver and non-advancing versions) and reworking it is out of scope here.

**After merge, this PR needs a tag on the squash commit** — it does not tag itself.

## Verification

`python3 -m unittest discover tests`: 582 tests, 16 failures — the known local Python 3.14 / cwd-dependent baseline, byte-identical to clean master from a worktree. No code changed in this PR.

Closes #78
