### PR TITLE
feat(rules): classify python test-runner invocations as read-only

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "yolt",
   "description": "Static safety analyzer for Bash invocations - auto-allows read-only commands and prompts for mutating ones, plus a Python AST analyzer for python3 / python3 -c / heredoc invocations.",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "author": {
     "name": "voitta-ai"
   },

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@
 - [Dependencies](#dependencies)
 - [What the grammar classifier handles](#what-the-grammar-classifier-handles)
 - [SQL CLIs](#sql-clis)
+- [Test runners](#test-runners)
+  - [Interpreter aliases (`inherits`)](#interpreter-aliases-inherits)
 - [Python rules (interpreter delegate)](#python-rules-interpreter-delegate)
 - [Custom rules](#custom-rules)
   - [Python rules — `~/.claude/yolt/rules.json`](#python-rules---claudeyoltrulesjson)
@@ -154,7 +156,9 @@ Argv is dispatched per-`command_name`: safe builtins → safe;
 interpreters delegate inline scripts (see lead-in); `python3 -m <mod>`
 consults the `safe_modules` / `unsafe_modules` / `nested_modules` lists
 in `rules/shell.json#interpreters.python3` (so e.g. `python3 -m pip list`
-is safe but `python3 -m pip install` is unsafe); known CLIs use their
+is safe but `python3 -m pip install` is unsafe — and `python` inherits
+that whole policy via `"inherits": "python3"`, so a venv's `python -m`
+classifies identically); known CLIs use their
 `rules/shell.json` spec; wrappers (`time`, `xargs`, `timeout`, `env`,
 `nice`, `watch`, ...) re-classify the wrapped command; anything else →
 unknown.
@@ -433,6 +437,49 @@ mutating operation on its own:
 deny-set yet, so only the dialect-agnostic keyword scan applies to them
 today; the field is recorded so adding a deny-set later lights up
 function detection for those services with no further wiring.
+
+## Test runners
+
+Python test invocations classify `safe`:
+
+```
+python3 -m unittest                                  # bare
+python3 -m unittest discover -p "test_*.py"          # discover
+python3 -m unittest tests.test_mod.TestCase.test_x   # explicit target
+python3 -m pytest -q tests/
+pytest -q
+python -m pytest                                     # via inherits
+```
+
+The target after `-m unittest` is a module / class / method path, not a
+verb, so it cannot be enumerated in `safe_subcommands`. It is matched by
+`safe_subcommand_patterns: ["*"]` on the `unittest` and `pytest` entries
+in `rules/shell.json#interpreters.python3.nested_modules`.
+
+**This is a policy call, not a proof.** A test run executes project
+code, and a test is free to write files or call an API. "Safe" here
+means *YOLT will not prompt for it* — the same trade the bundled rules
+already made for bare `python3 -m unittest`. Narrow it in your own
+`~/.claude/yolt/shell.json` if you do not want it:
+
+```json
+{"interpreters": {"python3": {"nested_modules": {
+  "unittest": {"safe_subcommands": ["discover"], "default": "safe"}
+}}}}
+```
+
+Runners for other ecosystems (`go test`, `cargo test`, `npm test`) are
+deliberately not covered by this rule — `npm test` in particular runs
+whatever `package.json` says, which is often a build.
+
+### Interpreter aliases (`inherits`)
+
+An interpreter spec may name another with `"inherits": "<name>"`; the
+base's keys fill in whatever the child does not set, and the child wins
+on any key it does set. `python` inherits `python3` so the two aliases
+cannot drift apart. Inheritance is one level — a base that itself
+declares `inherits` is left unexpanded (no cycles), and naming a
+nonexistent base is a schema-validation error.
 
 ## Python rules (interpreter delegate)
 
@@ -838,6 +885,7 @@ The tree-sitter-bash grammar walker handles:
 | `python3 file.py` | `hooks/yolt_analyzer.py` (stdlib `ast`) |
 | `python3 <<EOF ... EOF` | `hooks/yolt_analyzer.py` (stdlib `ast`) |
 | `python3 -m mod[.sub] ...` | `interpreters.python3.nested_modules` in `rules/shell.json` |
+| `python -m mod[.sub] ...` | same, via `interpreters.python.inherits` |
 
 ### Delegated language analysis (out of scope)
 

--- a/hooks/rule_classifier.py
+++ b/hooks/rule_classifier.py
@@ -651,6 +651,8 @@ _ALLOWED_SERVICE_OVERRIDE_KEYS = frozenset({
 })
 
 _ALLOWED_INTERPRETER_KEYS = frozenset({
+    "_note",
+    "inherits",
     "inline_flag", "module_flag", "delegate", "read_script_file",
     "safe_modules", "unsafe_modules",
     "safe_module_patterns", "unsafe_module_patterns",
@@ -658,6 +660,7 @@ _ALLOWED_INTERPRETER_KEYS = frozenset({
 })
 
 _ALLOWED_NESTED_MODULE_KEYS = frozenset({
+    "_note",
     "default",
     "safe_subcommands", "unsafe_subcommands",
     "safe_subcommand_patterns", "unsafe_subcommand_patterns",
@@ -705,6 +708,19 @@ def validate_shell_rules(rules):
                 errors.append(
                     "interpreters.{}: unknown key '{}'".format(name, key)
                 )
+        base_name = spec.get("inherits")
+        if base_name is not None:
+            base = interpreters.get(base_name)
+            if not isinstance(base, dict):
+                errors.append(
+                    "interpreters.{}: inherits unknown interpreter '{}'"
+                    .format(name, base_name)
+                )
+            elif base.get("inherits") is not None:
+                errors.append(
+                    "interpreters.{}: inherits '{}', which itself inherits "
+                    "(chains are not resolved)".format(name, base_name)
+                )
         nested = spec.get("nested_modules", {})
         if isinstance(nested, dict):
             for mod, mod_spec in nested.items():
@@ -731,6 +747,36 @@ def validate_shell_rules(rules):
                     )
 
     return errors
+
+
+def resolve_interpreter_inheritance(interpreters):
+    """Expand `inherits` in interpreter specs.
+
+    `python` and `python3` (and any future `python3.12`) share one module
+    policy; duplicating `safe_modules` / `nested_modules` per alias is how
+    the two copies drift apart. A spec may name a base with
+    `"inherits": "<other interpreter>"`; the base's keys fill in whatever
+    the child does not set, and the child always wins on a key it does set.
+
+    Inheritance is one level only — a base that itself declares `inherits`
+    is left unexpanded rather than followed, so a cycle cannot hang the
+    hook. Naming a base that does not exist is likewise a no-op here; the
+    validator reports it.
+    """
+    resolved = {}
+    for name, spec in interpreters.items():
+        if not isinstance(spec, dict):
+            resolved[name] = spec
+            continue
+        base_name = spec.get("inherits")
+        base = interpreters.get(base_name) if base_name else None
+        if not isinstance(base, dict):
+            resolved[name] = spec
+            continue
+        merged = {k: v for k, v in base.items() if k not in ("inherits", "_note")}
+        merged.update(spec)
+        resolved[name] = merged
+    return resolved
 
 
 def _validate_command_spec(path, spec, errors):
@@ -864,7 +910,9 @@ class RuleClassifier:
         self.rules = rules
         self.commands = rules.get("commands", {})
         self.shell_builtins_safe = set(rules.get("shell_builtins_safe", []))
-        self.interpreters = rules.get("interpreters", {})
+        self.interpreters = resolve_interpreter_inheritance(
+            rules.get("interpreters", {})
+        )
         self.safe_write_targets = list(rules.get("safe_write_targets", []))
         self.unsafe_write_targets = list(rules.get("unsafe_write_targets", []))
         self.python_analyzer_factory = python_analyzer_factory
@@ -1000,6 +1048,20 @@ class RuleClassifier:
             return (DECISION_SAFE, "{} {}: read-only".format(label, sub))
         if sub in unsafe_subs:
             return (DECISION_UNSAFE, "{} {}: mutating".format(label, sub))
+
+        # Patterns cover namespaces whose "subcommand" slot is really a
+        # free-form target — `python3 -m unittest <test.module>` names a
+        # module, not a verb, so no exact list can enumerate it. Unsafe
+        # patterns are consulted first so a broad safe pattern cannot
+        # swallow a narrower mutating one.
+        for pat in mod_spec.get("unsafe_subcommand_patterns", []):
+            if fnmatch(sub, pat):
+                return (DECISION_UNSAFE,
+                        "{} {}: matches unsafe pattern".format(label, sub))
+        for pat in mod_spec.get("safe_subcommand_patterns", []):
+            if fnmatch(sub, pat):
+                return (DECISION_SAFE,
+                        "{} {}: matches safe pattern".format(label, sub))
 
         return (DECISION_UNKNOWN, "{} {}: no rule".format(label, sub))
 

--- a/rules/shell.json
+++ b/rules/shell.json
@@ -108,15 +108,20 @@
         },
         "unittest": {
           "safe_subcommands": ["discover"],
-          "default": "safe"
+          "safe_subcommand_patterns": ["*"],
+          "default": "safe",
+          "_note": "The positional after `-m unittest` is a test target (module, class, or method path), not a verb, so no list can enumerate it. Bare `unittest`, `unittest discover`, and `unittest pkg.test_mod.TestCase` all classify safe. Deliberate policy call: a test run executes project code, so safe here means 'YOLT will not prompt', not 'provably no side effects'."
+        },
+        "pytest": {
+          "default": "safe",
+          "safe_subcommand_patterns": ["*"],
+          "_note": "pytest takes no subcommands; positionals are paths / node ids. Same policy call as unittest above."
         }
       }
     },
     "python":  {
-      "inline_flag": "-c",
-      "module_flag": "-m",
-      "delegate": "python",
-      "read_script_file": true
+      "inherits": "python3",
+      "_note": "Same binary in practice (venv `python`, `python3.12`). Inheriting keeps one copy of the module policy so the aliases cannot drift."
     },
     "bash":    {"inline_flag": "-c", "delegate": "bash",   "read_script_file": false},
     "sh":      {"inline_flag": "-c", "delegate": "bash",   "read_script_file": false},
@@ -638,6 +643,11 @@
 
     "yarn": {"default": "ask", "_note": "yarn invokes scripts by default. Punt."},
     "pnpm": {"default": "ask"},
+
+    "pytest": {
+      "default": "safe",
+      "_note": "Console-script form of `python3 -m pytest`; classified the same way. See interpreters.python3.nested_modules.pytest for why a test run counts as safe."
+    },
 
     "pip": {
       "default": "subcommand",


### PR DESCRIPTION
## Problem

These prompt on every run:

```
python3 -m unittest test_scan_transcripts -v          -> unknown
python3 -m unittest tests.test_mod.TestCase.test_x    -> unknown
python3 -m pytest -q tests/                           -> unknown
pytest -q                                             -> unknown
python -m pytest                                      -> unknown
```

`unittest`'s nested-module spec can only enumerate verbs, but the token after `-m unittest` is a test *target* (module / class / method path). `pytest` had no rule in any form. The `python` interpreter spec had no module policy at all, so venv `python -m ...` never matched.

## Changes

- **`_classify_nested_module` now implements `safe_subcommand_patterns` / `unsafe_subcommand_patterns`.** The schema validator already accepted both keys while the classifier silently ignored them — the exact drift `validate_shell_rules` exists to catch. Unsafe patterns are consulted first so a broad safe pattern cannot swallow a narrower mutating one.
- **New `inherits` key on interpreter specs**, with `python` inheriting `python3`. One level only: a base that itself inherits is left unexpanded (no cycles), and an unknown base is a validation error. Avoids a second copy of the module policy that drifts from the first.
- **`rules/shell.json`** — `safe_subcommand_patterns: ["*"]` on `unittest`, a new `pytest` nested module, a top-level `pytest` command.
- **README** — new "Test runners" section (+ TOC, boundaries table row).

After:

```
python3 -m unittest test_scan_transcripts -v   -> safe (matches safe pattern)
python3 -m pytest -q tests/                    -> safe
pytest -q                                      -> safe
python -m pytest                               -> safe (via inherits)
python -m pip install foo                      -> unsafe   (unchanged)
python -m http.server                          -> unsafe   (unchanged)
python3 -m nonesuch                            -> unknown  (unchanged)
```

## The policy call

A test run executes project code; a test is free to write files or call an API. `safe` here means *YOLT will not prompt*, not *provably no side effects*. That trade was already made for bare `python3 -m unittest` and `python3 -m unittest discover`; this extends it to the forms people actually type. The README states it plainly and shows the `~/.claude/yolt/shell.json` override that narrows it back.

Runners for other ecosystems (`go test`, `cargo test`, `npm test`) are deliberately **not** covered — `npm test` in particular runs whatever `package.json` says, which is often a build.

## Version

`0.2.0` → `0.3.0`. Minor per CLAUDE.md: user-visible classification change plus a new rules-file key.

## Testing

`python3 -m unittest discover tests`: 582 tests, same 3 environment-dependent failures as `master` in this environment (master shows 4). No new failures. Per repo convention no new tests were added in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
