### PR TITLE
feat(policies): allow self-authored commits, pushes, PRs, and comments

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "yolt",
   "description": "Static safety analyzer for Bash invocations - auto-allows read-only commands and prompts for mutating ones, plus a Python AST analyzer for python3 / python3 -c / heredoc invocations.",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "author": {
     "name": "voitta-ai"
   },

--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@
 - [What the grammar classifier handles](#what-the-grammar-classifier-handles)
 - [SQL CLIs](#sql-clis)
 - [Python rules (interpreter delegate)](#python-rules-interpreter-delegate)
+- [Policies](#policies)
+  - [What is allowed by default](#what-is-allowed-by-default)
+  - [Cost](#cost)
+  - [Turning it off or changing it](#turning-it-off-or-changing-it)
 - [Custom rules](#custom-rules)
   - [Python rules — `~/.claude/yolt/rules.json`](#python-rules---claudeyoltrulesjson)
   - [Shell rules — `~/.claude/yolt/shell.json`](#shell-rules---claudeyoltshelljson)
@@ -517,6 +521,109 @@ Still out of scope: variable rebinding via attribute access,
 Anything the analyzer cannot resolve statically is left at its surface
 name rather than guessed.
 
+## Policies
+
+The rules answer *"does this command mutate anything?"*. That question
+has no good answer for `git commit`: committing to a shared branch other
+people are building on is a very different act from committing to a
+feature branch you opened five minutes ago in your own worktree, and the
+argv is identical. The rules see the argv, so `git commit` is `unsafe`,
+and you approve the same prompt all day.
+
+A **policy** answers a second question — *"is this write confined to work
+that is already mine?"* — and needs repository state to do it. Policies
+live under the `policies` key of `rules/shell.json`.
+
+### What is allowed by default
+
+`self_authored_git`, enabled out of the box:
+
+| Command | Requires |
+| ------- | -------- |
+| `git commit` | linked worktree + non-default branch + solo author |
+| `git push` (no force / delete / foreign refspec) | same |
+| `gh pr create` | same |
+| `gh issue comment`, `gh pr comment` | nothing |
+
+The three predicates:
+
+- **`linked_worktree`** — the command's directory is a `git worktree`,
+  not the primary checkout. Under the convention where the repo dir
+  stays on its default branch and branch work happens in
+  `<repo>.worktrees/<branch>/`, this alone says "this is branch work".
+  Checked with `--git-dir` vs `--git-common-dir`.
+- **`non_default_branch`** — the checked-out branch is not the
+  repository's default. The default comes from `origin/HEAD`, falling
+  back to whichever of `init.defaultBranch` / `main` / `master`
+  actually resolves in this repo. Detached HEAD never qualifies.
+- **`solo_author`** — every commit on this branch that is not on the
+  default branch was authored *and* committed by `git config user.email`.
+  A branch with no commits of its own yet is vacuously solo — that is
+  the state you are in the moment before the first `git commit`.
+
+Three properties keep the layer honest:
+
+1. **It only upgrades.** A policy can turn `unsafe` into `safe`. It can
+   never make a safe command unsafe, and it never sees a command the
+   rules did not already flag.
+2. **Failure means "no".** Every probe is read-only `git` with a 3s
+   timeout. No git, not a repo, timeout, unparseable output, a `-C` path
+   with a shell expansion in it — all resolve to *predicate not
+   satisfied*, so the original `ask` stands.
+3. **It judges the right directory.** `cd /path/to/wt && git commit` is
+   followed (the walker tracks literal `cd` targets in order), and
+   `git -C <path>` retargets the probe. A `cd` the walker cannot resolve
+   statically — `cd "$DIR"`, `cd -` — disables the policy for the rest
+   of that invocation rather than letting it judge the wrong tree.
+
+So these still prompt:
+
+```
+git commit -m x            # in the repo dir, on master
+git push --force           # deny_flags
+git push origin master     # refspec the predicates never examined
+git commit -m x            # branch that has a commit by someone else
+cd "$DIR" && git commit     # unresolvable cd
+```
+
+### Cost
+
+Zero on every command that does not match a policy entry — the probes
+only run after the rules said `unsafe` *and* the argv head matched. On a
+matching command it is ~40ms of read-only `git`, memoized per directory,
+so `git commit ... && git push` probes once.
+
+### Turning it off or changing it
+
+`export YOLT_NO_POLICIES=1` disables the layer wholesale. Otherwise it is
+data like every other rule, and `~/.claude/yolt/shell.json` overrides the
+`policies` key:
+
+```json
+{"policies": {"self_authored_git": {"enabled": false}}}
+```
+
+Add an entry the bundled defaults leave out — `git add` is the obvious
+one, deliberately omitted because staging is not what the policy was
+asked to cover:
+
+```json
+{"policies": {"self_authored_git": {"enabled": true, "allow": [
+  {"argv": ["git", "add"],
+   "require": ["linked_worktree", "non_default_branch", "solo_author"]}
+]}}}
+```
+
+Overrides merge per top-level key, so an `allow` list in your override
+**replaces** the bundled one — copy the entries you want to keep.
+
+Entry fields: `argv` (prefix, matched skipping flags, argv[0] by
+basename), `require` (any of `linked_worktree`, `non_default_branch`,
+`solo_author`; empty means unconditional), `deny_flags`, and
+`deny_default_branch_refspec`. Unknown keys and unknown predicate names
+fail schema validation at hook load — a typo here would be a
+false-allow, not a false-prompt.
+
 ## Custom rules
 
 ### Python rules - `~/.claude/yolt/rules.json`
@@ -936,6 +1043,15 @@ this path:
   `rules-validation-error` and exits silently so Claude Code's
   default prompt fires.
 
+### Policy layer (in scope, and the one place YOLT forks)
+
+The `policies` block re-decides an already-`unsafe` command by probing
+read-only `git` state — see [Policies](#policies). It only upgrades
+`unsafe` -> `safe`, every probe failure counts as "predicate not
+satisfied", and the directory it judges follows literal `cd` and
+`git -C`. An unresolvable `cd` disables it for the rest of the
+invocation.
+
 Schema validation runs at hook load time
 (`hooks/rule_classifier.py:validate_shell_rules`) on both the
 bundled rules and any user override, so a typo in a policy field
@@ -952,4 +1068,8 @@ becomes a hard fail at startup rather than a silent false-allow.
 - **Configurable** — rules are data (`rules/shell.json`,
   `rules/default.json`), not code.
 - **Fast** — classification is purely syntactic; no subprocess fork. A
-  representative compound command parses in ~1ms.
+  representative compound command parses in ~1ms. The one exception is
+  the [policy layer](#policies), which forks read-only `git` probes —
+  only for a command the rules already classified `unsafe`, and only
+  when its argv head matches a configured policy entry. Nothing else
+  pays for it.

--- a/hooks/git_policy.py
+++ b/hooks/git_policy.py
@@ -1,0 +1,388 @@
+"""Policy layer: upgrade `unsafe` to `safe` for writes that are yours alone.
+
+The rest of YOLT is a static checker — it answers "does this command
+mutate anything?" from syntax alone. That question has no good answer for
+`git commit`: committing to a shared branch someone else is building on is
+a very different act from committing to a feature branch you opened five
+minutes ago in your own worktree, and the argv is identical.
+
+So this module answers a different question — "is this write confined to
+work that is already mine?" — and it needs repository state to do it, which
+means shelling out to `git`. That is a deliberate, scoped exception to the
+no-subprocess design principle:
+
+- It runs only when the static classifier already said `unsafe` AND the
+  argv head matches a configured policy entry, so the common path never
+  forks.
+- It can only turn `unsafe` into `safe`. It never makes a safe command
+  unsafe, and it never sees a command the classifier did not already flag.
+- Every probe is read-only `git`, with a timeout, and any failure
+  (no git, not a repo, timeout, weird output) resolves to "predicate not
+  satisfied", i.e. the original `unsafe` stands.
+
+Configuration lives under the `policies` key of `rules/shell.json` and is
+overridable from `~/.claude/yolt/shell.json` like every other rule.
+"""
+
+import os
+import subprocess
+
+# Read-only probes, but a hung git (network filesystem, index.lock
+# contention, a filter process) must not hang the permission prompt.
+_GIT_TIMEOUT_SECONDS = 3
+
+_DEFAULT_BRANCH_FALLBACKS = ("main", "master")
+
+# Predicate names a policy entry may list in its `require` array.
+PREDICATES = ("linked_worktree", "non_default_branch", "solo_author")
+
+
+class GitProbe:
+    """Read-only `git` queries about one directory, memoized per instance.
+
+    One hook invocation classifies one Bash command, but that command may
+    be `git add ... && git commit ... && git push`, which asks the same
+    questions of the same directory three times. Memoizing keeps that at
+    one round of probes.
+    """
+
+    def __init__(self, runner=None):
+        # Injectable for tests; signature mirrors `_run_git`.
+        self._runner = runner or _run_git
+        self._cache = {}
+
+    def state(self, directory):
+        """Return a dict of facts about `directory`, or None if it is not
+        usable as a git working tree."""
+        if directory is None:
+            return None
+        key = os.path.abspath(directory)
+        if key not in self._cache:
+            self._cache[key] = self._probe(key)
+        return self._cache[key]
+
+    def _probe(self, directory):
+        if not os.path.isdir(directory):
+            return None
+
+        out = self._runner(
+            directory,
+            ["rev-parse", "--git-dir", "--git-common-dir", "--abbrev-ref", "HEAD"],
+        )
+        if out is None:
+            return None
+        lines = out.splitlines()
+        if len(lines) < 3:
+            return None
+        git_dir, git_common_dir, branch = lines[0], lines[1], lines[2]
+
+        # In a linked worktree these differ: --git-dir points at
+        # <main>/.git/worktrees/<name> while --git-common-dir points at
+        # <main>/.git. In the primary checkout they are the same path.
+        linked_worktree = os.path.abspath(
+            os.path.join(directory, git_dir)
+        ) != os.path.abspath(os.path.join(directory, git_common_dir))
+
+        return {
+            "directory": directory,
+            "branch": branch,
+            "detached": branch == "HEAD",
+            "linked_worktree": linked_worktree,
+            "default_branch": self._default_branch(directory),
+            "user_email": self._config(directory, "user.email"),
+        }
+
+    def _default_branch(self, directory):
+        # The remote's HEAD is the authoritative answer when the remote
+        # has been fetched at least once.
+        out = self._runner(
+            directory, ["symbolic-ref", "--short", "refs/remotes/origin/HEAD"]
+        )
+        if out:
+            head = out.strip()
+            if head.startswith("origin/"):
+                return head[len("origin/"):]
+
+        # No remote HEAD (never fetched, or no remote). Fall back to
+        # whichever candidate actually resolves in THIS repo.
+        # `init.defaultBranch` is only a candidate, never an answer on its
+        # own: it is a global preference for repos yet to be created, so a
+        # user who sets it to `main` would otherwise make every existing
+        # `master` repo look like it has no default branch.
+        candidates = []
+        configured = self._config(directory, "init.defaultBranch")
+        if configured:
+            candidates.append(configured)
+        candidates.extend(
+            c for c in _DEFAULT_BRANCH_FALLBACKS if c not in candidates
+        )
+
+        for candidate in candidates:
+            for ref in ("refs/remotes/origin/" + candidate, "refs/heads/" + candidate):
+                if self._runner(
+                    directory, ["rev-parse", "--verify", "--quiet", ref]
+                ) is not None:
+                    return candidate
+        return None
+
+    def _config(self, directory, key):
+        out = self._runner(directory, ["config", "--get", key])
+        if not out:
+            return None
+        return out.strip() or None
+
+    def solo_author(self, directory):
+        """True when every commit on this branch that is not on the
+        default branch was authored AND committed by the configured user.
+
+        A branch with no commits of its own yet is vacuously solo — that
+        is the state you are in the moment before the first `git commit`,
+        which is exactly the case this policy exists to allow.
+        """
+        state = self.state(directory)
+        if state is None:
+            return (False, "not a git working tree")
+
+        email = state.get("user_email")
+        if not email:
+            return (False, "git user.email is not configured")
+
+        default_branch = state.get("default_branch")
+        if not default_branch:
+            return (False, "cannot determine the default branch")
+
+        base = None
+        for ref in ("origin/{}".format(default_branch), default_branch):
+            if self._runner(
+                directory, ["rev-parse", "--verify", "--quiet", ref]
+            ) is not None:
+                base = ref
+                break
+        if base is None:
+            return (False, "no {} ref to compare against".format(default_branch))
+
+        out = self._runner(
+            directory, ["log", "--format=%ae%n%ce", "{}..HEAD".format(base)]
+        )
+        if out is None:
+            return (False, "cannot read branch history")
+
+        others = {
+            line.strip() for line in out.splitlines()
+            if line.strip() and line.strip() != email
+        }
+        if others:
+            return (False, "branch has commits by {}".format(
+                ", ".join(sorted(others))
+            ))
+        return (True, "every commit on this branch is {}".format(email))
+
+
+class PolicySet:
+    """Every configured policy, sharing one probe cache."""
+
+    def __init__(self, policies):
+        probe = GitProbe()
+        self.policies = [
+            GitPolicy(spec, probe=probe)
+            for name, spec in sorted((policies or {}).items())
+            if not name.startswith("_") and isinstance(spec, dict)
+        ]
+
+    def evaluate(self, argv, directory):
+        for policy in self.policies:
+            reason = policy.evaluate(argv, directory)
+            if reason is not None:
+                return reason
+        return None
+
+
+def load_policies(rules):
+    """Build the policy set from loaded shell rules. Returns None when
+    nothing is configured, so the classifier can skip the layer entirely."""
+    policy_set = PolicySet(rules.get("policies", {}))
+    if not any(p.enabled and p.entries for p in policy_set.policies):
+        return None
+    return policy_set
+
+
+def _run_git(directory, args):
+    """Run a read-only git command. Returns stdout, or None on any
+    failure — a failed probe must never read as a satisfied predicate."""
+    try:
+        proc = subprocess.run(
+            ["git", "-C", directory, "--no-pager"] + args,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            timeout=_GIT_TIMEOUT_SECONDS,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if proc.returncode != 0:
+        return None
+    return proc.stdout.decode("utf-8", "replace")
+
+
+class GitPolicy:
+    """Evaluates configured policy entries against an argv + directory."""
+
+    def __init__(self, spec, probe=None):
+        spec = spec or {}
+        self.enabled = bool(spec.get("enabled", False))
+        if os.environ.get("YOLT_NO_POLICIES"):
+            self.enabled = False
+        self.entries = [e for e in spec.get("allow", []) if isinstance(e, dict)]
+        self.probe = probe or GitProbe()
+
+    def evaluate(self, argv, directory):
+        """Return (reason_string) when this argv in this directory is
+        allowed by policy, else None. Callers only invoke this for argv
+        the static rules already classified `unsafe`."""
+        if not self.enabled or not argv:
+            return None
+
+        # `git -C <path>` retargets the command; the policy must judge the
+        # directory git will actually act on, not the shell's cwd. Split it
+        # off first so it cannot be mistaken for a subcommand or a refspec.
+        argv, c_target = _split_dash_c(argv)
+
+        entry = self._match(argv)
+        if entry is None:
+            return None
+
+        for flag in entry.get("deny_flags", []):
+            if flag in argv:
+                return None
+
+        directory = _resolve_directory(c_target, directory)
+        if directory is None:
+            return None
+
+        label = " ".join(entry.get("argv", []))
+        requirements = entry.get("require", [])
+
+        if not requirements:
+            return "{}: allowed by policy".format(label)
+
+        state = self.probe.state(directory)
+        if state is None:
+            return None
+        if state.get("detached"):
+            return None
+
+        if "linked_worktree" in requirements and not state["linked_worktree"]:
+            return None
+        if "non_default_branch" in requirements:
+            default_branch = state.get("default_branch")
+            if not default_branch or state["branch"] == default_branch:
+                return None
+        if entry.get("deny_default_branch_refspec") and _pushes_elsewhere(
+            argv, state["branch"]
+        ):
+            return None
+        if "solo_author" in requirements:
+            ok, _detail = self.probe.solo_author(directory)
+            if not ok:
+                return None
+
+        return "{}: {} on {}, authored only by you".format(
+            label,
+            "linked worktree" if state["linked_worktree"] else "working tree",
+            state["branch"],
+        )
+
+    def _match(self, argv):
+        best = None
+        for entry in self.entries:
+            prefix = entry.get("argv", [])
+            if not prefix:
+                continue
+            if _argv_starts_with(argv, prefix):
+                if best is None or len(prefix) > len(best.get("argv", [])):
+                    best = entry
+        return best
+
+
+def _argv_starts_with(argv, prefix):
+    """Match a policy prefix against argv, skipping flags so that
+    `git --no-pager commit` still matches `["git", "commit"]`. argv[0] is
+    compared by basename so `/usr/bin/git` matches."""
+    if not argv or not prefix:
+        return False
+    if os.path.basename(argv[0]) != prefix[0]:
+        return False
+
+    remaining = list(prefix[1:])
+    for tok in argv[1:]:
+        if not remaining:
+            break
+        if tok.startswith("-"):
+            continue
+        if tok != remaining[0]:
+            return False
+        remaining.pop(0)
+    return not remaining
+
+
+def _split_dash_c(argv):
+    """Return (argv without any `-C <path>` pair, the last such path).
+
+    Leaving `-C` in place would break both the prefix match (`/path` reads
+    as the subcommand) and the refspec check (`/path` reads as the remote).
+    """
+    if not argv or os.path.basename(argv[0]) != "git":
+        return (argv, None)
+    out = [argv[0]]
+    target = None
+    i = 1
+    while i < len(argv):
+        tok = argv[i]
+        if tok == "-C" and i + 1 < len(argv):
+            target = argv[i + 1]
+            i += 2
+            continue
+        if tok.startswith("-C") and len(tok) > 2:
+            target = tok[2:]
+            i += 1
+            continue
+        out.append(tok)
+        i += 1
+    return (out, target)
+
+
+def _resolve_directory(c_target, directory):
+    """Resolve a `git -C` target against the shell's directory."""
+    if c_target is None:
+        return directory
+    if _has_expansion(c_target):
+        return None
+    target = os.path.expanduser(c_target)
+    if os.path.isabs(target):
+        return target
+    if directory is None:
+        return None
+    return os.path.join(directory, target)
+
+
+def _has_expansion(token):
+    return "$" in token or "`" in token or "*" in token
+
+
+def _pushes_elsewhere(argv, branch):
+    """True when a `git push` names a ref other than the current branch.
+
+    `git push` and `git push origin <current-branch>` stay inside the
+    policy; `git push origin master` or any `src:dst` refspec is a push at
+    something the predicates never examined, so it falls back to `ask`.
+    """
+    positionals = [
+        tok for tok in argv[1:]
+        if not tok.startswith("-") and tok != "push"
+    ]
+    # positionals[0] is the remote; anything after it is a refspec.
+    for refspec in positionals[1:]:
+        if ":" in refspec:
+            return True
+        if refspec != branch:
+            return True
+    return False

--- a/hooks/grammar_classifier.py
+++ b/hooks/grammar_classifier.py
@@ -51,10 +51,17 @@ class GrammarClassifier:
 
     MAX_RECURSION_DEPTH = 8
 
-    def __init__(self, rules, python_analyzer_factory=None, allow_patterns=None):
+    def __init__(self, rules, python_analyzer_factory=None, allow_patterns=None,
+                 cwd=None, policy=None):
         self.rules = rules
         self.python_analyzer_factory = python_analyzer_factory
         self.allow_patterns = list(allow_patterns) if allow_patterns else []
+        # The shell's directory when the command starts, and the policy
+        # layer that may consult git state there. `_cwd` is re-derived per
+        # `classify()` call because a leading `cd` moves it.
+        self.cwd = cwd
+        self.policy = policy
+        self._cwd = cwd
         self.safe_write_targets = list(rules.get("safe_write_targets", ["/dev/null"]))
         self.unsafe_write_targets = list(rules.get("unsafe_write_targets", []))
         self._rules = RuleClassifier(
@@ -78,6 +85,9 @@ class GrammarClassifier:
 
         if root.has_error:
             return (DECISION_UNKNOWN, "tree-sitter parse error")
+
+        if _depth == 0:
+            self._cwd = self.cwd
 
         decisions = []
         self._walk(root, src, decisions, _depth)
@@ -220,12 +230,53 @@ class GrammarClassifier:
         for c in node.children:
             self._collect_substitutions(c, src, sub_decisions, _depth + 1)
 
+        if cmd_name == "cd":
+            self._track_cd(argv)
+
         match_string = " ".join(argv)
         result = self._rules.classify_tokens(argv)
         result = self._maybe_allow(match_string, result)
+        result = self._maybe_allow_by_policy(argv, result)
         if sub_decisions:
             return aggregate_decisions(sub_decisions + [result])
         return result
+
+    def _track_cd(self, argv):
+        """Follow a literal `cd` so the policy layer judges the directory
+        the later commands actually run in.
+
+        `cd /path/to/worktree && git commit ...` is the shape this exists
+        for. Anything the walker cannot resolve statically — an expansion,
+        `cd -`, a substitution — sets the tracked directory to None, which
+        disables the policy for the rest of the invocation rather than
+        letting it judge the wrong tree.
+        """
+        args = [a for a in argv[1:] if not a.startswith("-")]
+        if not args:
+            self._cwd = os.path.expanduser("~")
+            return
+        target = args[0]
+        if target == "-" or "$" in target or "`" in target or "*" in target:
+            self._cwd = None
+            return
+        target = os.path.expanduser(target)
+        if os.path.isabs(target):
+            self._cwd = target
+        elif self._cwd is not None:
+            self._cwd = os.path.normpath(os.path.join(self._cwd, target))
+
+    def _maybe_allow_by_policy(self, argv, result):
+        """Give the policy layer a chance to upgrade `unsafe` -> `safe`.
+
+        Only `unsafe` is offered: the policy exists to allow writes that
+        are confined to your own work, never to flag something the static
+        rules already cleared."""
+        if self.policy is None or result[0] != DECISION_UNSAFE:
+            return result
+        reason = self.policy.evaluate(argv, self._cwd)
+        if reason is None:
+            return result
+        return (DECISION_SAFE, reason)
 
     def _collect_substitutions(self, node, src, decisions, _depth):
         if node.type in ("command_substitution", "process_substitution"):
@@ -467,12 +518,15 @@ class GrammarClassifier:
         return None
 
 
-def classify_command(command, rules, python_analyzer_factory=None, allow_patterns=None):
+def classify_command(command, rules, python_analyzer_factory=None,
+                     allow_patterns=None, cwd=None, policy=None):
     """Module-level convenience wrapper."""
     classifier = GrammarClassifier(
         rules,
         python_analyzer_factory=python_analyzer_factory,
         allow_patterns=allow_patterns,
+        cwd=cwd,
+        policy=policy,
     )
     return classifier.classify(command)
 
@@ -510,11 +564,15 @@ def run_cli():
     def factory():
         return SafetyAnalyzer(py_rules)
 
+    from git_policy import load_policies
+
     decision, reason = classify_command(
         command,
         rules,
         python_analyzer_factory=factory,
         allow_patterns=allow_patterns,
+        cwd=str(cwd),
+        policy=load_policies(rules),
     )
 
     print(json.dumps({"decision": decision, "reason": reason}, indent=2))

--- a/hooks/rule_classifier.py
+++ b/hooks/rule_classifier.py
@@ -619,6 +619,13 @@ _ALLOWED_TOP_LEVEL_KEYS = frozenset({
     "shell_builtins_safe", "shell_keywords",
     "safe_write_targets", "unsafe_write_targets",
     "commands", "interpreters",
+    "policies",
+})
+
+_ALLOWED_POLICY_KEYS = frozenset({"_note", "enabled", "allow"})
+
+_ALLOWED_POLICY_ENTRY_KEYS = frozenset({
+    "_note", "argv", "require", "deny_flags", "deny_default_branch_refspec",
 })
 
 _ALLOWED_COMMAND_KEYS = frozenset({
@@ -730,7 +737,60 @@ def validate_shell_rules(rules):
                         .format(name, mod, mod_default)
                     )
 
+    _validate_policies(rules.get("policies", {}), errors)
+
     return errors
+
+
+def _validate_policies(policies, errors):
+    """Schema-check the `policies` block.
+
+    A policy can only turn `unsafe` into `safe`, so a typo here is a
+    false-allow, not a false-prompt. Unknown keys and unknown predicate
+    names are hard errors for the same reason the rest of the validator
+    exists: the classifier would silently ignore them."""
+    from git_policy import PREDICATES
+
+    if not isinstance(policies, dict):
+        errors.append("policies: must be a dict")
+        return
+
+    for name, spec in policies.items():
+        if name.startswith("_"):
+            continue
+        path = "policies.{}".format(name)
+        if not isinstance(spec, dict):
+            errors.append("{}: must be a dict".format(path))
+            continue
+        for key in spec:
+            if key not in _ALLOWED_POLICY_KEYS:
+                errors.append("{}: unknown key '{}'".format(path, key))
+
+        entries = spec.get("allow", [])
+        if not isinstance(entries, list):
+            errors.append("{}.allow: must be a list".format(path))
+            continue
+        for i, entry in enumerate(entries):
+            entry_path = "{}.allow[{}]".format(path, i)
+            if not isinstance(entry, dict):
+                errors.append("{}: must be a dict".format(entry_path))
+                continue
+            for key in entry:
+                if key not in _ALLOWED_POLICY_ENTRY_KEYS:
+                    errors.append(
+                        "{}: unknown key '{}'".format(entry_path, key)
+                    )
+            argv = entry.get("argv")
+            if not isinstance(argv, list) or not argv:
+                errors.append(
+                    "{}: 'argv' must be a non-empty list".format(entry_path)
+                )
+            for predicate in entry.get("require", []):
+                if predicate not in PREDICATES:
+                    errors.append(
+                        "{}: unknown predicate '{}' (known: {})"
+                        .format(entry_path, predicate, ", ".join(PREDICATES))
+                    )
 
 
 def _validate_command_spec(path, spec, errors):

--- a/hooks/yolt_analyzer.py
+++ b/hooks/yolt_analyzer.py
@@ -1099,6 +1099,7 @@ def run_hook():
         if str(hooks_dir) not in sys.path:
             sys.path.insert(0, str(hooks_dir))
         from grammar_classifier import GrammarClassifier
+        from git_policy import load_policies
         from rule_classifier import (
             DECISION_SAFE, DECISION_UNSAFE,
             ShellRulesValidationError,
@@ -1134,6 +1135,8 @@ def run_hook():
         shell_rules,
         python_analyzer_factory=_python_factory,
         allow_patterns=allow_patterns,
+        cwd=cwd_str,
+        policy=load_policies(shell_rules),
     )
     decision, reason = classifier.classify(command)
     _log_hook_decision(command, decision, reason, permission_mode, agent_id)

--- a/rules/shell.json
+++ b/rules/shell.json
@@ -4,6 +4,42 @@
     "description": "YOLT shell command classification rules. Used to decide whether the *full* invocation of a Bash command is read-only (auto-allow) or mutating (ask)."
   },
 
+  "policies": {
+    "_note": "Policies answer a question static analysis cannot: not 'does this mutate?' but 'is this write confined to work that is already mine?'. They run ONLY on commands the rules already classified unsafe, they can only upgrade unsafe -> safe, and every predicate is a read-only git probe that resolves to 'not satisfied' on any failure. Set enabled=false (or export YOLT_NO_POLICIES=1) to turn the layer off.",
+    "self_authored_git": {
+      "enabled": true,
+      "allow": [
+        {
+          "argv": ["git", "commit"],
+          "require": ["linked_worktree", "non_default_branch", "solo_author"],
+          "_note": "Committing to a branch nobody else has touched, in a worktree that is not the primary checkout."
+        },
+        {
+          "argv": ["git", "push"],
+          "require": ["linked_worktree", "non_default_branch", "solo_author"],
+          "deny_flags": ["-f", "--force", "--force-with-lease", "--force-if-includes", "--delete", "--mirror", "--prune", "--all", "--tags", "--follow-tags"],
+          "deny_default_branch_refspec": true,
+          "_note": "Bare `git push` or `git push [-u] <remote> <current-branch>`. History rewrites, deletions, and pushing any ref other than the branch the predicates examined still ask."
+        },
+        {
+          "argv": ["gh", "pr", "create"],
+          "require": ["linked_worktree", "non_default_branch", "solo_author"],
+          "_note": "Opening a PR for the branch you are standing on."
+        },
+        {
+          "argv": ["gh", "issue", "comment"],
+          "require": [],
+          "_note": "A comment is additive and reversible and carries no repository state, so it needs no predicate."
+        },
+        {
+          "argv": ["gh", "pr", "comment"],
+          "require": []
+        }
+      ],
+      "_note": "To also skip the prompt on `git add`, append {\"argv\": [\"git\", \"add\"], \"require\": [\"linked_worktree\", \"non_default_branch\", \"solo_author\"]} in ~/.claude/yolt/shell.json. It is out of the bundled defaults because staging is not what the policy was asked to cover."
+    }
+  },
+
   "shell_builtins_safe": [
     "echo", "printf", "pwd", "true", "false",
     "test", "[", "[[",


### PR DESCRIPTION
## Why

The rules answer *"does this command mutate anything?"*. That question has no good answer for `git commit`: committing to a shared branch other people are building on is a very different act from committing to a feature branch you opened five minutes ago in your own worktree — and the argv is identical. So `git commit` is `unsafe`, and the same prompt gets approved all day.

This adds a **policy layer** that answers a second question: *"is this write confined to work that is already mine?"* That needs repository state, so it shells out to read-only `git`.

## The design-principle carve-out

"Purely syntactic; no subprocess fork" is not repealed, it is scoped:

- Probes run **only** after the static rules already returned `unsafe` **and** the argv head matched a configured policy entry. The common path never forks.
- A policy can **only** upgrade `unsafe` → `safe`. It never makes a safe command unsafe, and it never sees a command the rules cleared.
- **Every probe failure means "no"** — no git, not a repo, 3s timeout, unparseable output, a `-C` path containing a shell expansion. The original `ask` stands.

## What is allowed by default

`self_authored_git`, enabled out of the box:

| Command | Requires |
| ------- | -------- |
| `git commit` | `linked_worktree` + `non_default_branch` + `solo_author` |
| `git push` (no force / delete / foreign refspec) | same |
| `gh pr create` | same |
| `gh issue comment`, `gh pr comment` | nothing — additive and reversible, no repository state |

Predicates:

- **`linked_worktree`** — `--git-dir` != `--git-common-dir`, i.e. not the primary checkout. Under the repo-stays-on-default-branch + `<repo>.worktrees/<branch>` convention, this alone says "this is branch work".
- **`non_default_branch`** — default from `origin/HEAD`, falling back to whichever of `init.defaultBranch` / `main` / `master` actually resolves *in this repo*. `init.defaultBranch` is a global preference for repos yet to be created, so it is treated as a candidate, never as an answer — otherwise setting it to `main` makes every existing `master` repo look like it has no default branch. Detached HEAD never qualifies.
- **`solo_author`** — every commit in `<default>..HEAD` was authored **and** committed by `git config user.email`. A branch with no commits of its own is vacuously solo — the state you are in the moment before the first `git commit`, which is exactly the case this exists to allow.

## Judging the right directory

`cd /path/to/wt && git commit` is the shape this exists for, so the walker tracks literal `cd` targets in source order, and `git -C <path>` retargets the probe. A `cd` that cannot be resolved statically (`cd "$DIR"`, `cd -`) sets the tracked directory to `None`, which disables the policy for the rest of the invocation rather than letting it judge the wrong tree.

## Verified matrix

In a real linked worktree on a solo branch:

```
git commit -m "x"                              safe   linked worktree on feature/..., authored only by you
git --no-pager commit -m "x"                   safe
git push                                       safe
git push -u origin feature/git-worktree-allow  safe
gh pr create --title t --body b                safe
gh issue comment 5 --body hi                   safe   allowed by policy
```

Still prompts:

```
git push origin master     unsafe   refspec the predicates never examined
git push --force           unsafe   deny_flags
cd $SOMEWHERE && git commit unsafe  unresolvable cd
cd /tmp && git commit      unsafe   not a repo
```

Against a synthetic repo (primary + linked worktree, then a commit forged with another `GIT_AUTHOR_EMAIL`):

```
worktree, solo branch                      safe
same branch after a commit by someone else unsafe
primary checkout on main                   unsafe
detached HEAD in the worktree              unsafe
YOLT_NO_POLICIES=1                         unsafe
```

## Configuration

Data like every other rule — `policies` in `rules/shell.json`, overridable from `~/.claude/yolt/shell.json`, `YOLT_NO_POLICIES=1` as a wholesale kill switch. Entry fields: `argv` (prefix, matched skipping flags, `argv[0]` by basename), `require`, `deny_flags`, `deny_default_branch_refspec`. Unknown keys and unknown predicate names fail schema validation at hook load — a typo here would be a false-*allow*, not a false-prompt.

`git add` is deliberately **not** in the defaults (staging is not what the policy was asked to cover), so `git add -A && git commit && git push` still prompts on the `git add`. The README shows the two-line override that adds it.

## Cost

0ms on every command that does not match. ~40ms on a match, memoized per directory so `git commit ... && git push` probes once.

## Version

`0.2.0` → `0.3.0`. Minor per CLAUDE.md: user-visible decision change, new config key, new env var. (Note: #81 also targets `0.3.0`; whichever merges second needs the trivial bump conflict resolved.)

## Testing

`python3 -m unittest discover tests`: 582 tests, same 3 environment-dependent failures as `master` here. No new failures. Per repo convention no new tests were added in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
