### PR TITLE
feat(review): offer /yolt:contribute from a UserPromptSubmit nudge

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "yolt",
   "description": "Static safety analyzer for Bash invocations - auto-allows read-only commands and prompts for mutating ones, plus a Python AST analyzer for python3 / python3 -c / heredoc invocations.",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "author": {
     "name": "voitta-ai"
   },

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@
   - [Shell rules — `~/.claude/yolt/shell.json`](#shell-rules---claudeyoltshelljson)
 - [Debug / dogfood log](#debug--dogfood-log)
 - [Self-improvement loop](#self-improvement-loop)
+  - [Contributing a rules fix upstream (`/yolt:contribute`)](#contributing-a-rules-fix-upstream-yoltcontribute)
 - [CLI usage](#cli-usage)
 - [Tests and demo](#tests-and-demo)
 - [Analysis boundaries](#analysis-boundaries)
@@ -711,12 +712,47 @@ stripped to `<...>`) may leave the machine in an upstream issue. The
 - **SessionEnd** regenerates the doc with `--generate --if-stale`: a
   no-op (just an mtime check) when the log has not changed since the last
   run, so quiet sessions cost almost nothing.
+- **UserPromptSubmit** offers `/yolt:contribute` once per session when
+  *this* session hit enough distinct friction — see below.
+
+### Contributing a rules fix upstream (`/yolt:contribute`)
+
+`/yolt:review` triages friction into *your* settings and *your*
+overrides. The other outcome is that the bundled rules are wrong, and the
+fix belongs upstream where everyone gets it. `/yolt:contribute` covers
+that path: interview, then an issue and a PR on voitta-ai/voitta-yolt for
+the maintainers to review.
+
+The timing is the point. A log line records that `foo bar` prompted, but
+only the session that produced it still knows *what you were doing* — and
+that is exactly what decides whether the fix is a whole-command default, a
+subcommand entry, or a flag-conditional rule. So the offer arrives while
+the session is still live, from a `UserPromptSubmit` hook, in the same
+shape as any other end-of-turn evaluation: **it is an offer, and a
+declined offer is dropped for the rest of the session.**
+
+The nudge fires at most once per session, and only after the session has
+hit at least `YOLT_SESSION_NUDGE_MIN` (default 3) **distinct** friction
+prefixes — ten prompts on one command is one gap, and one gap is not worth
+interrupting for. It is cheap enough to run on every prompt because it
+reads the decision log from a stored byte offset (`~/.claude/yolt/
+sessions.json`), never from the top; a session seen for the first time
+records the current end-of-file, so it only ever counts its own records.
+
+The command itself will not draft anything until the interview
+establishes: what you were doing, whether the command is read-only under
+*every* flag, whether some flag could make it write, whether the rule
+should apply to other people's machines, and what the narrowest fix is. If
+the answers say "local", it routes you back to `/yolt:review`. Only the
+redacted `shape` field leaves the machine, and the PR must show both the
+now-allowed invocation and the still-prompting mutating variant.
 
 Run it by hand the same way the hooks do:
 
 ```bash
 python3 hooks/yolt_review.py --generate   # parse logs, write doc + state
 python3 hooks/yolt_review.py --status     # {"pending": N, ...}
+python3 hooks/yolt_review.py --session-nudge < payload.json  # UserPromptSubmit offer
 python3 hooks/yolt_review.py --list       # full suggestion JSON
 python3 hooks/yolt_review.py --applied <id> [<id> ...]
 python3 hooks/yolt_review.py --dismiss <id> [<id> ...]

--- a/commands/contribute.md
+++ b/commands/contribute.md
@@ -1,0 +1,167 @@
+---
+description: Interview the user about this session's YOLT friction and, if it is a real rules gap, open an issue and a PR on voitta-ai/voitta-yolt
+---
+
+# /yolt:contribute
+
+`/yolt:review` triages friction into *your* settings and *your* overrides.
+This command is for the other outcome: the friction is a gap in the
+**bundled** rules, so the fix belongs upstream where every YOLT user gets
+it.
+
+You are the author here, not the maintainer. The output is an issue and a
+PR for the YOLT maintainers to review — never a merge.
+
+This command may be invoked directly, or offered by the UserPromptSubmit
+nudge after a session accumulates friction. **If the user declines at any
+step, stop and say nothing further about it.**
+
+## Step 1 — Gather
+
+```bash
+python3 "${CLAUDE_PLUGIN_ROOT}/hooks/yolt_review.py" --generate
+python3 "${CLAUDE_PLUGIN_ROOT}/hooks/yolt_review.py" --list
+```
+
+Work from the `--list` JSON. Do not re-derive suggestions by reading the
+raw log.
+
+Candidates for this command are the suggestions where the *bundled rules*
+are wrong or missing:
+
+- `upstream_candidate: true` — a common CLI repeatedly hitting `unknown`.
+- `friction-unsafe` with a high `approved` count — YOLT prompted, and the
+  user approved anyway, every time. That is a rule that is too broad.
+- A `friction-unknown` on a shape rather than a tool: an invocation form
+  the grammar walker does not model (a wrapper, an interpreter flag, a
+  redirect target class).
+
+Explicitly **not** candidates, route these to `/yolt:review` instead:
+
+- A personal or internal CLI nobody else has. That is a local override.
+- `friction-unsafe` with `approved: 0` — YOLT prompted and the user
+  declined. YOLT was right.
+- A `fastpath` suggestion. That is a `settings.json` question.
+
+If nothing qualifies, say so in one line and stop.
+
+## Step 2 — Interview
+
+Do not skip to drafting. A rules PR that encodes a wrong generalization is
+worse than the prompt it removes, and the answers below are what separate
+the two. Ask, in order, and stop early if an answer disqualifies the case:
+
+1. **What were you doing?** The command shape alone does not say whether
+   `foo deploy --dry-run` is read-only. The user's intent does.
+2. **Is it read-only under every flag, or only some?** This picks the fix:
+   a whole-command `default: "safe"`, a `safe_subcommands` entry, or a
+   flag-conditional rule (`unsafe_flag_values`, `unsafe_flag_any_value`,
+   ...). If the answer is "only some", get the mutating flags by name.
+3. **Can it be made to write with a flag you did not use?** Almost every
+   read verb has one (`--output`, `-o`, `--save`, `--export`). If so, the
+   rule needs `write_flag_value_targets` or the flag on an unsafe list —
+   not a blanket safe.
+4. **Would you want this for someone else's machine?** The bundled rules
+   ship to everyone. "I always run this in a scratch dir" is a local
+   override, not an upstream rule.
+5. **What is the narrowest fix that removes the prompt?** Prefer a
+   subcommand entry over a whole-command default; prefer a flag rule over
+   a subcommand entry when the mutation is flag-driven.
+
+Summarize the answers back in three or four lines and get an explicit
+"yes, file it" before Step 3. If the interview shows the fix is really a
+local one, say so and point at `/yolt:review`.
+
+## Step 3 — Redaction (before anything leaves the machine)
+
+Only the redacted `shape` field (argv head plus flag names, every value
+stripped to `<...>`) may go upstream. The `examples` field is raw log data
+— real paths, account ids, possibly secrets — and stays local.
+
+Say this to the user, and show them the exact `shape` strings that will
+appear in the issue and PR before creating either.
+
+## Step 4 — Issue
+
+```bash
+gh issue create --repo voitta-ai/voitta-yolt \
+  --title "rules: <cli> <subcommand> classifies unknown/unsafe but is read-only" \
+  --body-file <tmpfile>
+```
+
+The body should carry: the redacted shape(s), the fire count, what the
+current decision is and what it should be, the flag conditions from the
+interview (especially any flag that *would* make it mutating), and the
+proposed rule shape. Show the draft and create it only on approval.
+
+## Step 5 — PR
+
+Follow the repo's own conventions — they are in its `CLAUDE.md`, read it
+first.
+
+1. **Worktree, not a branch in the repo dir.** The repo stays on its
+   default branch:
+
+   ```bash
+   git -C <yolt-repo> fetch origin
+   git -C <yolt-repo> worktree add <yolt-repo>.worktrees/<branch> -b <branch> origin/master
+   ```
+
+   Locate the repo before cloning; the user may already have it checked
+   out. If not, ask where to put it rather than picking a directory.
+
+2. **Edit `rules/shell.json`** with the narrowest fix from the interview.
+   Add a `_note` explaining *why*, including the flag conditions — the
+   next person to touch that entry needs the reasoning, not just the verb.
+
+3. **Verify the classification actually flipped**, both directions:
+
+   ```bash
+   python3 hooks/grammar_classifier.py '<the read-only invocation>'   # expect safe
+   python3 hooks/grammar_classifier.py '<the mutating variant>'       # expect unsafe/unknown
+   ```
+
+   Include both in the PR body. A rules PR without the negative case is
+   not reviewable.
+
+4. **Run the suite** and report the result honestly, including any
+   pre-existing failures:
+
+   ```bash
+   python3 -m unittest discover tests
+   ```
+
+5. **Bump `.claude-plugin/plugin.json#version`** in the PR itself. A rules
+   change is a MINOR bump. This is not optional — see the repo's
+   `CLAUDE.md` for why an unbumped version means nobody receives the fix.
+
+6. **Open the PR**, linking the issue from Step 4:
+
+   ```bash
+   gh pr create --repo voitta-ai/voitta-yolt --base master \
+     --title "..." --body-file <tmpfile>
+   ```
+
+## Step 6 — Record and report
+
+Mark the suggestions so they stop resurfacing:
+
+```bash
+python3 "${CLAUDE_PLUGIN_ROOT}/hooks/yolt_review.py" --applied <id> [<id> ...]
+```
+
+Then tell the user, in a few lines: the issue URL, the PR URL, what the
+rule now says, and what still prompts (the negative case). Say plainly
+that the PR is pending maintainer review and is not merged.
+
+## Notes
+
+- The user can decline at every step. A declined offer is dropped for the
+  session; do not re-raise it.
+- The nudge that offers this command fires at most once per session, when
+  the session hit at least `YOLT_SESSION_NUDGE_MIN` (default 3) *distinct*
+  friction prefixes. Set it higher for fewer offers.
+- Nothing here writes to the user's `settings.json` or
+  `~/.claude/yolt/shell.json`. That is `/yolt:review`'s job, and the two
+  are deliberately separate: a local override is yours, a rules change is
+  everyone's.

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -22,6 +22,16 @@
         ]
       }
     ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/user-prompt-submit.sh"
+          }
+        ]
+      }
+    ],
     "SessionStart": [
       {
         "hooks": [

--- a/hooks/user-prompt-submit.sh
+++ b/hooks/user-prompt-submit.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# YOLT (You Only Live Twice) - UserPromptSubmit hook for Claude Code.
+#
+# Offers /yolt:contribute once per session, when THIS session has hit
+# enough distinct Bash friction to be worth looking at while the context
+# that produced it is still in the window. That timing is the whole point:
+# a log line records that `foo bar` prompted, but only the live session
+# still knows what you were doing and why the prompt was wrong.
+#
+# The SessionStart nudge (--nudge) is the other half and points at
+# accumulated, already-distilled suggestions via /yolt:review. This one is
+# about the session you are in.
+#
+# It is an offer. The injected context says so, and says explicitly that a
+# declined offer is dropped for the rest of the session.
+#
+# Cheap by construction: reads the decision log from a stored byte offset,
+# never from the top, and fires at most once per session. Best-effort --
+# any failure exits silently so a prompt is never blocked.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+exec python3 "$SCRIPT_DIR/yolt_review.py" --session-nudge

--- a/hooks/yolt_review.py
+++ b/hooks/yolt_review.py
@@ -98,6 +98,32 @@ RAN_MATCH_SKEW_SECONDS = 5
 # direction -- better than fabricating an approval.
 RAN_MATCH_WINDOW_SECONDS = 600
 
+SESSION_STATE_NAME = "sessions.json"
+
+# How many DISTINCT friction prefixes this session must hit before the
+# UserPromptSubmit nudge fires. Distinct, not total: ten prompts on the
+# same command is one gap, and one gap is not worth interrupting for.
+SESSION_NUDGE_MIN_PREFIXES = 3
+MAX_TRACKED_SESSIONS = 20
+
+# Decision values in the log that count as friction for the session nudge.
+KIND_DECISION_UNSAFE = "unsafe"
+KIND_DECISION_UNKNOWN = "unknown"
+
+SESSION_NUDGE_TEMPLATE = (
+    "YOLT friction in this session: {fires} prompt(s) across {distinct}"
+    " distinct commands ({sample}).\n"
+    "AFTER you finish the user's current request, evaluate whether that"
+    " friction is a YOLT rules gap worth fixing upstream -- i.e. a common"
+    " CLI or invocation shape that should have classified read-only. If it"
+    " is, tell the user in one line what you saw and offer /yolt:contribute"
+    " (interview, then an issue + PR on voitta-ai/voitta-yolt). If it is"
+    " not -- YOLT was right to prompt, or the command is personal to this"
+    " machine -- say nothing about it.\n"
+    "This is an offer, not a task. If the user declines or ignores it, drop"
+    " it and do not raise it again this session."
+)
+
 KIND_UNSAFE = "friction-unsafe"
 KIND_UNKNOWN = "friction-unknown"
 KIND_FASTPATH = "fastpath"
@@ -1000,6 +1026,132 @@ def cmd_nudge(args):
     return 0
 
 
+def cmd_session_nudge(args):
+    """UserPromptSubmit helper. Emits an `additionalContext` block once per
+    session, when THIS session has hit enough distinct friction to be worth
+    reviewing while the context that produced it is still in the window.
+
+    `--nudge` (SessionStart) points at accumulated, already-distilled
+    suggestions. This one is about the session you are in: it is the
+    moment the reasoning behind a rules gap is still recoverable, which is
+    what turns friction into a filable issue instead of a log line.
+
+    Deliberately cheap, because it runs on every prompt: the log is read
+    from a stored byte offset, never from the top. A session seen for the
+    first time records the current end-of-file as its offset, so it only
+    ever counts its own records.
+    """
+    payload = {}
+    if not sys.stdin.isatty():
+        try:
+            payload = json.load(sys.stdin) or {}
+        except (json.JSONDecodeError, EOFError, OSError):
+            payload = {}
+    session_id = payload.get("session_id") or "unknown"
+
+    log_path = resolve_log_path(args.log)
+    if log_path is None:
+        # Logging opted out; there is nothing to mine.
+        return 0
+    state_dir = resolve_state_dir(args.state_dir)
+    sessions_path = state_dir / SESSION_STATE_NAME
+
+    try:
+        size = log_path.stat().st_size
+    except OSError:
+        return 0
+
+    sessions = _load_json_obj(sessions_path) or {}
+    if not isinstance(sessions, dict):
+        sessions = {}
+    entry = sessions.get(session_id)
+    first_sight = entry is None
+    if first_sight:
+        entry = {"offset": size, "nudged": False}
+        sessions[session_id] = entry
+
+    if entry.get("nudged"):
+        return 0
+
+    offset = min(entry.get("offset", 0), size)
+    prefixes, fires = _scan_friction_since(log_path, offset)
+
+    threshold = _session_nudge_threshold()
+    if len(prefixes) < threshold:
+        _save_sessions(sessions_path, sessions)
+        return 0
+
+    entry["nudged"] = True
+    _save_sessions(sessions_path, sessions)
+
+    message = SESSION_NUDGE_TEMPLATE.format(
+        fires=fires,
+        distinct=len(prefixes),
+        sample=", ".join("`{}`".format(p) for p in prefixes[:5]),
+    )
+    print(json.dumps({
+        "hookSpecificOutput": {
+            "hookEventName": "UserPromptSubmit",
+            "additionalContext": message,
+        }
+    }))
+    return 0
+
+
+def _session_nudge_threshold():
+    raw = os.environ.get("YOLT_SESSION_NUDGE_MIN")
+    if raw:
+        try:
+            return max(1, int(raw))
+        except ValueError:
+            pass
+    return SESSION_NUDGE_MIN_PREFIXES
+
+
+def _scan_friction_since(log_path, offset):
+    """Return (distinct friction prefixes, total friction fires) from the
+    log tail starting at `offset`. Compound commands are counted but never
+    contribute a prefix, matching how suggestions are grouped."""
+    seen = []
+    fires = 0
+    try:
+        with open(log_path, "r", errors="replace") as f:
+            f.seek(offset)
+            for line in f:
+                try:
+                    record = json.loads(line)
+                except (json.JSONDecodeError, ValueError):
+                    continue
+                if record.get("decision") not in (KIND_DECISION_UNSAFE,
+                                                  KIND_DECISION_UNKNOWN):
+                    continue
+                fires += 1
+                command = record.get("command", "")
+                if is_compound(command):
+                    continue
+                prefix = group_key(command)
+                if prefix and prefix not in seen:
+                    seen.append(prefix)
+    except OSError:
+        return ([], 0)
+    return (seen, fires)
+
+
+def _save_sessions(path, sessions):
+    """Persist per-session nudge state, keeping only the most recent few.
+
+    Sessions are never explicitly ended here, so without a cap this file
+    would grow one entry per session forever."""
+    if len(sessions) > MAX_TRACKED_SESSIONS:
+        keys = list(sessions)[-MAX_TRACKED_SESSIONS:]
+        sessions = {k: sessions[k] for k in keys}
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        _atomic_write_json(path, sessions)
+    except OSError:
+        pass
+
+
 def cmd_list(args):
     state_dir = resolve_state_dir(args.state_dir)
     state = load_state(state_dir / STATE_NAME)
@@ -1190,6 +1342,11 @@ def main():
     group.add_argument("--generate", action="store_true")
     group.add_argument("--status", action="store_true")
     group.add_argument("--nudge", action="store_true")
+    group.add_argument("--session-nudge", action="store_true",
+                       dest="session_nudge",
+                       help="UserPromptSubmit helper: offer /yolt:contribute "
+                            "once per session when this session hit enough "
+                            "distinct friction")
     group.add_argument("--list", action="store_true")
     group.add_argument("--applied", nargs="+", metavar="ID", dest="applied_ids")
     group.add_argument("--dismiss", nargs="+", metavar="ID", dest="dismiss_ids")
@@ -1206,6 +1363,8 @@ def main():
         retval = cmd_status(args)
     elif args.nudge:
         retval = cmd_nudge(args)
+    elif args.session_nudge:
+        retval = cmd_session_nudge(args)
     elif args.list:
         retval = cmd_list(args)
     elif args.applied_ids:


### PR DESCRIPTION
## Why

The reviewer already routes a repeated `unknown` on a common CLI to "upstream issue" (`upstream_candidate: true`), but nothing carried that the rest of the way — no interview, no issue, no PR. And the routing happens at **SessionEnd**, by which point the only context that can answer *"is this read-only under every flag, or just the one you ran?"* is gone.

So the offer moves into the live session, in the same shape as any other end-of-turn evaluation: an **offer**, which the user can decline.

## What

**`yolt_review.py --session-nudge`**, wired to a new `UserPromptSubmit` hook:

- Fires **at most once per session**, and only after the session has hit `YOLT_SESSION_NUDGE_MIN` (default 3) **distinct** friction prefixes. Distinct, not total — ten prompts on one command is one gap, and one gap is not worth interrupting for.
- The injected context says explicitly that it is an offer, that it should be evaluated *after* the user's current request, and that a declined offer is dropped for the rest of the session.
- Cheap enough for every prompt: reads the decision log from a stored byte offset in `~/.claude/yolt/sessions.json`, never from the top. A session seen for the first time records the current EOF as its offset, so it only ever counts its own records. Capped at the last 20 sessions, since nothing here observes a session ending.

**`/yolt:contribute`** — interview, then an issue and a PR on `voitta-ai/voitta-yolt` for the maintainers to review (never a merge).

The interview *is* the command, not preamble. It refuses to draft until it has: what you were doing; whether the command is read-only under every flag or only some; whether a flag you did not use could make it write (`--output`, `--save`, ...); whether the rule should apply to other people's machines; and what the narrowest fix is. An answer that says "local" routes back to `/yolt:review`. A rules PR that encodes a wrong generalization is worse than the prompt it removes.

The PR step follows the repo's own conventions: worktree (repo stays on its default branch), a `_note` on the rule carrying the *why*, both `grammar_classifier.py` invocations in the body (the now-allowed one **and** the still-prompting mutating variant — a rules PR without the negative case is not reviewable), the test suite result reported honestly, and the version bump in the PR itself.

Redaction is unchanged and restated in the command: only the redacted `shape` field leaves the machine; `examples` are raw log data and stay local.

## Division of labor

`/yolt:review` is untouched and still owns the local half. The split is deliberate: **a local override is yours, a rules change is everyone's.**

| | `/yolt:review` | `/yolt:contribute` |
| - | - | - |
| Surfaced by | SessionStart, throttled 24h | UserPromptSubmit, once per session |
| About | accumulated, distilled suggestions | the session you are in |
| Writes | `settings.json`, `~/.claude/yolt/shell.json` | an upstream issue + PR |

## Verified

```
first sight of a session        silent (records offset)
2 distinct prefixes             silent (below threshold)
3 distinct prefixes             nudge emitted
same session again              silent (once per session)
new session, log past offset    silent
YOLT_SESSION_NUDGE_MIN=1        nudge at 1 prefix
YOLT_LOG_FILE=""                silent, exit 0
```

`hooks.json` parses; `python3 -m unittest discover tests` → 582 tests, same 3 environment-dependent failures as `master` here, no new ones. Per repo convention no new tests were added in this PR.

## Version

`0.2.0` → `0.3.0`. Minor per CLAUDE.md: new slash command, new hook event, new env var. (#81 and #82 also target `0.3.0`; whichever merges last needs the trivial bump conflict resolved.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
