### PR TITLE
fix(logs): redact credentials before writing yolt.log / yolt-ran.log (#84)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "yolt",
   "description": "Static safety analyzer for Bash invocations - auto-allows read-only commands and prompts for mutating ones, plus a Python AST analyzer for python3 / python3 -c / heredoc invocations.",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "author": {
     "name": "voitta-ai"
   },

--- a/README.md
+++ b/README.md
@@ -627,6 +627,47 @@ YOLT rotates the log when it grows past 5 MB by renaming it to
 preserved. `YOLT_LOG_MAX_BYTES` overrides the threshold; set
 `YOLT_LOG_MAX_BYTES=0` to disable rotation.
 
+### Credential redaction
+
+Credentials land on command lines routinely — `curl -H "X-Api-Key: ..."`,
+`--token`, connection strings — and both logs are append-only, so
+anything written to them should be assumed permanent. Before a record is
+written, credential-shaped substrings in `command` (and in `reason`) are
+replaced with a `[REDACTED:<shape>]` marker naming the shape only, never
+the value. This applies to `~/.claude/yolt.log` and
+`~/.claude/yolt-ran.log` alike, and happens at write time — the risk
+being closed is the file on disk. Issue
+[#84](https://github.com/voitta-ai/voitta-yolt/issues/84).
+
+```json
+{"ts": "...", "decision": "unsafe", "reason": "curl: mutating", "command": "curl -H \"Authorization: Bearer [REDACTED:github-token]\" https://api.github.com", "permission_mode": "default", "agent_id": null}
+```
+
+Two match families (`hooks/secret_redact.py`):
+
+- **Structured prefixes** — `ghp_`/`gho_`/`ghs_`/`ghr_`/`ghu_`,
+  `github_pat_`, `glpat-`, `xox[baprse]-`, `xapp-`, `AKIA`/`ASIA`,
+  `sk-`, PEM `PRIVATE KEY` blocks, and the password field of
+  `scheme://user:secret@host`. Self-identifying, so these are matched
+  wherever they appear.
+- **Assignment shapes** — `--token X`, `Authorization: X`, `FOO_TOKEN=X`
+  and friends. Only the *value* is redacted, and only when it looks like
+  a literal: a shell expansion (`--token $API_KEY`) or an ordinary name
+  (`--token some-resource-name`) is left alone.
+
+Redaction is deliberately value-only where it can be, because the
+command *shape* is what the self-improvement reviewer mines — a redacted
+value costs it nothing.
+
+Note the scope: this stops YOLT persisting a secret it already saw. It
+does not stop the secret reaching `argv` in the first place, where any
+process that can run `ps` sees it. Prefer keeping credentials in the
+environment:
+
+```bash
+KEY="$(fetch-secret)" sh -c 'curl -H "X-Api-Key: $KEY" https://service/endpoint'
+```
+
 ## Self-improvement loop
 
 The dogfood log is also a record of where YOLT got in your way. The

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@
   - [Python rules — `~/.claude/yolt/rules.json`](#python-rules---claudeyoltrulesjson)
   - [Shell rules — `~/.claude/yolt/shell.json`](#shell-rules---claudeyoltshelljson)
 - [Debug / dogfood log](#debug--dogfood-log)
+  - [Credential redaction](#credential-redaction)
 - [Self-improvement loop](#self-improvement-loop)
 - [CLI usage](#cli-usage)
 - [Tests and demo](#tests-and-demo)

--- a/README.md
+++ b/README.md
@@ -651,14 +651,33 @@ Two match families (`hooks/secret_redact.py`):
   `sk-`, PEM `PRIVATE KEY` blocks, and the password field of
   `scheme://user:secret@host`. Self-identifying, so these are matched
   wherever they appear.
-- **Assignment shapes** — `--token X`, `Authorization: X`, `FOO_TOKEN=X`
-  and friends. Only the *value* is redacted, and only when it looks like
-  a literal: a shell expansion (`--token $API_KEY`) or an ordinary name
-  (`--token some-resource-name`) is left alone.
+- **Contextual shapes**, where only the surrounding text identifies the
+  value — `--token X`, `Authorization: X`, `FOO_TOKEN=X`,
+  `curl -u user:X`, `?password=X` in a query string, and bare
+  `aws_secret_access_key X` (the AWS *secret* key, unlike the `AKIA` id,
+  has no prefix of its own). Only the *value* is redacted, and only when
+  it passes a literal-shape guard: a shell expansion (`--token $API_KEY`)
+  or an ordinary name (`--token some-resource-name`) is left alone.
 
 Redaction is deliberately value-only where it can be, because the
 command *shape* is what the self-improvement reviewer mines — a redacted
 value costs it nothing.
+
+**This is best-effort, not a guarantee.** It removes the shapes above,
+not "all credentials". A value with no self-identifying prefix and no
+secret-ish context around it is indistinguishable from an ordinary
+argument. Known gaps, kept open on purpose:
+
+- `mysql -pSECRET` and friends — a `-p` rule cannot be told apart from
+  `mkdir -p /var/log/app/2024/01`, and a redactor that mangles ordinary
+  commands gets switched off, which protects nothing.
+- A bare positional secret: `./deploy s3cr3tvalue00000000`.
+- Credentials inside a file the command merely references.
+
+So treat the logs as sensitive regardless — redaction narrows the blast
+radius, it does not license leaving a credential on a command line. The
+`YOLT_LOG_FILE=""` / `YOLT_RAN_LOG_FILE=""` opt-outs remain the way to
+write nothing at all.
 
 Note the scope: this stops YOLT persisting a secret it already saw. It
 does not stop the secret reaching `argv` in the first place, where any

--- a/hooks/secret_redact.py
+++ b/hooks/secret_redact.py
@@ -24,6 +24,23 @@ Nothing here ever emits, logs or returns the matched value: a
 secret-detector that writes secrets into its own diagnostics is the same
 bug one layer down. `find_secrets` reports shape and position only.
 
+Known limits, so nobody mistakes this for a guarantee
+-----------------------------------------------------
+This is best-effort. It removes the shapes below, not "all credentials".
+A value with no self-identifying prefix and no secret-ish context around
+it is indistinguishable from an ordinary argument, and is not caught:
+
+  - `mysql -pSECRET` and friends. Deliberately skipped: a `-p` rule
+    cannot be told apart from `mkdir -p /var/log/app/2024/01`, and a
+    matcher that mangles ordinary commands gets switched off, which
+    protects nothing.
+  - A bare positional secret: `./deploy s3cr3tvalue00000000`.
+  - Credentials inside a file the command merely references.
+
+When adding a shape, add it to the false-positive corpus in
+`tests/test_secret_redact.py` too - widening is only safe while that
+stays green.
+
 Zero external dependencies - stdlib only.
 """
 
@@ -61,6 +78,20 @@ _SECRETISH_HEADER = (
     r"Authorization|Proxy-Authorization|Cookie|"
     r"X-Api-Key|Api-Key|X-Auth-Token|X-Access-Token|Private-Token"
 )
+# Bare names that carry a value as the *next* token rather than after a
+# `--flag`. Kept to an unambiguous list: these words do not appear as
+# ordinary positional arguments, so the following token is a value.
+# `aws configure set aws_secret_access_key <value>` is the shape that
+# motivated this - the AWS *secret* key has no prefix of its own, so
+# only its context identifies it.
+_SECRETISH_WORD = (
+    r"aws_secret_access_key|aws_session_token|"
+    r"client_secret|refresh_token|access_token|private_key_id"
+)
+_SECRETISH_QUERY = (
+    r"password|passwd|pwd|token|api_key|apikey|"
+    r"secret|client_secret|access_token|auth"
+)
 
 # Same tuple shape, but the captured value must additionally pass
 # `_looks_like_literal_secret` before it is treated as a match.
@@ -73,12 +104,24 @@ _ASSIGNMENT_PATTERNS = [
     ("header-value", re.compile(
         r"(?:" + _SECRETISH_HEADER + r")\s*:\s*"
         r"(?:Bearer\s+|Basic\s+|token\s+)?([^\s\"']+)", re.I), 1),
+    ("named-value", re.compile(
+        r"\b(?:" + _SECRETISH_WORD + r")[\s=]+[\"']?([^\s\"']+)", re.I), 1),
+    # curl -u user:password / --user user:password - redact the password
+    # half only, so the account stays visible in the record.
+    ("basic-auth", re.compile(
+        r"(?:^|\s)(?:-u|--user)[=\s]+[\"']?[^\s:\"']+:([^\s\"']+)"), 1),
+    ("query-param", re.compile(
+        r"[?&](?:" + _SECRETISH_QUERY + r")=([^\s&\"'#]+)", re.I), 1),
 ]
 
 # Below this, a value is too short to be a credential worth the false
-# positives. Real tokens (AWS secret key 40, GitHub 40, Slack ~50) clear
-# it comfortably; resource names like `my-bucket-2024` do not.
-_MIN_VALUE_LEN = 20
+# positives it would cost. 16 is the shortest token length in common use.
+_MIN_VALUE_LEN = 16
+# At or above this, a value is too long to be a resource name, so the
+# usual "must mix letters and digits" test is waived - it would otherwise
+# miss an all-hex key that happens to contain no digits, or an all-alpha
+# base62 token.
+_LONG_VALUE_LEN = 32
 
 
 def _looks_like_literal_secret(value):
@@ -86,7 +129,9 @@ def _looks_like_literal_secret(value):
 
     Deliberately conservative - the assignment shapes fire on any
     `--token X`, so this guard is what keeps `--token $MY_TOKEN` and
-    `--token some-resource-name` out of the results.
+    `--token some-resource-name` out of the results. It errs toward
+    redacting: a false positive costs one unreadable value in a debug
+    log, a false negative costs a credential on disk forever.
     """
     retval = True
     if value.startswith("$") or "$(" in value or "`" in value:
@@ -95,11 +140,13 @@ def _looks_like_literal_secret(value):
         retval = False
     elif len(value) < _MIN_VALUE_LEN:
         retval = False
-    elif not re.fullmatch(r"[A-Za-z0-9_\-.+/=~:]+", value):
+    elif not re.fullmatch(r"[A-Za-z0-9_\-.+/=~:%]+", value):
         retval = False
-    elif not (any(c.isdigit() for c in value)
-              and any(c.isalpha() for c in value)):
-        # All-alphabetic or all-numeric reads as a name or an id, not a key.
+    elif len(value) < _LONG_VALUE_LEN and not (
+            any(c.isdigit() for c in value)
+            and any(c.isalpha() for c in value)):
+        # Short *and* all-alphabetic or all-numeric reads as a name or an
+        # id, not a key. Long values skip this test - see _LONG_VALUE_LEN.
         retval = False
     return retval
 

--- a/hooks/secret_redact.py
+++ b/hooks/secret_redact.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Credential detection and redaction for command strings.
+
+YOLT sees every Bash command and writes it to two append-only logs under
+`~/.claude/`. Credentials routinely appear on command lines (headers,
+`--token` flags, connection strings), so without this the logs become an
+unswept plaintext credential store. See issue #84.
+
+Scope note: a command line is not prose. It is short and structured, and
+secrets in it appear in known shapes, so prefix matching is accurate here
+in a way it is not across a transcript.
+
+Two match families:
+
+  - Structured prefixes (`ghp_`, `AKIA`, `xoxb-`, PEM blocks, ...) —
+    self-identifying, matched whole.
+  - Assignment shapes (`--token X`, `Authorization: X`, `FOO_TOKEN=X`) —
+    only the *value* is redacted, and only when it looks like a literal
+    secret rather than a shell expansion or an ordinary resource name.
+    Keeping the flag and the key name preserves the command *shape*,
+    which is what `yolt_review.py` actually mines.
+
+Nothing here ever emits, logs or returns the matched value: a
+secret-detector that writes secrets into its own diagnostics is the same
+bug one layer down. `find_secrets` reports shape and position only.
+
+Zero external dependencies - stdlib only.
+"""
+
+import re
+
+
+# (kind, pattern, group). Group 0 means "redact the whole match"; a
+# positive group redacts just that capture and leaves the rest intact.
+_STRUCTURED_PATTERNS = [
+    ("private-key", re.compile(
+        r"-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----"
+        r".*?"
+        r"-----END [A-Z0-9 ]*PRIVATE KEY-----", re.S), 0),
+    ("github-pat", re.compile(r"\bgithub_pat_[A-Za-z0-9_]{16,}"), 0),
+    ("github-token", re.compile(r"\bgh[posru]_[A-Za-z0-9]{16,}"), 0),
+    ("gitlab-token", re.compile(r"\bglpat-[A-Za-z0-9_\-]{16,}"), 0),
+    ("slack-app-token", re.compile(r"\bxapp-[0-9]-[A-Za-z0-9\-]{10,}"), 0),
+    ("slack-token", re.compile(r"\bxox[baprse]-[A-Za-z0-9\-]{10,}"), 0),
+    ("aws-access-key-id", re.compile(r"\b(?:AKIA|ASIA)[0-9A-Z]{16}\b"), 0),
+    ("api-key", re.compile(r"\bsk-[A-Za-z0-9_\-]{16,}"), 0),
+    # scheme://user:secret@host - redact only the password field.
+    ("url-credentials", re.compile(
+        r"\b[a-zA-Z][a-zA-Z0-9+.\-]*://[^\s:/@]+:([^\s/@]+)@"), 1),
+]
+
+_SECRETISH_FLAG = (
+    r"token|password|passwd|secret|"
+    r"api[-_]?key|access[-_]?key|secret[-_]?key|auth"
+)
+_SECRETISH_NAME = (
+    r"TOKEN|SECRET|PASSWORD|PASSWD|APIKEY|API_KEY|"
+    r"ACCESS_KEY|SECRET_KEY|CREDENTIAL|CREDENTIALS"
+)
+_SECRETISH_HEADER = (
+    r"Authorization|Proxy-Authorization|Cookie|"
+    r"X-Api-Key|Api-Key|X-Auth-Token|X-Access-Token|Private-Token"
+)
+
+# Same tuple shape, but the captured value must additionally pass
+# `_looks_like_literal_secret` before it is treated as a match.
+_ASSIGNMENT_PATTERNS = [
+    ("flag-value", re.compile(
+        r"--(?:" + _SECRETISH_FLAG + r")(?:[=\s]+)[\"']?([^\s\"']+)", re.I), 1),
+    ("env-assignment", re.compile(
+        r"\b[A-Za-z_][A-Za-z0-9_]*(?:" + _SECRETISH_NAME + r")"
+        r"\s*=\s*[\"']?([^\s\"']+)", re.I), 1),
+    ("header-value", re.compile(
+        r"(?:" + _SECRETISH_HEADER + r")\s*:\s*"
+        r"(?:Bearer\s+|Basic\s+|token\s+)?([^\s\"']+)", re.I), 1),
+]
+
+# Below this, a value is too short to be a credential worth the false
+# positives. Real tokens (AWS secret key 40, GitHub 40, Slack ~50) clear
+# it comfortably; resource names like `my-bucket-2024` do not.
+_MIN_VALUE_LEN = 20
+
+
+def _looks_like_literal_secret(value):
+    """True when `value` looks like a credential literal sitting in argv.
+
+    Deliberately conservative - the assignment shapes fire on any
+    `--token X`, so this guard is what keeps `--token $MY_TOKEN` and
+    `--token some-resource-name` out of the results.
+    """
+    retval = True
+    if value.startswith("$") or "$(" in value or "`" in value:
+        # A shell expansion: the secret is not in the command string,
+        # which is exactly the form we want people using.
+        retval = False
+    elif len(value) < _MIN_VALUE_LEN:
+        retval = False
+    elif not re.fullmatch(r"[A-Za-z0-9_\-.+/=~:]+", value):
+        retval = False
+    elif not (any(c.isdigit() for c in value)
+              and any(c.isalpha() for c in value)):
+        # All-alphabetic or all-numeric reads as a name or an id, not a key.
+        retval = False
+    return retval
+
+
+def find_secrets(text):
+    """Return credential spans in `text` as `(start, end, kind)` tuples.
+
+    Sorted by position, non-overlapping (an outer match wins over one
+    nested inside it). The value itself is never returned - callers get
+    shape and position only, so a caller cannot accidentally surface a
+    secret in a warning or a diagnostic.
+    """
+    spans = []
+    for kind, pattern, group in _STRUCTURED_PATTERNS:
+        for match in pattern.finditer(text):
+            spans.append((match.start(group), match.end(group), kind))
+    for kind, pattern, group in _ASSIGNMENT_PATTERNS:
+        for match in pattern.finditer(text):
+            if _looks_like_literal_secret(match.group(group)):
+                spans.append((match.start(group), match.end(group), kind))
+
+    # Longest-first at a given start so a header-value span that contains
+    # a `ghp_...` span swallows it rather than producing two records.
+    spans.sort(key=lambda s: (s[0], -s[1]))
+    retval = []
+    reach = -1
+    for start, end, kind in spans:
+        if start >= reach:
+            retval.append((start, end, kind))
+            reach = end
+    return retval
+
+
+def redact(text):
+    """Return `text` with every credential span replaced by a marker.
+
+    The marker names the shape (`[REDACTED:github-token]`) so the record
+    stays diagnosable, and the command's structure survives intact.
+    Returns `text` unchanged when nothing matches, and is a no-op on
+    empty / non-string input.
+    """
+    if not text:
+        retval = text
+        return retval
+    spans = find_secrets(text)
+    if not spans:
+        retval = text
+        return retval
+    out = []
+    cursor = 0
+    for start, end, kind in spans:
+        out.append(text[cursor:start])
+        out.append("[REDACTED:{}]".format(kind))
+        cursor = end
+    out.append(text[cursor:])
+    retval = "".join(out)
+    return retval

--- a/hooks/yolt_analyzer.py
+++ b/hooks/yolt_analyzer.py
@@ -990,7 +990,13 @@ def _log_hook_decision(command, decision, reason,
         }
         with open(log_path, "a") as f:
             f.write(json.dumps(record) + "\n")
-    except OSError:
+    except Exception:
+        # Broader than OSError on purpose. `redact` runs inside this
+        # block, so a future bug in a pattern would otherwise take down
+        # every PreToolUse fire. Failing here loses one log line and
+        # nothing else - and it fails closed, since the record is built
+        # before it is written: a redactor that raises writes nothing
+        # rather than writing the raw command.
         pass
 
 
@@ -1034,7 +1040,10 @@ def _log_ran_command(command):
         }
         with open(log_path, "a") as f:
             f.write(json.dumps(record) + "\n")
-    except OSError:
+    except Exception:
+        # Same reasoning as `_log_hook_decision`: broad on purpose so a
+        # redactor bug costs a log line, not the session, and never a
+        # raw command.
         pass
 
 

--- a/hooks/yolt_analyzer.py
+++ b/hooks/yolt_analyzer.py
@@ -16,6 +16,16 @@ import symtable
 from fnmatch import fnmatch
 from pathlib import Path
 
+# Both hook entry points run this file as a script, so its directory is
+# already sys.path[0]; the guard is for callers that import the module by
+# path. Deliberately not wrapped in a try/except: if the redactor cannot
+# be loaded, failing loudly beats silently writing credentials to disk.
+_HOOKS_DIR = str(Path(__file__).resolve().parent)
+if _HOOKS_DIR not in sys.path:
+    sys.path.insert(0, _HOOKS_DIR)
+
+from secret_redact import redact  # noqa: E402
+
 
 def load_rules(rules_dir, user_overrides_path=None):
     """Load and merge rules from default + user overrides."""
@@ -953,6 +963,13 @@ def _log_hook_decision(command, decision, reason,
     5MB) by renaming it to `<log>.old` — one previous generation
     preserved. Set `YOLT_LOG_MAX_BYTES=0` to disable.
 
+    Credential-shaped substrings in `command` and `reason` are replaced
+    with `[REDACTED:<shape>]` markers before the record is written - this
+    log is append-only and long-lived, so anything landing in it should
+    be assumed permanent. Redaction runs *before* the 500-char truncation
+    so a secret straddling that boundary cannot be half-written. See
+    `secret_redact.py` and issue #84.
+
     Failures (unwritable path, full disk, ...) are swallowed: logging
     must never break the hook. The command is truncated to 500 chars to
     avoid pathologically long lines.
@@ -966,8 +983,8 @@ def _log_hook_decision(command, decision, reason,
         record = {
             "ts": datetime.datetime.now(datetime.timezone.utc).isoformat(),
             "decision": decision,
-            "reason": reason,
-            "command": command[:500] if command else "",
+            "reason": redact(reason),
+            "command": redact(command)[:500] if command else "",
             "permission_mode": permission_mode,
             "agent_id": agent_id,
         }
@@ -1001,8 +1018,9 @@ def _resolve_ran_log_path():
 
 def _log_ran_command(command):
     """Append a JSON-line ran-record to the resolved ran-log path. Shares
-    the size-based rotation and failure-swallowing conventions of
-    `_log_hook_decision`. The command is truncated to 500 chars.
+    the credential redaction, size-based rotation and failure-swallowing
+    conventions of `_log_hook_decision`. The command is truncated to 500
+    chars, after redaction.
     """
     log_path = _resolve_ran_log_path()
     if log_path is None:
@@ -1012,7 +1030,7 @@ def _log_ran_command(command):
         _maybe_rotate_log(log_path, _resolve_log_max_bytes())
         record = {
             "ts": datetime.datetime.now(datetime.timezone.utc).isoformat(),
-            "command": command[:500] if command else "",
+            "command": redact(command)[:500] if command else "",
         }
         with open(log_path, "a") as f:
             f.write(json.dumps(record) + "\n")

--- a/tests/test_secret_redact.py
+++ b/tests/test_secret_redact.py
@@ -325,6 +325,37 @@ class LogWritingTests(unittest.TestCase):
     def test_ran_log_redacts(self):
         self.assert_log_clean("--ran-hook", "YOLT_RAN_LOG_FILE")
 
+    def test_redactor_failure_writes_nothing_and_does_not_raise(self):
+        """A bug in the redactor must cost a log line, not the session -
+        and must never fall back to writing the raw command."""
+        import importlib.util
+        spec = importlib.util.spec_from_file_location(
+            "ya_failclosed", REPO_ROOT / "hooks" / "yolt_analyzer.py")
+        analyzer = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(analyzer)
+
+        def exploding_redact(text):
+            raise ValueError("simulated redactor bug")
+
+        analyzer.redact = exploding_redact
+        command = "curl -H 'X-Api-Key: {}' https://x".format(FAKE_GH_TOKEN)
+        with tempfile.TemporaryDirectory() as tmp:
+            log_path = Path(tmp) / "yolt.log"
+            os.environ["YOLT_LOG_FILE"] = str(log_path)
+            os.environ["YOLT_RAN_LOG_FILE"] = str(log_path)
+            try:
+                # Must not propagate.
+                analyzer._log_hook_decision(
+                    command, "safe", "reason", "default", None)
+                analyzer._log_ran_command(command)
+            finally:
+                os.environ.pop("YOLT_LOG_FILE", None)
+                os.environ.pop("YOLT_RAN_LOG_FILE", None)
+            # Fail closed: the record is built before it is written, so a
+            # raising redactor writes nothing rather than the raw command.
+            written = log_path.read_text() if log_path.exists() else ""
+            self.assertNotIn(FAKE_GH_TOKEN, written)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_secret_redact.py
+++ b/tests/test_secret_redact.py
@@ -1,0 +1,220 @@
+"""Tests for credential redaction in YOLT's own logs (issue #84).
+
+Runs with stdlib unittest only:
+
+    python3 -m unittest discover -v tests
+"""
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "hooks"))
+
+from secret_redact import find_secrets, redact  # noqa: E402
+
+# Synthetic values only - shaped like the real thing, valid nowhere.
+FAKE_GH_TOKEN = "ghp_" + "A1b2C3d4E5f6G7h8I9j0" * 2
+FAKE_GH_PAT = "github_pat_" + "11ABCDEFG0" * 3
+FAKE_GITLAB = "glpat-" + "xY3zAb9QrS7tUv1W"
+FAKE_SLACK = "xoxb-1234567890-1234567890123-" + "AbCdEf1234567890AbCdEf12"
+FAKE_SLACK_APP = "xapp-1-A01BCDEFGHI-1234567890123-" + "abcdef1234567890"
+FAKE_AWS_ID = "AKIAIOSFODNN7EXAMPLE"
+FAKE_API_KEY = "sk-ant-api03-" + "aB3dE6gH9jK2mN5pQ8sT1vW4"
+
+
+class RedactStructuredTests(unittest.TestCase):
+    """Self-identifying prefixes are matched whole, wherever they sit."""
+
+    def assert_scrubbed(self, command, secret, kind):
+        out = redact(command)
+        self.assertNotIn(secret, out,
+                         "{} survived redaction".format(kind))
+        self.assertIn("[REDACTED:{}]".format(kind), out)
+
+    def test_github_token(self):
+        self.assert_scrubbed(
+            'curl -H "Authorization: token {}" https://api.github.com'.format(
+                FAKE_GH_TOKEN),
+            FAKE_GH_TOKEN, "github-token")
+
+    def test_github_pat(self):
+        self.assert_scrubbed(
+            "gh auth login --with-token <<< {}".format(FAKE_GH_PAT),
+            FAKE_GH_PAT, "github-pat")
+
+    def test_gitlab_token(self):
+        self.assert_scrubbed(
+            "glab auth login -t {}".format(FAKE_GITLAB),
+            FAKE_GITLAB, "gitlab-token")
+
+    def test_slack_bot_token(self):
+        self.assert_scrubbed(
+            "curl -d token={} https://slack.com/api/auth.test".format(
+                FAKE_SLACK),
+            FAKE_SLACK, "slack-token")
+
+    def test_slack_app_token(self):
+        self.assert_scrubbed(
+            "export SLACK_APP={}".format(FAKE_SLACK_APP),
+            FAKE_SLACK_APP, "slack-app-token")
+
+    def test_aws_access_key_id(self):
+        self.assert_scrubbed(
+            "aws configure set aws_access_key_id {}".format(FAKE_AWS_ID),
+            FAKE_AWS_ID, "aws-access-key-id")
+
+    def test_api_key_prefix(self):
+        self.assert_scrubbed(
+            'curl -H "x-api-key: {}" https://api.anthropic.com'.format(
+                FAKE_API_KEY),
+            FAKE_API_KEY, "api-key")
+
+    def test_private_key_block(self):
+        pem = ("-----BEGIN RSA PRIVATE KEY-----\n"
+               "MIIEowIBAAKCAQEAxfake1\nMIIEowIBAAKCAQEAxfake2\n"
+               "-----END RSA PRIVATE KEY-----")
+        out = redact("echo '{}' > id_rsa".format(pem))
+        self.assertNotIn("MIIEowIBAAKCAQEAxfake1", out)
+        self.assertIn("[REDACTED:private-key]", out)
+
+    def test_url_credentials_keep_host(self):
+        out = redact("psql postgres://appuser:hunter2ismypassword@db.internal/prod")
+        self.assertNotIn("hunter2ismypassword", out)
+        self.assertIn("[REDACTED:url-credentials]", out)
+        # The parts that make the record useful survive.
+        self.assertIn("appuser", out)
+        self.assertIn("db.internal/prod", out)
+
+
+class RedactAssignmentShapeTests(unittest.TestCase):
+    """Value-only redaction, gated on the value looking like a literal."""
+
+    def test_generic_header_value(self):
+        secret = "9f3c1a7e42b8d05e6c1f9a7b3d2e8c40"
+        out = redact('curl -H "X-Api-Key: {}" https://service/endpoint'.format(
+            secret))
+        self.assertNotIn(secret, out)
+        self.assertIn("X-Api-Key", out)
+        self.assertIn("https://service/endpoint", out)
+
+    def test_generic_flag_value(self):
+        secret = "7d1e4b90c3a25f68d4e7b1c093a56f28"
+        out = redact("deploy --token {} --region us-east-1".format(secret))
+        self.assertNotIn(secret, out)
+        self.assertIn("--token", out)
+        self.assertIn("--region us-east-1", out)
+
+    def test_env_assignment(self):
+        secret = "e81f5c27b940a63de5f2c8194b7a0d36"
+        out = redact('SERVICE_TOKEN="{}" ./run.sh'.format(secret))
+        self.assertNotIn(secret, out)
+        self.assertIn("SERVICE_TOKEN", out)
+        self.assertIn("./run.sh", out)
+
+    def test_shell_expansion_not_flagged(self):
+        # The recommended form: the secret never enters argv.
+        for command in (
+            'curl -H "X-Api-Key: $API_KEY" https://service/endpoint',
+            "deploy --token ${DEPLOY_TOKEN_FOR_PRODUCTION}",
+            'gh auth login --with-token "$(cat /run/secrets/gh_token_value)"',
+        ):
+            self.assertEqual(redact(command), command, command)
+
+    def test_ordinary_names_not_flagged(self):
+        for command in (
+            "deploy --token some-resource-name",
+            "aws s3 ls s3://my-bucket-2024/",
+            "kubectl get secret app-credentials -n default",
+            "terraform apply -var access_key_id=aws_iam_access_key.ci.id",
+        ):
+            self.assertEqual(redact(command), command, command)
+
+
+class FindSecretsTests(unittest.TestCase):
+
+    def test_reports_shape_and_position_only(self):
+        command = "gh auth login --with-token {}".format(FAKE_GH_TOKEN)
+        spans = find_secrets(command)
+        self.assertEqual(len(spans), 1)
+        start, end, kind = spans[0]
+        self.assertEqual(kind, "github-token")
+        self.assertEqual(command[start:end], FAKE_GH_TOKEN)
+        # Nothing in the report itself carries the value.
+        self.assertNotIn(FAKE_GH_TOKEN, repr((start, end, kind)))
+
+    def test_overlapping_matches_collapse(self):
+        # Both header-value and github-token match here; one span wins.
+        command = 'curl -H "Authorization: Bearer {}" https://x'.format(
+            FAKE_GH_TOKEN)
+        self.assertEqual(len(find_secrets(command)), 1)
+
+    def test_multiple_distinct_secrets(self):
+        command = "AWS_KEY={} gh auth login --with-token {}".format(
+            FAKE_AWS_ID, FAKE_GH_TOKEN)
+        kinds = [k for _, _, k in find_secrets(command)]
+        self.assertEqual(len(kinds), 2)
+        out = redact(command)
+        self.assertNotIn(FAKE_AWS_ID, out)
+        self.assertNotIn(FAKE_GH_TOKEN, out)
+
+    def test_clean_command_untouched(self):
+        command = "git --no-pager log --oneline -20"
+        self.assertEqual(find_secrets(command), [])
+        self.assertEqual(redact(command), command)
+
+    def test_empty_input(self):
+        self.assertEqual(redact(""), "")
+        self.assertEqual(redact(None), None)
+
+
+class LogWritingTests(unittest.TestCase):
+    """End-to-end: the bytes that hit disk carry no credential.
+
+    This is the actual bug in #84 - unit-level redaction is only half the
+    claim, the other half is that both hook entry points call it.
+    """
+
+    def run_hook(self, flag, command, env_key, log_path):
+        env = dict(os.environ)
+        env[env_key] = str(log_path)
+        env["PYTHONPATH"] = str(REPO_ROOT / "hooks")
+        payload = {
+            "tool_name": "Bash",
+            "tool_input": {"command": command},
+            "permission_mode": "default",
+        }
+        subprocess.run(
+            [sys.executable, str(REPO_ROOT / "hooks" / "yolt_analyzer.py"), flag],
+            input=json.dumps(payload), capture_output=True, text=True,
+            env=env, timeout=60,
+        )
+
+    def assert_log_clean(self, flag, env_key):
+        command = 'curl -H "Authorization: Bearer {}" https://api.github.com'.format(
+            FAKE_GH_TOKEN)
+        with tempfile.TemporaryDirectory() as tmp:
+            log_path = Path(tmp) / "yolt-test.log"
+            self.run_hook(flag, command, env_key, log_path)
+            self.assertTrue(log_path.exists(),
+                            "{} wrote no log".format(flag))
+            written = log_path.read_text()
+            self.assertNotIn(FAKE_GH_TOKEN, written)
+            self.assertIn("REDACTED", written)
+            # Still a usable record: the command shape survives.
+            self.assertIn("curl", written)
+
+    def test_decision_log_redacts(self):
+        self.assert_log_clean("--hook", "YOLT_LOG_FILE")
+
+    def test_ran_log_redacts(self):
+        self.assert_log_clean("--ran-hook", "YOLT_RAN_LOG_FILE")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_secret_redact.py
+++ b/tests/test_secret_redact.py
@@ -136,6 +136,116 @@ class RedactAssignmentShapeTests(unittest.TestCase):
             self.assertEqual(redact(command), command, command)
 
 
+class BypassRegressionTests(unittest.TestCase):
+    """Shapes that survived redaction during adversarial review.
+
+    Each of these was a verified bypass: the credential reached the log
+    in plaintext. Keep them failing-if-broken.
+    """
+
+    def assert_redacted(self, command):
+        self.assertNotEqual(redact(command), command,
+                            "credential survived: {}".format(command))
+
+    def test_aws_secret_access_key_has_no_prefix_of_its_own(self):
+        # Only the surrounding context identifies it, unlike AKIA/ASIA.
+        self.assert_redacted(
+            "aws configure set aws_secret_access_key "
+            "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY")
+
+    def test_curl_basic_auth(self):
+        for flag in ("-u", "--user"):
+            self.assert_redacted(
+                "curl {} admin:s3cr3tP4ssw0rdVeryLong123 "
+                "https://api.example.com".format(flag))
+
+    def test_curl_basic_auth_keeps_the_account(self):
+        out = redact("curl -u admin:s3cr3tP4ssw0rdVeryLong123 https://x")
+        self.assertNotIn("s3cr3tP4ssw0rdVeryLong123", out)
+        self.assertIn("admin", out)
+
+    def test_password_in_query_string(self):
+        self.assert_redacted(
+            'curl "https://api.example.com/login'
+            '?password=hunter2VeryLongPassword99"')
+
+    def test_token_in_later_query_param(self):
+        self.assert_redacted(
+            'curl "https://x/api?page=2'
+            '&access_token=8f14e45fceea167a5a36dedd4bea2543"')
+
+    def test_sixteen_char_token(self):
+        # The old 20-char floor let common token lengths through.
+        self.assert_redacted("deploy --token a1b2c3d4e5f6g7h8")
+
+    def test_long_value_without_digits(self):
+        # An all-hex key can contain no digits; an all-alpha base62 token
+        # is ordinary. Both used to be dismissed as "reads like a name".
+        self.assert_redacted(
+            "deploy --token deadbeefcafebabedeadbeefcafebabe")
+        self.assert_redacted(
+            "deploy --token abcdefghijklmnopqrstuvwxyzABCDEF")
+
+    def test_url_encoded_value(self):
+        self.assert_redacted("deploy --token abc%123def%456ghi%789jkl")
+
+    def test_bare_secretish_word_then_value(self):
+        self.assert_redacted(
+            "oauth2 client_secret 8f14e45fceea167a5a36dedd4bea2543")
+
+
+class FalsePositiveCorpusTests(unittest.TestCase):
+    """Ordinary commands that must survive redaction byte-for-byte.
+
+    Widening the matcher is only safe while this stays green - a
+    redactor that mangles normal commands makes the log useless and
+    gets the whole feature turned off.
+    """
+
+    CLEAN = [
+        "deploy --token some-resource-name",
+        "deploy --token $DEPLOY_TOKEN_FOR_PRODUCTION",
+        "aws s3 ls s3://my-bucket-2024/",
+        "aws secretsmanager get-secret-value --secret-id prod/db/credentials-v2",
+        "kubectl get secret app-credentials -n default",
+        "mkdir -p /var/log/myapp/2024/01/backups",
+        "docker run -u 1000:1000 alpine",
+        "git checkout a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0",
+        "curl https://api.example.com/v1/users?page=2&limit=100",
+        "terraform apply -var access_key_id=aws_iam_access_key.ci.id",
+        "python3 -m pytest tests/test_secret_redact.py -v",
+        "ssh -i ~/.ssh/id_ed25519 user@host.example.com",
+        'curl -H "Authorization: Bearer $GITHUB_TOKEN" https://api.github.com',
+        'find . -name "*.log" -mtime +30 -delete',
+        "aws configure set region us-east-1",
+        "helm upgrade myapp ./chart --set image.tag=v1.2.3-rc4",
+        'psql -h db.internal -U appuser -d production -c "select 1"',
+    ]
+
+    def test_ordinary_commands_untouched(self):
+        for command in self.CLEAN:
+            self.assertEqual(redact(command), command, command)
+
+
+class PerformanceTests(unittest.TestCase):
+    """The matcher runs on every Bash call, so a pathological command
+    must not stall the hook."""
+
+    def test_pathological_inputs_stay_fast(self):
+        import time
+        for command in (
+            "echo " + "a" * 100000,
+            # Unterminated PEM header + bulk: exercises the `.*?` with re.S.
+            "echo '-----BEGIN RSA PRIVATE KEY-----" + "A" * 100000,
+            " ".join(["--token abc"] * 5000),
+        ):
+            start = time.perf_counter()
+            find_secrets(command)
+            elapsed = time.perf_counter() - start
+            self.assertLess(elapsed, 1.0,
+                            "find_secrets took {:.2f}s".format(elapsed))
+
+
 class FindSecretsTests(unittest.TestCase):
 
     def test_reports_shape_and_position_only(self):


### PR DESCRIPTION
Closes #84.

## Problem

Both YOLT logs stored the full command string verbatim, default-on and
append-only. Credentials appear on command lines routinely, so the logs
accumulated a plaintext credential store under `~/.claude/` — written by
the tool users installed to be *safer*, in a file nobody greps during a
leak cleanup.

## Fix

New `hooks/secret_redact.py`, called from both log writers
(`_log_hook_decision`, `_log_ran_command`) so the value never reaches
disk. Redaction runs **before** the existing 500-char truncation, so a
secret straddling that boundary cannot be half-written. `reason` is
redacted too — classifier reasons can quote argument text.

Two match families:

- **Structured prefixes** — `gh[posru]_`, `github_pat_`, `glpat-`,
  `xox[baprse]-`, `xapp-`, `AKIA`/`ASIA`, `sk-`, PEM `PRIVATE KEY`
  blocks, and the password field of `scheme://user:secret@host`.
  Self-identifying, matched whole.
- **Assignment shapes** — `--token X`, `Authorization: X`,
  `FOO_TOKEN=X`. Only the *value* is redacted, and only when it passes a
  literal-shape guard, so `--token $API_KEY` and
  `--token some-resource-name` do not trip it.

```
curl -H "Authorization: Bearer [REDACTED:github-token]" https://api.github.com
```

The flag, the key name and the command shape survive — `yolt_review.py`
mines shapes, not values, so redaction costs it nothing.

Both details the issue asked for are built in:

- **Write time, not read time.** The risk being closed is the file on disk.
- **The redactor never emits the matched value.** `find_secrets()`
  returns `(start, end, kind)` only, so a caller cannot accidentally
  surface a secret in a warning. A secret-detector that logs secrets is
  the same bug one layer down.

The redactor is imported unguarded on purpose: if it cannot load, failing
loudly beats silently writing credentials to disk.

## On the "no rotation" point in the issue

Size-based rotation already exists (`_maybe_rotate_log`, 5 MB default,
`YOLT_LOG_MAX_BYTES` to tune, `0` to disable). It is single-generation,
so a secret does survive one rotation — redaction is what actually closes
this, as the issue says.

## Not in scope

Stopping the secret reaching `argv` in the first place. That is #85,
which builds on `find_secrets()` from this PR.

## Tests

`tests/test_secret_redact.py` — 21 tests: every structured prefix, the
value-only assignment shapes, the false-positive guards (shell
expansions, ordinary resource names), overlap collapsing, and two
end-to-end tests that run each hook entry point as a subprocess and
assert the bytes on disk carry no credential. That last pair is the
actual claim of this PR: unit-level redaction is only half of it, the
other half is that both writers call it.

Full suite: 582 -> 603 tests, all green (3.12 and 3.14 locally, 3.10–3.12 in CI).

## Version

`0.2.0` -> `0.3.0`. Minor: log record content is user-visible.



---

## Adversarial review round

Reviewed by trying to break the claim rather than confirm it. Ten
bypasses were found and fixed; the over-claim in this description was
corrected.

**Bypasses found (all verified by execution, all now redacted):**

| shape | why it slipped |
|---|---|
| `aws configure set aws_secret_access_key <v>` | the AWS *secret* key has no prefix of its own — only context identifies it. `AKIA`/`ASIA` covers the id, which is the half that matters less |
| `curl -u user:pass`, `--user` | no rule at all |
| `?password=`, `&access_token=` in a URL | no rule at all |
| 16-char tokens | 20-char floor was too high |
| all-hex-no-digit and all-alpha values ≥32 chars | the "must mix letters and digits" test dismissed them as names |
| URL-encoded values containing `%` | `%` was outside the allowed charset |

**Also fixed:** `redact` ran inside a `try` block catching only
`OSError`, so a future bug in any pattern would have propagated out of
both log writers and killed every PreToolUse/PostToolUse fire. Broadened
to `except Exception`, which is what the function's stated contract
already promised. It fails **closed** — the record is built before it is
written, so a raising redactor writes nothing rather than falling back
to the raw command. Verified: the log file is not even created.

**Held up under attack:**

- No ReDoS. Worst case ~16 ms on a 100 KB command (including an
  unterminated PEM header against the `.*?` with `re.S`); 0.01 ms on a
  normal command.
- No anchoring false positives — `sk-` does not fire inside `task-` or
  `disk-`; url-credentials does not misfire on `example.com/a:b@c`.
- Span merge is correct, including a match at index 0 and
  partially-overlapping spans.
- Redact-then-truncate holds: a token straddling char 500 leaves no
  fragment on disk.
- Neither `permissionDecisionReason` nor `suggest_allow_pattern` echoes
  the credential back — so the allowlist entry a user is invited to copy
  cannot carry one.
- `yolt_review.py`'s existing `redact_command` is a complementary
  shape-reducer, not a conflicting second implementation.

**Correction to this description:** the original claim — "a credential
present in a Bash command cannot reach either log in plaintext" — was
too strong and is now demonstrably false. This is best-effort. The
README and the module docstring now state the known gaps, notably
`mysql -pSECRET`, which is left open on purpose: a `-p` rule cannot be
told apart from `mkdir -p /var/log/app/2024/01`, and a redactor that
mangles ordinary commands gets switched off, which protects nothing.

**Regression coverage:** one test per verified bypass, plus an
18-command false-positive corpus that must survive byte-for-byte
(widening the matcher is only safe while that stays green), plus a
latency guard. 615 tests, green on 3.10/3.11/3.12 in CI.

**Field note:** while this PR was open, a GitHub token leaked again on
another machine through exactly this path. Revoked and rotated. Not a
hypothetical.
