### PR TITLE
feat(hook): warn when a command line carries a credential (#85)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "yolt",
   "description": "Static safety analyzer for Bash invocations - auto-allows read-only commands and prompts for mutating ones, plus a Python AST analyzer for python3 / python3 -c / heredoc invocations.",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "author": {
     "name": "voitta-ai"
   },

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@
 - [Custom rules](#custom-rules)
   - [Python rules — `~/.claude/yolt/rules.json`](#python-rules---claudeyoltrulesjson)
   - [Shell rules — `~/.claude/yolt/shell.json`](#shell-rules---claudeyoltshelljson)
+- [Credentials in the command line (advisory)](#credentials-in-the-command-line-advisory)
 - [Debug / dogfood log](#debug--dogfood-log)
   - [Credential redaction](#credential-redaction)
 - [Self-improvement loop](#self-improvement-loop)
@@ -590,6 +591,65 @@ entire list; if you want to add `/scratch/*` while keeping the defaults,
 copy the default list through. `unsafe_write_targets` is checked before
 `safe_write_targets`, so a deny entry wins over a broader safe glob.
 Examples: `examples/user-overrides.json`, `examples/shell-overrides.json`.
+
+## Credentials in the command line (advisory)
+
+YOLT already parses every Bash command for safety, which makes
+`PreToolUse` the natural place to catch a hazard it is otherwise blind
+to: **a credential sitting in the command string itself.** Issue
+[#85](https://github.com/voitta-ai/voitta-yolt/issues/85).
+
+The motivating case is not a mistake:
+
+```bash
+curl -H "X-Api-Key: <value>" https://service/endpoint
+```
+
+The key was fetched correctly from a secret manager. Nothing about the
+command is unsafe by YOLT's lights. But that string then lands in the
+session transcript, in session memory (usually embedded and searchable,
+so it can resurface in a *later* session's context), in any spilled tool
+output, in YOLT's own logs, and in `permissions.allow` if the approved
+command string contained it — copies with different lifetimes, none in
+git, most never swept. `argv` is also world-readable to anything that
+can run `ps` while the process lives.
+
+`PreToolUse` is the only point where that is preventable rather than
+cleanable. Once the command has run, every one of those copies exists.
+
+So YOLT warns — and only warns:
+
+```
+YOLT: this command line appears to carry a credential (github-token at char 24).
+It is not blocked, and the command may be perfectly correct — but the string
+itself is about to be copied to places with different lifetimes: ...
+Move the value into the environment so it never appears in `argv`:
+  KEY="$(fetch-secret)" sh -c 'curl -H "X-Api-Key: $KEY" https://service/endpoint'
+```
+
+Properties, all deliberate:
+
+- **Advisory, never blocking.** The warning attaches to whatever
+  decision was already reached (`allow`, `ask`, `deny`, and the silent
+  `unknown` fallthrough alike) and never changes it. A control that
+  false-positives on legitimate work gets switched off and then protects
+  nothing.
+- **Suggests the fix.** Delivered as both `systemMessage` (you see it)
+  and `additionalContext` (Claude sees it, so the remediation is
+  actionable rather than decorative).
+- **Reports shape and offset, never the value.** A warning that quotes
+  the secret puts the secret straight into the transcript it is warning
+  about.
+- **Structured prefixes first**, assignment shapes second with a
+  literal-value guard — the same matcher as [credential
+  redaction](#credential-redaction), so `--token $API_KEY` and
+  `--token some-resource-name` do not trip it.
+
+Set `YOLT_SECRET_WARN=0` to disable.
+
+Note the division of labour: this stops the secret reaching the command
+line; redaction stops YOLT persisting one it already saw. They are
+independent, and redaction is worth having regardless.
 
 ## Debug / dogfood log
 

--- a/README.md
+++ b/README.md
@@ -620,12 +620,16 @@ cleanable. Once the command has run, every one of those copies exists.
 So YOLT warns — and only warns:
 
 ```
-YOLT: this command line appears to carry a credential (github-token at char 24).
-It is not blocked, and the command may be perfectly correct — but the string
-itself is about to be copied to places with different lifetimes: ...
-Move the value into the environment so it never appears in `argv`:
+YOLT: possible credential on this command line (github-token at char 24). Not blocked.
+It will persist in the transcript, session memory and the allowlist, and `argv` is
+visible to `ps`. Keep it out of `argv`:
   KEY="$(fetch-secret)" sh -c 'curl -H "X-Api-Key: $KEY" https://service/endpoint'
 ```
+
+Three lines, deliberately. It rides along with a permission prompt the
+user is already reading, and a paragraph of security prose on every
+credential-bearing command is the fastest route to the whole feature
+being switched off.
 
 Properties, all deliberate:
 
@@ -645,11 +649,21 @@ Properties, all deliberate:
   redaction](#credential-redaction), so `--token $API_KEY` and
   `--token some-resource-name` do not trip it.
 
-Set `YOLT_SECRET_WARN=0` to disable.
+- **Never breaks the hook.** The scan runs in the critical path of every
+  Bash call, so a bug in a credential pattern costs the warning and
+  nothing else — the safety decision is already made by that point, and
+  it matters more than the advisory.
+
+To disable, set `YOLT_SECRET_WARN` to any of `0`, `false`, `no`, `off`,
+`n`, `disable`, `disabled` (case and surrounding space ignored). The
+generous list is on purpose: an exact `=0` test looks precise and
+behaves as a trap, since someone silencing a noisy control reaches for
+`false` or `off` first and would conclude the switch is broken.
 
 Note the division of labour: this stops the secret reaching the command
 line; redaction stops YOLT persisting one it already saw. They are
-independent, and redaction is worth having regardless.
+independent, and redaction is worth having regardless. Neither is a
+guarantee — see the [known gaps](#credential-redaction).
 
 ## Debug / dogfood log
 

--- a/hooks/yolt_analyzer.py
+++ b/hooks/yolt_analyzer.py
@@ -24,7 +24,7 @@ _HOOKS_DIR = str(Path(__file__).resolve().parent)
 if _HOOKS_DIR not in sys.path:
     sys.path.insert(0, _HOOKS_DIR)
 
-from secret_redact import redact  # noqa: E402
+from secret_redact import find_secrets, redact  # noqa: E402
 
 
 def load_rules(rules_dir, user_overrides_path=None):
@@ -887,6 +887,61 @@ def format_unsafe_reason(reason, allow_hint=None):
     return message
 
 
+SECRET_ADVISORY_HEADER = (
+    "YOLT: this command line appears to carry a credential ({}).\n"
+    "It is not blocked, and the command may be perfectly correct — but "
+    "the string itself is about to be copied to places with different "
+    "lifetimes: the session transcript, session memory (searchable, so "
+    "it can resurface in a later session), any spilled tool output, and "
+    "the permissions allowlist if you approve it. `argv` is also "
+    "readable by anything that can run `ps` while the process lives.\n"
+    "Move the value into the environment so it never appears in `argv`:\n"
+    "  KEY=\"$(fetch-secret)\" sh -c 'curl -H \"X-Api-Key: $KEY\" "
+    "https://service/endpoint'"
+)
+
+
+def format_secret_advisory(command):
+    """Build the credential warning for `command`, or None if clean.
+
+    Advisory only — this never changes YOLT's decision. A control that
+    false-positives on legitimate work gets switched off and then
+    protects nothing, so this warns and suggests the fix rather than
+    refusing. `YOLT_SECRET_WARN=0` disables it. See issue #85.
+
+    The text reports shape and character offset only. The matched value
+    is never interpolated into it: a warning that quotes the secret puts
+    the secret straight into the transcript it is warning about.
+    """
+    if os.environ.get("YOLT_SECRET_WARN") == "0":
+        retval = None
+        return retval
+    spans = find_secrets(command)
+    if not spans:
+        retval = None
+        return retval
+    found = ", ".join(
+        "{} at char {}".format(kind, start) for start, _, kind in spans
+    )
+    retval = SECRET_ADVISORY_HEADER.format(found)
+    return retval
+
+
+def attach_secret_advisory(response, advisory):
+    """Add `advisory` to an already-built hook response, in place.
+
+    `systemMessage` surfaces it to the user; `additionalContext` puts it
+    in front of Claude, which is what makes the suggested remediation
+    actionable rather than decorative. Neither field affects the
+    permission decision, so this is safe to attach to allow, ask and
+    deny alike.
+    """
+    if advisory:
+        response["systemMessage"] = advisory
+        response["hookSpecificOutput"]["additionalContext"] = advisory
+    return response
+
+
 DEFAULT_LOG_PATH = Path.home() / ".claude" / "yolt.log"
 DEFAULT_RAN_LOG_PATH = Path.home() / ".claude" / "yolt-ran.log"
 DEFAULT_LOG_MAX_BYTES = 5 * 1024 * 1024  # 5 MB
@@ -1093,6 +1148,12 @@ def run_hook():
     unsupported platform), exit silently so Claude Code falls through to
     its default prompt rather than failing the hook.
 
+    Independently of the decision, the command is scanned for
+    credential-shaped substrings; a hit attaches an advisory warning
+    (`systemMessage` + `additionalContext`) to whatever response was
+    already built, including the unknown fallthrough. It never changes
+    the decision. See `format_secret_advisory` and issue #85.
+
     When `YOLT_LOG_FILE` is set, every examined Bash invocation appends
     a JSON-line record there — including the silent-fallthrough cases.
     """
@@ -1165,9 +1226,14 @@ def run_hook():
     decision, reason = classifier.classify(command)
     _log_hook_decision(command, decision, reason, permission_mode, agent_id)
 
+    # Orthogonal to the safety decision: a command can be entirely safe
+    # and still be carrying a credential into argv. Advisory only — it
+    # rides along with whatever decision was reached. Issue #85.
+    advisory = format_secret_advisory(command)
+
     if decision == DECISION_SAFE:
         response = make_hook_response("allow", "YOLT: {}".format(reason))
-        print(json.dumps(response))
+        print(json.dumps(attach_secret_advisory(response, advisory)))
         sys.exit(0)
     if decision == DECISION_UNSAFE:
         allow_hint = classifier.suggest_allow_pattern(command)
@@ -1183,9 +1249,16 @@ def run_hook():
             )
         else:
             response = make_hook_response("ask", message)
-        print(json.dumps(response))
+        print(json.dumps(attach_secret_advisory(response, advisory)))
         sys.exit(0)
-    # decision == DECISION_UNKNOWN: let Claude Code handle it
+
+    # decision == DECISION_UNKNOWN: let Claude Code handle it. Emit a
+    # response only when there is an advisory to carry — omitting
+    # `permissionDecision` leaves Claude Code's default prompt intact,
+    # so the warning costs the fallthrough nothing.
+    if advisory:
+        response = {"hookSpecificOutput": {"hookEventName": "PreToolUse"}}
+        print(json.dumps(attach_secret_advisory(response, advisory)))
     sys.exit(0)
 
 

--- a/hooks/yolt_analyzer.py
+++ b/hooks/yolt_analyzer.py
@@ -887,17 +887,23 @@ def format_unsafe_reason(reason, allow_hint=None):
     return message
 
 
+# Kept to three short lines on purpose. This rides along with a prompt
+# the user is already reading, and a wall of text on every
+# credential-bearing command is the fastest route to the whole feature
+# being switched off. The full rationale lives in the README.
 SECRET_ADVISORY_HEADER = (
-    "YOLT: this command line appears to carry a credential ({}).\n"
-    "It is not blocked, and the command may be perfectly correct — but "
-    "the string itself is about to be copied to places with different "
-    "lifetimes: the session transcript, session memory (searchable, so "
-    "it can resurface in a later session), any spilled tool output, and "
-    "the permissions allowlist if you approve it. `argv` is also "
-    "readable by anything that can run `ps` while the process lives.\n"
-    "Move the value into the environment so it never appears in `argv`:\n"
+    "YOLT: possible credential on this command line ({}). Not blocked.\n"
+    "It will persist in the transcript, session memory and the allowlist, "
+    "and `argv` is visible to `ps`. Keep it out of `argv`:\n"
     "  KEY=\"$(fetch-secret)\" sh -c 'curl -H \"X-Api-Key: $KEY\" "
     "https://service/endpoint'"
+)
+
+# Any of these disables the warning. An exact `== "0"` test looks precise
+# and behaves as a trap: a user who reaches for `false` or `off` to
+# silence a noisy control sees no change and concludes it is broken.
+SECRET_WARN_OFF_VALUES = frozenset(
+    {"0", "false", "no", "off", "n", "disable", "disabled"}
 )
 
 
@@ -907,18 +913,27 @@ def format_secret_advisory(command):
     Advisory only — this never changes YOLT's decision. A control that
     false-positives on legitimate work gets switched off and then
     protects nothing, so this warns and suggests the fix rather than
-    refusing. `YOLT_SECRET_WARN=0` disables it. See issue #85.
+    refusing. See `SECRET_WARN_OFF_VALUES` for the disable switch, and
+    issue #85.
 
     The text reports shape and character offset only. The matched value
     is never interpolated into it: a warning that quotes the secret puts
     the secret straight into the transcript it is warning about.
+
+    Never raises. The scan runs in the critical path of every Bash call,
+    so a bug in a credential pattern must cost the warning and nothing
+    else — the safety decision is already made by this point, and it is
+    strictly more important than the advisory.
     """
-    if os.environ.get("YOLT_SECRET_WARN") == "0":
-        retval = None
+    retval = None
+    setting = os.environ.get("YOLT_SECRET_WARN", "").strip().lower()
+    if setting in SECRET_WARN_OFF_VALUES:
         return retval
-    spans = find_secrets(command)
+    try:
+        spans = find_secrets(command)
+    except Exception:
+        return retval
     if not spans:
-        retval = None
         return retval
     found = ", ".join(
         "{} at char {}".format(kind, start) for start, _, kind in spans

--- a/tests/test_secret_advisory.py
+++ b/tests/test_secret_advisory.py
@@ -1,0 +1,112 @@
+"""Tests for the PreToolUse credential advisory (issue #85).
+
+Invokes `python3 hooks/yolt_analyzer.py --hook` as a subprocess with a
+simulated hook payload, and asserts on the JSON emitted on stdout.
+
+Runs with stdlib unittest only:
+
+    python3 -m unittest discover -v tests
+"""
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Synthetic value, shaped like the real thing, valid nowhere.
+FAKE_GH_TOKEN = "ghp_" + "A1b2C3d4E5f6G7h8I9j0" * 2
+
+
+def run_hook(command, extra_env=None):
+    """Fire the PreToolUse hook and return its parsed response ({} if
+    it exited silently). Logging is pointed at a temp dir so the test
+    never appends to the developer's real ~/.claude/yolt.log."""
+    payload = {
+        "tool_name": "Bash",
+        "tool_input": {"command": command},
+        "permission_mode": "default",
+    }
+    with tempfile.TemporaryDirectory() as tmp:
+        env = dict(os.environ)
+        env["YOLT_LOG_FILE"] = str(Path(tmp) / "yolt.log")
+        env["YOLT_RAN_LOG_FILE"] = ""
+        if extra_env:
+            env.update(extra_env)
+        proc = subprocess.run(
+            [sys.executable, str(REPO_ROOT / "hooks" / "yolt_analyzer.py"),
+             "--hook"],
+            input=json.dumps(payload), capture_output=True, text=True,
+            env=env, timeout=60,
+        )
+    if not proc.stdout.strip():
+        return {}
+    return json.loads(proc.stdout)
+
+
+class AdvisoryTests(unittest.TestCase):
+
+    def assert_warned(self, response, command_fragment=None):
+        self.assertIn("systemMessage", response)
+        self.assertIn("credential", response["systemMessage"])
+        self.assertIn(
+            "additionalContext", response.get("hookSpecificOutput", {}))
+        # The warning must not quote the secret it is warning about.
+        self.assertNotIn(FAKE_GH_TOKEN, json.dumps(response))
+        if command_fragment:
+            self.assertIn(command_fragment, response["systemMessage"])
+
+    def test_warns_on_safe_command_without_blocking(self):
+        # `curl` a URL with a token in a header: nothing unsafe by YOLT's
+        # lights, which is exactly the case that motivated the issue.
+        response = run_hook(
+            'curl -H "Authorization: Bearer {}" https://api.github.com'.format(
+                FAKE_GH_TOKEN))
+        self.assert_warned(response)
+        decision = response["hookSpecificOutput"].get("permissionDecision")
+        self.assertNotEqual(decision, "deny")
+
+    def test_advisory_names_shape_and_offset_only(self):
+        response = run_hook("gh auth login --with-token {}".format(
+            FAKE_GH_TOKEN))
+        self.assert_warned(response, "github-token at char")
+
+    def test_advisory_suggests_the_env_remediation(self):
+        response = run_hook("gh auth login --with-token {}".format(
+            FAKE_GH_TOKEN))
+        self.assertIn("environment", response["systemMessage"])
+        self.assertIn("$KEY", response["systemMessage"])
+
+    def test_unsafe_command_keeps_its_decision(self):
+        response = run_hook(
+            'curl -X POST -H "Authorization: Bearer {}" '
+            "https://api.github.com/repos/o/r/issues".format(FAKE_GH_TOKEN))
+        self.assert_warned(response)
+        # The advisory rides along; it does not replace the safety verdict.
+        self.assertIn("permissionDecision", response["hookSpecificOutput"])
+
+    def test_clean_command_gets_no_advisory(self):
+        response = run_hook("ls /tmp")
+        self.assertNotIn("systemMessage", response)
+        self.assertNotIn(
+            "additionalContext", response.get("hookSpecificOutput", {}))
+
+    def test_shell_expansion_gets_no_advisory(self):
+        # The form we are steering people toward must not be warned about.
+        response = run_hook(
+            'curl -H "Authorization: Bearer $GITHUB_TOKEN" https://api.github.com')
+        self.assertNotIn("systemMessage", response)
+
+    def test_kill_switch(self):
+        response = run_hook(
+            "gh auth login --with-token {}".format(FAKE_GH_TOKEN),
+            extra_env={"YOLT_SECRET_WARN": "0"})
+        self.assertNotIn("systemMessage", response)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_secret_advisory.py
+++ b/tests/test_secret_advisory.py
@@ -78,8 +78,12 @@ class AdvisoryTests(unittest.TestCase):
     def test_advisory_suggests_the_env_remediation(self):
         response = run_hook("gh auth login --with-token {}".format(
             FAKE_GH_TOKEN))
-        self.assertIn("environment", response["systemMessage"])
-        self.assertIn("$KEY", response["systemMessage"])
+        # The runnable fix, not just a complaint: the value moves into an
+        # env var so it never appears in argv.
+        message = response["systemMessage"]
+        self.assertIn("argv", message)
+        self.assertIn('KEY="$(fetch-secret)"', message)
+        self.assertIn("$KEY", message)
 
     def test_unsafe_command_keeps_its_decision(self):
         response = run_hook(
@@ -102,10 +106,82 @@ class AdvisoryTests(unittest.TestCase):
         self.assertNotIn("systemMessage", response)
 
     def test_kill_switch(self):
+        # An exact `== "0"` test would leave `false` / `off` silently
+        # warning, which reads as a broken switch.
+        for value in ("0", "false", "FALSE", "no", "off", " off "):
+            response = run_hook(
+                "gh auth login --with-token {}".format(FAKE_GH_TOKEN),
+                extra_env={"YOLT_SECRET_WARN": value})
+            self.assertNotIn(
+                "systemMessage", response,
+                "YOLT_SECRET_WARN={!r} did not disable".format(value))
+
+    def test_advisory_stays_short(self):
+        # It rides along with a prompt the user is already reading. A
+        # wall of text is how a security control gets switched off.
+        response = run_hook("gh auth login --with-token {}".format(
+            FAKE_GH_TOKEN))
+        self.assertLess(len(response["systemMessage"]), 400)
+
+
+class DecisionIntegrityTests(unittest.TestCase):
+    """The central claim of this PR: the advisory changes nothing.
+
+    Asserting "the decision is not deny" is not enough — that would pass
+    even if the advisory silently flipped `ask` to `allow`. These
+    compare the same command with and without a credential and require
+    the decision to come out identical.
+    """
+
+    def decision_of(self, response):
+        return response.get("hookSpecificOutput", {}).get("permissionDecision")
+
+    def test_decision_identical_with_and_without_credential(self):
+        templates = [
+            'curl -H "X-Api-Key: {}" https://service/endpoint',
+            "gh auth login --with-token {}",
+            'curl -X POST -H "Authorization: Bearer {}" https://api.github.com/x',
+            "some-unknown-internal-cli --token {}",
+        ]
+        for template in templates:
+            with_secret = run_hook(template.format(FAKE_GH_TOKEN))
+            without_secret = run_hook(template.format("PLACEHOLDERVALUE"))
+            # Guard against a vacuous pass: the credential case must
+            # actually have warned, or this proves nothing.
+            self.assertIn("systemMessage", with_secret, template)
+            self.assertNotIn("systemMessage", without_secret, template)
+            self.assertEqual(self.decision_of(with_secret),
+                             self.decision_of(without_secret),
+                             "advisory moved the decision for: " + template)
+
+    def test_unknown_path_warns_without_claiming_a_decision(self):
+        """The riskiest path: this previously printed nothing at all.
+
+        Emitting a `permissionDecision` here would convert Claude Code's
+        default prompt into an allow. The response must carry the
+        warning and assert no decision.
+        """
         response = run_hook(
-            "gh auth login --with-token {}".format(FAKE_GH_TOKEN),
-            extra_env={"YOLT_SECRET_WARN": "0"})
-        self.assertNotIn("systemMessage", response)
+            "some-unknown-internal-cli --token {}".format(FAKE_GH_TOKEN))
+        self.assertIn("systemMessage", response)
+        self.assertIsNone(self.decision_of(response),
+                          "advisory asserted a permission decision on the "
+                          "unknown fallthrough")
+
+    def test_scanner_failure_does_not_break_the_hook(self):
+        """A bug in a credential pattern must cost the warning, not the
+        session. The safety decision is already made by this point."""
+        import importlib.util
+        spec = importlib.util.spec_from_file_location(
+            "ya_advisory", REPO_ROOT / "hooks" / "yolt_analyzer.py")
+        analyzer = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(analyzer)
+
+        def exploding_find_secrets(text):
+            raise ValueError("simulated pattern bug")
+
+        analyzer.find_secrets = exploding_find_secrets
+        self.assertIsNone(analyzer.format_secret_advisory("ls /tmp"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #85.

## Why here

YOLT already parses every Bash command for safety, so `PreToolUse` is
the natural place to catch a hazard it was blind to — a credential in
the command string itself.

The motivating case is not a mistake:

```
curl -H "X-Api-Key: <value>" https://service/endpoint
```

The key was fetched correctly from a secret manager. Nothing about the
command is unsafe by YOLT's current lights. But that string then lands
in the transcript, in session memory (embedded and searchable, so it can
resurface in a *later* session), in spilled tool output, in YOLT's own
logs, and in `permissions.allow` if the approved command contained it.
Copies with different lifetimes, none in git, most never swept — plus
`argv` is readable by anything that can run `ps` while the process lives.

`PreToolUse` is the only point where that is preventable rather than
cleanable. Once the command has run, every one of those copies exists.

## Shape

Reuses `find_secrets()` from #86 (merged), so the match set and the
false-positive guards are shared — one place to tune, and structured
prefixes come first with assignment shapes gated on a literal-value
guard, as the issue asked.

- **Advisory, never blocking.** The warning attaches to whatever
  decision was already reached — `allow`, `ask`, `deny`, and the silent
  `unknown` fallthrough alike — and never changes it. On the `unknown`
  path the response carries no `permissionDecision`, so Claude Code's
  default prompt is untouched and the warning costs the fallthrough
  nothing.
- **Suggests the remediation, does not just refuse.** Emitted as
  `systemMessage` (the user sees it) *and* `additionalContext` (Claude
  sees it), which is what makes the fix actionable rather than
  decorative:
  ```
  KEY="$(fetch-secret)" sh -c 'curl -H "X-Api-Key: $KEY" https://service/endpoint'
  ```
- **Never logs or prints the matched value.** Shape and character offset
  only — a warning that quotes the secret puts the secret into the
  transcript it is warning about.
- **`YOLT_SECRET_WARN=0`** turns it off. A control that false-positives
  on legitimate work gets disabled wholesale and then protects nothing;
  a documented switch keeps that decision cheap and visible.

## Counting, for the "tighten later" step

No new log field needed — #86 already writes `[REDACTED:<shape>]` into
`~/.claude/yolt.log`, so the hit rate is greppable from the existing log
and can be weighed against real usage before anything is escalated
beyond advisory.

## Tests

`tests/test_secret_advisory.py` — 7 tests driving the real hook entry
point as a subprocess: warns on a *safe* `curl` without blocking, keeps
the safety verdict on an unsafe one, names shape and offset, includes
the env remediation, never leaks the value into the response JSON, stays
silent on clean commands and on `$GITHUB_TOKEN`-style expansions, and
honours the kill switch.

Full suite: 603 -> 610 tests, all green (3.12 and 3.14 locally, 3.10–3.12
in CI — which for this PR runs after retargeting to `master`, since the
workflow only triggers on PRs based on `master`).

## Version

`0.3.0` -> `0.4.0`. Minor: new user-visible warning and a new env var.



---

## Adversarial review round

Three verified findings, all fixed.

1. **A scanner exception killed the whole hook.** `find_secrets` ran
   unguarded in `format_secret_advisory`, which sits in the critical
   path of every Bash call — a future bug in any credential pattern
   would have propagated out of PreToolUse and broken the session. Now
   caught: the warning is lost, the safety decision is not.
2. **The kill switch was a trap.** `YOLT_SECRET_WARN` was compared
   exactly against `"0"`, so `false` / `no` / `off` silently kept
   warning. For a control this PR itself argues gets switched off when
   noisy, a disable that appears not to work is worse than none. Now
   accepts the usual falsy spellings, case- and space-insensitive.
3. **The message was 618 characters.** It rides along with a permission
   prompt the user is already reading. Cut to three lines, keeping the
   shape, the offset and the runnable remediation; asserted under 400
   chars by test.

**The riskiest question, settled:** the `unknown` path now emits JSON
where it previously printed nothing. Verified against the hook docs —
`hookSpecificOutput` without `permissionDecision` is the documented
advisory shape, and "exit 0 with no output means the hook has no
decision to report, so the tool call continues through the normal
permission flow. The hook can deny the call, but staying silent doesn't
approve it." So the default prompt is preserved; the advisory cannot
silently convert an `unknown` into an allow. There is now a test
asserting exactly that.

**Tests the previous round was missing, now added:**

- `DecisionIntegrityTests` proves this PR's actual claim by running the
  same command with and without a credential and requiring an identical
  `permissionDecision`. The old assertion (`decision != "deny"`) would
  have passed even if the advisory flipped `ask` to `allow`. It also
  guards against a vacuous pass by requiring the credential case to have
  genuinely warned.
- A test for the unknown fallthrough — previously untested, and the
  highest-risk path in the PR.
- A test that a raising scanner cannot break the hook.

**Held up under attack:** no value reaches `systemMessage`,
`additionalContext`, or stdout; `permissionDecisionReason` and
`suggest_allow_pattern` do not echo the credential either; the subagent
`deny` path is still `deny` with the advisory attached; latency is
0.01 ms on a normal command.

626 tests, green.

**Field note:** while these PRs were open, a GitHub token leaked again
on another machine through exactly this path. Revoked and rotated. This
is the class of event the advisory is meant to interrupt.
