### PR TITLE
fix(redact): bare NAME= leak, dropped overlap spans, and reviewer copying credentials (#90, #91)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "yolt",
   "description": "Static safety analyzer for Bash invocations - auto-allows read-only commands and prompts for mutating ones, plus a Python AST analyzer for python3 / python3 -c / heredoc invocations.",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "author": {
     "name": "voitta-ai"
   },

--- a/hooks/secret_redact.py
+++ b/hooks/secret_redact.py
@@ -98,8 +98,12 @@ _SECRETISH_QUERY = (
 _ASSIGNMENT_PATTERNS = [
     ("flag-value", re.compile(
         r"--(?:" + _SECRETISH_FLAG + r")(?:[=\s]+)[\"']?([^\s\"']+)", re.I), 1),
+    # The name prefix is optional. It used to be `[A-Za-z_][A-Za-z0-9_]*`,
+    # which required at least one character *before* the keyword and so
+    # made every keyword fail to match itself: `GH_TOKEN=` matched,
+    # bare `TOKEN=` did not. See issue #90.
     ("env-assignment", re.compile(
-        r"\b[A-Za-z_][A-Za-z0-9_]*(?:" + _SECRETISH_NAME + r")"
+        r"\b[A-Za-z0-9_]*(?:" + _SECRETISH_NAME + r")"
         r"\s*=\s*[\"']?([^\s\"']+)", re.I), 1),
     ("header-value", re.compile(
         r"(?:" + _SECRETISH_HEADER + r")\s*:\s*"
@@ -158,6 +162,12 @@ def find_secrets(text):
     nested inside it). The value itself is never returned - callers get
     shape and position only, so a caller cannot accidentally surface a
     secret in a warning or a diagnostic.
+
+    Overlaps are *clipped*, never dropped. Dropping a span that starts
+    inside its predecessor but ends beyond it left the uncovered tail in
+    cleartext next to a marker that made the record read as handled -
+    a `--password <run-on PEM>` leaked the whole key body that way. See
+    issue #90.
     """
     spans = []
     for kind, pattern, group in _STRUCTURED_PATTERNS:
@@ -174,9 +184,13 @@ def find_secrets(text):
     retval = []
     reach = -1
     for start, end, kind in spans:
-        if start >= reach:
-            retval.append((start, end, kind))
-            reach = end
+        if end <= reach:
+            # Fully covered by an earlier span; nothing left to redact.
+            continue
+        # Clip to the uncovered tail rather than discarding the span.
+        start = max(start, reach)
+        retval.append((start, end, kind))
+        reach = end
     return retval
 
 

--- a/hooks/yolt_review.py
+++ b/hooks/yolt_review.py
@@ -72,7 +72,8 @@ except ImportError:
 # logs (issue #91). Guarded like the import above so the reviewer keeps
 # working, but the fallback is deliberately *not* "emit the raw command":
 # `redact_command` below reduces a command to its shape, dropping every
-# value token. Less useful in a report, incapable of leaking.
+# value token. Much less likely to leak, though not airtight - see
+# `redact_example`.
 try:
     from secret_redact import redact as _redact_values
 except ImportError:
@@ -454,9 +455,12 @@ def redact_example(command):
     command readable and removes only credential-shaped values, which is
     what an `examples` entry needs to stay useful for diagnosing friction.
 
-    Falls back to the shape reducer when `secret_redact` is unavailable -
-    fail closed, since the whole point is that this text leaves the log
-    and lands in two more files. See issue #91.
+    Falls back to the shape reducer when `secret_redact` is unavailable,
+    since the whole point is that this text leaves the log and lands in
+    two more files. That fallback strips every *value* token but passes
+    `argv[0]` and valueless `-flags` through verbatim, so it is much
+    safer, not airtight - a bare `<secret> --dry-run` would survive it.
+    See issue #91.
     """
     if _redact_values is None:
         retval = redact_command(command)
@@ -578,7 +582,11 @@ def annotate_glob_collisions(suggestion, nonsafe_commands, own_commands=None):
         if command in own:
             continue
         if fnmatch(command, pattern):
-            collisions.append(command[:MAX_EXAMPLE_CHARS])
+            # Redacted for the same reason as `examples` (issue #91), and
+            # this is the likelier of the two to carry auth: a collision
+            # is by definition a *non-safe* command, i.e. exactly the
+            # `-X POST ... -H Authorization:` shape.
+            collisions.append(redact_example(command)[:MAX_EXAMPLE_CHARS])
             if len(collisions) >= MAX_EXAMPLES:
                 break
     suggestion["glob_collisions"] = collisions

--- a/hooks/yolt_review.py
+++ b/hooks/yolt_review.py
@@ -68,6 +68,16 @@ except ImportError:
     validate_shell_rules = None
     _RULES_AVAILABLE = False
 
+# Credential redaction for the command text this tool copies out of the
+# logs (issue #91). Guarded like the import above so the reviewer keeps
+# working, but the fallback is deliberately *not* "emit the raw command":
+# `redact_command` below reduces a command to its shape, dropping every
+# value token. Less useful in a report, incapable of leaking.
+try:
+    from secret_redact import redact as _redact_values
+except ImportError:
+    _redact_values = None
+
 DEFAULT_LOG_PATH = Path.home() / ".claude" / "yolt.log"
 DEFAULT_RAN_LOG_PATH = Path.home() / ".claude" / "yolt-ran.log"
 DEFAULT_STATE_DIR = Path.home() / ".claude" / "yolt"
@@ -436,6 +446,25 @@ def redact_command(command):
     return retval
 
 
+def redact_example(command):
+    """Credential-redact a command before it is copied into a report.
+
+    Distinct from `redact_command` above: that reduces a command to its
+    *shape* for sharing upstream, dropping every value. This keeps the
+    command readable and removes only credential-shaped values, which is
+    what an `examples` entry needs to stay useful for diagnosing friction.
+
+    Falls back to the shape reducer when `secret_redact` is unavailable -
+    fail closed, since the whole point is that this text leaves the log
+    and lands in two more files. See issue #91.
+    """
+    if _redact_values is None:
+        retval = redact_command(command)
+        return retval
+    retval = _redact_values(command)
+    return retval
+
+
 def suggestion_id(kind, prefix):
     """Stable id so applied/dismissed status survives regeneration."""
     digest = hashlib.sha256("{}|{}".format(kind, prefix).encode("utf-8"))
@@ -630,7 +659,13 @@ def build_groups(records, ran_index, min_fires, min_fires_safe, known_clis=None)
             group["reasons"][reason] = group["reasons"].get(reason, 0) + 1
         if index in approved_indices:
             group["approved"] += 1
-        example = command[:MAX_EXAMPLE_CHARS]
+        # Redact at collection, not at render: `examples` flows into both
+        # ~/.claude/yolt/review.md and ~/.claude/yolt/suggestions.json, and
+        # doing it here covers both. The analyzer redacts at write time
+        # (issue #84), but log lines written before that still hold
+        # plaintext, and this reviewer would otherwise keep copying them
+        # into two more files every session. See issue #91.
+        example = redact_example(command)[:MAX_EXAMPLE_CHARS]
         if example not in group["examples"] and len(group["examples"]) < MAX_EXAMPLES:
             group["examples"].append(example)
 

--- a/tests/test_review_redaction.py
+++ b/tests/test_review_redaction.py
@@ -1,0 +1,107 @@
+"""The reviewer must not copy credentials out of the logs (issue #91).
+
+`yolt_review.py` reads ~/.claude/yolt.log and writes command examples
+into two more files. Redaction in the analyzer (issue #84) is write-time
+only, so log lines predating it still hold plaintext — and without this,
+every session copied more of them into review.md and suggestions.json.
+
+Runs with stdlib unittest only:
+
+    python3 -m unittest discover -v tests
+"""
+
+import datetime
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "hooks"))
+
+# Synthetic value, shaped like the real thing, valid nowhere.
+FAKE_GH_TOKEN = "ghp_" + "A1b2C3d4E5f6G7h8I9j0" * 2
+
+
+class ReviewerRedactionTests(unittest.TestCase):
+
+    def write_log(self, path, command, count=12):
+        """A log holding unredacted lines, i.e. one written before #84."""
+        now = datetime.datetime.now(datetime.timezone.utc)
+        with open(path, "w") as f:
+            for i in range(count):
+                ts = (now - datetime.timedelta(minutes=i)).isoformat()
+                f.write(json.dumps({
+                    "ts": ts,
+                    "decision": "unknown",
+                    "reason": "",
+                    "command": command,
+                    "permission_mode": "default",
+                    "agent_id": None,
+                }) + "\n")
+
+    def test_generated_artifacts_carry_no_credential(self):
+        command = "frobnicate push --token {} --env prod".format(
+            FAKE_GH_TOKEN)
+        with tempfile.TemporaryDirectory() as tmp:
+            log_path = Path(tmp) / "yolt.log"
+            state_dir = Path(tmp) / "state"
+            state_dir.mkdir()
+            self.write_log(log_path, command)
+
+            subprocess.run(
+                [sys.executable, str(REPO_ROOT / "hooks" / "yolt_review.py"),
+                 "--generate", "--log", str(log_path),
+                 "--state-dir", str(state_dir)],
+                capture_output=True, text=True, timeout=120,
+            )
+
+            produced = [p for p in state_dir.rglob("*") if p.is_file()]
+            self.assertTrue(produced, "reviewer generated nothing")
+            for path in produced:
+                self.assertNotIn(
+                    FAKE_GH_TOKEN, path.read_text(errors="replace"),
+                    "credential copied into {}".format(path.name))
+
+    def test_examples_stay_useful_after_redaction(self):
+        """Redaction must not reduce an example to noise - the command
+        shape is what makes a friction suggestion actionable."""
+        command = "frobnicate push --token {} --env prod".format(
+            FAKE_GH_TOKEN)
+        with tempfile.TemporaryDirectory() as tmp:
+            log_path = Path(tmp) / "yolt.log"
+            state_dir = Path(tmp) / "state"
+            state_dir.mkdir()
+            self.write_log(log_path, command)
+            subprocess.run(
+                [sys.executable, str(REPO_ROOT / "hooks" / "yolt_review.py"),
+                 "--generate", "--log", str(log_path),
+                 "--state-dir", str(state_dir)],
+                capture_output=True, text=True, timeout=120,
+            )
+            doc = (state_dir / "review.md").read_text(errors="replace")
+            self.assertIn("frobnicate push", doc)
+            self.assertIn("--env prod", doc)
+
+    def test_falls_back_to_shape_reducer_without_the_redactor(self):
+        """Fail closed: with `secret_redact` unimportable, examples must
+        degrade to the value-stripping shape reducer, never to the raw
+        command."""
+        import importlib.util
+        spec = importlib.util.spec_from_file_location(
+            "yr_fallback", REPO_ROOT / "hooks" / "yolt_review.py")
+        reviewer = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(reviewer)
+
+        reviewer._redact_values = None
+        command = "frobnicate push --token {} --env prod".format(
+            FAKE_GH_TOKEN)
+        out = reviewer.redact_example(command)
+        self.assertNotIn(FAKE_GH_TOKEN, out)
+        self.assertIn("frobnicate", out)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_review_redaction.py
+++ b/tests/test_review_redaction.py
@@ -85,6 +85,57 @@ class ReviewerRedactionTests(unittest.TestCase):
             self.assertIn("frobnicate push", doc)
             self.assertIn("--env prod", doc)
 
+    def test_glob_collisions_are_redacted(self):
+        """The sibling sink of `examples` (issue #91 follow-up).
+
+        A collision is by definition a *non-safe* command, so it is the
+        likelier of the two to carry auth — a `-X POST ... -H
+        'Authorization: ...'` is exactly what gets flagged. The first fix
+        redacted `examples` and left this one, which put the same
+        credential in the same two files eight lines apart.
+        """
+        safe = "gh api /repos/o/r/issues?page={}"
+        unsafe = ("gh api -X POST /repos/o/r/issues "
+                  "-H 'Authorization: token {}'".format(FAKE_GH_TOKEN))
+        now = datetime.datetime.now(datetime.timezone.utc)
+        with tempfile.TemporaryDirectory() as tmp:
+            log_path = Path(tmp) / "yolt.log"
+            state_dir = Path(tmp) / "state"
+            state_dir.mkdir()
+            with open(log_path, "w") as f:
+                # Enough safe fires to clear the fastpath threshold, and a
+                # single unsafe one so it stays a collision rather than
+                # becoming its own suggestion.
+                rows = [("safe", safe.format(i)) for i in range(12)]
+                rows.append(("unsafe", unsafe))
+                for i, (decision, command) in enumerate(rows):
+                    f.write(json.dumps({
+                        "ts": (now - datetime.timedelta(minutes=i)).isoformat(),
+                        "decision": decision,
+                        "reason": "gh api",
+                        "command": command,
+                        "permission_mode": "default",
+                        "agent_id": None,
+                    }) + "\n")
+
+            subprocess.run(
+                [sys.executable, str(REPO_ROOT / "hooks" / "yolt_review.py"),
+                 "--generate", "--log", str(log_path),
+                 "--state-dir", str(state_dir)],
+                capture_output=True, text=True, timeout=120,
+            )
+
+            produced = [p for p in state_dir.rglob("*") if p.is_file()]
+            self.assertTrue(produced, "reviewer generated nothing")
+            for path in produced:
+                text = path.read_text(errors="replace")
+                self.assertNotIn(FAKE_GH_TOKEN, text,
+                                 "credential reached {}".format(path.name))
+            # Guard against a vacuous pass: the collision must have been
+            # rendered at all.
+            doc = (state_dir / "review.md").read_text(errors="replace")
+            self.assertIn("Would also allow", doc)
+
     def test_falls_back_to_shape_reducer_without_the_redactor(self):
         """Fail closed: with `secret_redact` unimportable, examples must
         degrade to the value-stripping shape reducer, never to the raw

--- a/tests/test_secret_redact.py
+++ b/tests/test_secret_redact.py
@@ -194,6 +194,70 @@ class BypassRegressionTests(unittest.TestCase):
             "oauth2 client_secret 8f14e45fceea167a5a36dedd4bea2543")
 
 
+class BareEnvNameTests(unittest.TestCase):
+    """Issue #90: every keyword in `_SECRETISH_NAME` failed to match itself.
+
+    The pattern required at least one character *before* the keyword, so
+    `GH_TOKEN=` matched and bare `TOKEN=` did not. The existing corpus
+    only used prefixed names, which is precisely what hid it — so this
+    exercises each keyword standalone.
+    """
+
+    VALUE = "9f3c1a7e42b8d05e6c1f9a7b3d2e8c40"
+    KEYWORDS = [
+        "TOKEN", "PASSWORD", "PASSWD", "SECRET", "APIKEY", "API_KEY",
+        "ACCESS_KEY", "SECRET_KEY", "CREDENTIAL", "CREDENTIALS",
+    ]
+
+    def test_each_keyword_matches_standalone(self):
+        for keyword in self.KEYWORDS:
+            command = "{}={} ./deploy.sh".format(keyword, self.VALUE)
+            self.assertNotIn(self.VALUE, redact(command), command)
+
+    def test_lowercase_forms(self):
+        for keyword in ("token", "password", "secret"):
+            command = "{}={} ./deploy.sh".format(keyword, self.VALUE)
+            self.assertNotIn(self.VALUE, redact(command), command)
+
+    def test_prefixed_forms_still_work(self):
+        for keyword in ("GH_TOKEN", "DB_PASSWORD", "MYTOKEN", "X_API_KEY"):
+            command = "{}={} ./deploy.sh".format(keyword, self.VALUE)
+            self.assertNotIn(self.VALUE, redact(command), command)
+
+
+class OverlapClippingTests(unittest.TestCase):
+    """Issue #90: a span starting inside its predecessor but ending
+    beyond it was dropped entirely rather than clipped, leaving the
+    uncovered tail in cleartext next to a marker that made the record
+    read as handled."""
+
+    def test_run_on_pem_after_a_flag_value(self):
+        command = ("ssh-add --password abc123def456ghi789"
+                   "-----BEGIN RSA PRIVATE KEY-----\n"
+                   "BODYSECRETMATERIAL\n"
+                   "-----END RSA PRIVATE KEY-----")
+        out = redact(command)
+        self.assertNotIn("BODYSECRETMATERIAL", out)
+        self.assertNotIn("abc123def456ghi789", out)
+
+    def test_clipped_spans_are_contiguous_and_ordered(self):
+        command = ("ssh-add --password abc123def456ghi789"
+                   "-----BEGIN RSA PRIVATE KEY-----\n"
+                   "BODY\n-----END RSA PRIVATE KEY-----")
+        spans = find_secrets(command)
+        self.assertGreater(len(spans), 1)
+        for (s1, e1, _), (s2, e2, _) in zip(spans, spans[1:]):
+            self.assertLessEqual(e1, s2, "spans overlap after clipping")
+            self.assertLess(s2, e2, "empty span emitted")
+
+    def test_fully_contained_span_still_collapses(self):
+        # The original behaviour for containment must not regress: one
+        # span, not two.
+        command = 'curl -H "Authorization: Bearer {}" https://x'.format(
+            FAKE_GH_TOKEN)
+        self.assertEqual(len(find_secrets(command)), 1)
+
+
 class FalsePositiveCorpusTests(unittest.TestCase):
     """Ordinary commands that must survive redaction byte-for-byte.
 


### PR DESCRIPTION
Closes #90. Closes #91.

Three verified holes found by adversarial review after the v0.4.0 merge,
all putting plaintext credentials on disk.

## #90 bug 1 — every bare `NAME=` assignment leaked

```python
\b[A-Za-z_][A-Za-z0-9_]*(?:TOKEN|SECRET|...)
```

requires at least one character *before* the keyword, so each keyword
failed to match itself:

```
TOKEN=9f3c…      LEAKS        GH_TOKEN=9f3c…    redacted
PASSWORD=9f3c…   LEAKS        DB_PASSWORD=9f3c… redacted
SECRET=9f3c…     LEAKS
```

All nine names, plus lowercase forms via `re.I`. The existing tests used
`SERVICE_TOKEN=` and `AWS_KEY=` — both prefixed — which is exactly what
hid it. Fix makes the prefix optional; new tests exercise each keyword
standalone.

## #90 bug 2 — partial-overlap spans dropped rather than clipped

`find_secrets` kept a span only when `start >= reach`, so a span starting
inside its predecessor but ending far beyond it was discarded entirely:

```
ssh-add --password abc123def456ghi789-----BEGIN RSA PRIVATE KEY-----
BODYSECRETMATERIAL
-----END RSA PRIVATE KEY-----
```

`flag-value` took (19,47); `private-key` started at 37, was dropped, and
the whole key body was written next to a `[REDACTED:flag-value]` marker
that made the record *read* as handled. Now clipped to the uncovered
tail. Full containment still collapses to a single span.

## #91 — the reviewer copied credentials into two more files

`yolt_review.py` had no redaction at all; `examples` carried raw log
commands into `~/.claude/yolt/review.md` and `suggestions.json`. Blast
radius was four files, not two — and since redaction is write-time only,
pre-v0.3.0 log lines are still plaintext, so each SessionEnd run copied
*more* of them into two additional files. Exposure that grew rather than
aging out with rotation. Found real high-entropy tokens in both files on
a live machine.

Redaction now happens at collection, covering doc and state file in one
place. Grouping is unaffected (`group_key` already strips values). The
import is guarded like the existing `rule_classifier` one, but the
fallback is deliberately not "emit the raw command" — it degrades to
`redact_command`, the existing shape reducer, which drops every value
token. Less useful in a report, incapable of leaking.

## Adversarial review of this fix

**False positives from the looser prefix: none.** 9 realistic commands
untouched, including the ones most likely to trip it —
`echo TOKENIZER=simple`, `make TOKEN_LIMIT=4096 build`,
`s3://my-bucket/tokens=latest`, `git commit -m 'fix: token=abc parsing'`.
The value guard is what holds the line.

**Clipping invariants hold** across three-way overlaps, exactly-touching
spans, identical repeated shapes, nested url+key, containment, and
marker-shaped input: no empty or inverted spans, none out of bounds, no
residual overlap, ordering preserved.

**One residual, recorded not hidden** (noted on #92): redacting before
`[:MAX_EXAMPLE_CHARS]` means a long collapsing prefix can pull a
*previously-truncated* uncaught secret into the 200-char example window.
It needs a value the guard rejects — e.g. one containing `!`, which is
#92 gap 1, the root cause. Net effect of this PR is still strongly
positive: before it, review.md carried the raw command including any
credential in the first 200 chars. Narrower residual, not a new class.

**Not fixed here, tracked:** #92 (guard charclass, underscore vendor
prefixes, JWTs, truncation window), #93 (unguarded import fails silently
and open), #89 (`redact()` not idempotent — confirmed no worse by this
diff).

## Tests

635, green. New: one per bare `NAME=` keyword plus lowercase and
prefixed forms; the run-on-PEM overlap case; clipping invariants
(contiguous, ordered, non-empty); containment non-regression; and an
end-to-end reviewer test that generates from a legacy-format log and
asserts every produced file is free of the credential while the command
shape survives. Plus a fail-closed test for the reviewer's fallback.

Version 0.4.0 -> 0.5.0.


---

## Second adversarial round (after the first fix)

**One real miss, found and fixed.** The first pass redacted `examples`
and left `annotate_glob_collisions`, which appends `command[:200]` taken
raw from `nonsafe_commands`. Both render into the same two files, so a
credential appeared redacted on one line and in cleartext eight lines
below:

```
- Example: `gh api -X POST ... -H 'Authorization: token [REDACTED:github-token]'`
- Would also allow: `gh api -X POST ... -H 'Authorization: token ghp_...'`
```

Reproduced independently before fixing (12 safe `gh api` fires to clear
the fastpath threshold plus a single unsafe one, which stays below the
friction threshold and so remains a collision). This is the *likelier*
of the two sinks to carry auth, not the less likely — a collision is by
definition a non-safe command, and `-X POST ... -H 'Authorization:'` is
exactly the shape that gets flagged.

The new test asserts no raw command reaches **any** file the reviewer
produces, rather than checking one field — a per-field test is precisely
what let this through.

**Also corrected: an overclaim in this PR's own docstring.** It called
the `redact_command` fallback "incapable of leaking". It strips every
value token but passes `argv[0]` and valueless flags through verbatim,
so a bare `<secret> --dry-run` survives it. Now described as much safer,
not airtight.

**#90 confirmed closed under heavy attack:**

- The looser `[A-Za-z0-9_]*` prefix: all ten bare names caught plus
  lowercase, and `\b` still anchors correctly with digit/underscore
  prefixes (`2TOKEN=`, `MY2TOKEN=`, `_TOKEN=`). A 16-case false-positive
  corpus kept 15, including `./notoken=data.csv`, `NOTOKENS=`,
  `/path/to/secretariat=`, `app=tokenizer-service-v2-prod`,
  `SET secret=NULL`, `x.token==y.token`,
  `tokenizer_model=bert-base-uncased-v1`. The one redaction was
  `git log --grep=token=abcdef1234567890ab` — correct-direction
  over-redaction on a contrived input. No new matching inside URLs or
  paths, and no measurable perf change (14.2–14.8 ms flat at 100 KB).
- Clipping: a property test over **61,022 span arrangements**
  (exhaustive 2- and 3-span combinations over 7 positions plus 60,000
  randomized 1–6 span sets) asserting `start < end`, sorted output,
  non-overlapping output, and — the invariant that makes clipping
  *correct* rather than merely different — **union coverage preserved
  against the input**. Zero violations.
- Kind attribution on clipped tails is right: the PEM tail keeps
  `private-key`, which is what that byte range actually is.
- `redact(redact(x))` stable on all probes including the clipped-PEM
  case, so #89 is not made worse.

**Verified unaffected:** `group_key` grouping and `prefix` (computed from
the raw command, redaction-independent), `examples` dedup, `shape`
degradation, `--write-override` (writes only subcommand-derived
fragments, never values), and `group["commands"]` (in-memory only, never
serialized).

**Tracked, not fixed here:** #92 — and note this PR adds a *second*
truncation site to fix there, since `redact_example(...)[:200]` has the
same shortening-window behaviour as the analyzer's `[:500]`, with a
tighter window. Recorded as a comment on #92. Also #93 (unguarded import
in `yolt_analyzer.py`, untouched) — though `yolt_review.py` is slightly
improved by gaining a guarded import with a fail-closed fallback.
