### PR TITLE
fix(redact): deny-list guard, vendor prefixes, idempotence, safe degradation (#89, #92, #93) — v1.0.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "yolt",
   "description": "Static safety analyzer for Bash invocations - auto-allows read-only commands and prompts for mutating ones, plus a Python AST analyzer for python3 / python3 -c / heredoc invocations.",
-  "version": "0.5.0",
+  "version": "1.0.0",
   "author": {
     "name": "voitta-ai"
   },

--- a/README.md
+++ b/README.md
@@ -742,6 +742,15 @@ does *not* restrict which characters a value may contain — an earlier
 allow-list ran backwards, dismissing `Tr0ub4dor&3!…` precisely because
 the punctuation that made it strong was not on the list.
 
+One accepted cost: past 24 characters the "must mix letters and digits"
+test is waived, so a long ordinary word passed to a secret-ish flag
+(`--secret ThisIsAVeryLongDescription`) is redacted too. There is no
+cheap way to separate that from a passphrase —
+`CORRECTHORSEBATTERYSTAPLE` and `authenticationprovidername` have the
+same length class and the same alphabet diversity. Erring this way is
+deliberate: a false positive costs one unreadable value in a debug log,
+a false negative costs a credential on disk forever.
+
 Redaction is deliberately value-only where it can be, because the
 command *shape* is what the self-improvement reviewer mines — a redacted
 value costs it nothing. It is also **idempotent**: re-running it over

--- a/README.md
+++ b/README.md
@@ -742,14 +742,20 @@ does *not* restrict which characters a value may contain — an earlier
 allow-list ran backwards, dismissing `Tr0ub4dor&3!…` precisely because
 the punctuation that made it strong was not on the list.
 
-One accepted cost: past 24 characters the "must mix letters and digits"
-test is waived, so a long ordinary word passed to a secret-ish flag
-(`--secret ThisIsAVeryLongDescription`) is redacted too. There is no
-cheap way to separate that from a passphrase —
-`CORRECTHORSEBATTERYSTAPLE` and `authenticationprovidername` have the
-same length class and the same alphabet diversity. Erring this way is
-deliberate: a false positive costs one unreadable value in a debug log,
-a false negative costs a credential on disk forever.
+Two tests carry that decision. Past 28 characters the "must mix letters
+and digits" rule is waived, which catches passphrases like
+`CORRECTHORSEBATTERYSTAPLE`. Separately, any all-hex value of 20+
+characters is treated as a key regardless of length, which catches
+`deadbeefcafebabedeadbeef`. Keeping those two rules distinct matters:
+the hex case was never about length, it is about being drawn from an
+alphabet nobody names things in — and conflating them redacted ordinary
+words like `authenticationprovidername`.
+
+Residual over-redaction is accepted where it remains, e.g. a
+Secret-Manager *path* in `SECRET=projects/…/secrets/db-password/…` is
+redacted although a path is not a secret. The direction is deliberate: a
+false positive costs one unreadable value in a debug log, a false
+negative costs a credential on disk forever.
 
 Redaction is deliberately value-only where it can be, because the
 command *shape* is what the self-improvement reviewer mines — a redacted

--- a/README.md
+++ b/README.md
@@ -722,20 +722,31 @@ Two match families (`hooks/secret_redact.py`):
 
 - **Structured prefixes** — `ghp_`/`gho_`/`ghs_`/`ghr_`/`ghu_`,
   `github_pat_`, `glpat-`, `xox[baprse]-`, `xapp-`, `AKIA`/`ASIA`,
-  `sk-`, PEM `PRIVATE KEY` blocks, and the password field of
-  `scheme://user:secret@host`. Self-identifying, so these are matched
-  wherever they appear.
+  `sk-`/`sk_`/`rk_`, `dckr_pat_`, `npm_`, `hf_`, `glc_`, `shpat_`,
+  `AIza`, bare JWTs (`eyJ….eyJ….`), PEM `PRIVATE KEY` blocks, and the
+  password field of `scheme://user:secret@host`. Self-identifying, so
+  these are matched wherever they appear.
 - **Contextual shapes**, where only the surrounding text identifies the
   value — `--token X`, `Authorization: X`, `FOO_TOKEN=X`,
   `curl -u user:X`, `?password=X` in a query string, and bare
   `aws_secret_access_key X` (the AWS *secret* key, unlike the `AKIA` id,
-  has no prefix of its own). Only the *value* is redacted, and only when
-  it passes a literal-shape guard: a shell expansion (`--token $API_KEY`)
-  or an ordinary name (`--token some-resource-name`) is left alone.
+  has no prefix of its own). Quoted values are captured whole, so
+  `--password "correct horse battery staple"` does not lose everything
+  after the first space. Only the *value* is redacted, and only when it
+  passes a literal-shape guard.
+
+That guard is a **deny**-list: it rejects shell expansions
+(`--token $API_KEY`, `$(…)`, backticks) and values too short or too
+monotonous to be keys (`--token some-resource-name`). It deliberately
+does *not* restrict which characters a value may contain — an earlier
+allow-list ran backwards, dismissing `Tr0ub4dor&3!…` precisely because
+the punctuation that made it strong was not on the list.
 
 Redaction is deliberately value-only where it can be, because the
 command *shape* is what the self-improvement reviewer mines — a redacted
-value costs it nothing.
+value costs it nothing. It is also **idempotent**: re-running it over
+already-redacted text is a no-op, which is what makes "re-scan and
+expect zero hits" a valid way to verify a cleanup of old log files.
 
 **This is best-effort, not a guarantee.** It removes the shapes above,
 not "all credentials". A value with no self-identifying prefix and no
@@ -752,6 +763,13 @@ So treat the logs as sensitive regardless — redaction narrows the blast
 radius, it does not license leaving a credential on a command line. The
 `YOLT_LOG_FILE=""` / `YOLT_RAN_LOG_FILE=""` opt-outs remain the way to
 write nothing at all.
+
+If `hooks/secret_redact.py` cannot be imported at all, the hook does not
+fail and does not fall back to writing raw commands. Classification
+still happens — it never needed the redactor — and the log record
+carries `"command": "[WITHHELD:redactor-unavailable]"` plus a
+`redactor_error` field, so the failure is visible without a credential
+riding along.
 
 Note the scope: this stops YOLT persisting a secret it already saw. It
 does not stop the secret reaching `argv` in the first place, where any

--- a/hooks/secret_redact.py
+++ b/hooks/secret_redact.py
@@ -60,7 +60,22 @@ _STRUCTURED_PATTERNS = [
     ("slack-app-token", re.compile(r"\bxapp-[0-9]-[A-Za-z0-9\-]{10,}"), 0),
     ("slack-token", re.compile(r"\bxox[baprse]-[A-Za-z0-9\-]{10,}"), 0),
     ("aws-access-key-id", re.compile(r"\b(?:AKIA|ASIA)[0-9A-Z]{16}\b"), 0),
-    ("api-key", re.compile(r"\bsk-[A-Za-z0-9_\-]{16,}"), 0),
+    # `sk-` (OpenAI/Anthropic) and `sk_`/`rk_` (Stripe) - the separator
+    # differs by vendor, so accept both. See issue #92.
+    ("api-key", re.compile(r"\b[sr]k[-_][A-Za-z0-9_\-]{16,}"), 0),
+    ("vendor-token", re.compile(
+        r"\b(?:dckr_pat_|npm_|hf_|glc_|shpat_|shpss_)"
+        r"[A-Za-z0-9_\-]{16,}"), 0),
+    # Google keys are 39 chars (`AIza` + 35), but pinning the length
+    # exactly means a truncated or vendor-variant key sails through.
+    # `AIza` is distinctive enough that a lower bound is safe.
+    ("google-api-key", re.compile(r"\bAIza[0-9A-Za-z_\-]{30,}"), 0),
+    # A JWT is self-identifying (two base64url segments that decode to
+    # `{"...`), so this is near-zero false-positive risk. Previously
+    # caught only when it sat behind an Authorization header.
+    ("jwt", re.compile(
+        r"\beyJ[A-Za-z0-9_\-]{8,}\.eyJ[A-Za-z0-9_\-]{8,}"
+        r"\.[A-Za-z0-9_\-]{8,}"), 0),
     # scheme://user:secret@host - redact only the password field.
     ("url-credentials", re.compile(
         r"\b[a-zA-Z][a-zA-Z0-9+.\-]*://[^\s:/@]+:([^\s/@]+)@"), 1),
@@ -96,15 +111,28 @@ _SECRETISH_QUERY = (
 # Same tuple shape, but the captured value must additionally pass
 # `_looks_like_literal_secret` before it is treated as a match.
 _ASSIGNMENT_PATTERNS = [
+    # Quoted first, so `--password "two words"` captures the whole value
+    # rather than stopping at the space. An unquoted capture would take
+    # only `two`, leaving the rest in cleartext. See issue #92.
     ("flag-value", re.compile(
-        r"--(?:" + _SECRETISH_FLAG + r")(?:[=\s]+)[\"']?([^\s\"']+)", re.I), 1),
+        r"--(?:" + _SECRETISH_FLAG + r")[=\s]+\"([^\"]+)\"", re.I), 1),
+    ("flag-value", re.compile(
+        r"--(?:" + _SECRETISH_FLAG + r")[=\s]+'([^']+)'", re.I), 1),
+    ("flag-value", re.compile(
+        r"--(?:" + _SECRETISH_FLAG + r")(?:[=\s]+)([^\s\"']+)", re.I), 1),
     # The name prefix is optional. It used to be `[A-Za-z_][A-Za-z0-9_]*`,
     # which required at least one character *before* the keyword and so
     # made every keyword fail to match itself: `GH_TOKEN=` matched,
     # bare `TOKEN=` did not. See issue #90.
     ("env-assignment", re.compile(
         r"\b[A-Za-z0-9_]*(?:" + _SECRETISH_NAME + r")"
-        r"\s*=\s*[\"']?([^\s\"']+)", re.I), 1),
+        r"\s*=\s*\"([^\"]+)\"", re.I), 1),
+    ("env-assignment", re.compile(
+        r"\b[A-Za-z0-9_]*(?:" + _SECRETISH_NAME + r")"
+        r"\s*=\s*'([^']+)'", re.I), 1),
+    ("env-assignment", re.compile(
+        r"\b[A-Za-z0-9_]*(?:" + _SECRETISH_NAME + r")"
+        r"\s*=\s*([^\s\"']+)", re.I), 1),
     ("header-value", re.compile(
         r"(?:" + _SECRETISH_HEADER + r")\s*:\s*"
         r"(?:Bearer\s+|Basic\s+|token\s+)?([^\s\"']+)", re.I), 1),
@@ -123,28 +151,38 @@ _ASSIGNMENT_PATTERNS = [
 _MIN_VALUE_LEN = 16
 # At or above this, a value is too long to be a resource name, so the
 # usual "must mix letters and digits" test is waived - it would otherwise
-# miss an all-hex key that happens to contain no digits, or an all-alpha
-# base62 token.
-_LONG_VALUE_LEN = 32
+# miss an all-hex key that happens to contain no digits, an all-alpha
+# base62 token, or a passphrase. Lowered from 32; `deadbeefcafebabedeadbeef`
+# (24) and `CORRECTHORSEBATTERYSTAPLE` were slipping through. Issue #92.
+_LONG_VALUE_LEN = 24
+
+# Rejected outright: the value is a shell expansion, so the secret is not
+# in the command string at all - which is the form we want people using.
+# This is a *deny*-list on purpose. The previous allow-list
+# (`[A-Za-z0-9_\-.+/=~:%]+`) ran backwards: it excluded `! @ # , & { }`
+# and space, so the more punctuation a password had - the more entropy -
+# the likelier it was to be dismissed. Issue #92.
+_EXPANSION_MARKERS = ("$(", "${", "`")
+
+# The markers this module emits, so a second pass can recognise its own
+# output and leave it alone. Issue #89.
+_MARKER_RE = re.compile(r"\[REDACTED:[a-z0-9-]+\]")
 
 
 def _looks_like_literal_secret(value):
     """True when `value` looks like a credential literal sitting in argv.
 
-    Deliberately conservative - the assignment shapes fire on any
-    `--token X`, so this guard is what keeps `--token $MY_TOKEN` and
-    `--token some-resource-name` out of the results. It errs toward
-    redacting: a false positive costs one unreadable value in a debug
-    log, a false negative costs a credential on disk forever.
+    Deliberately conservative about *context*, not about characters - the
+    assignment shapes fire on any `--token X`, so this guard is what keeps
+    `--token $MY_TOKEN` and `--token some-resource-name` out of the
+    results. Within that, it errs toward redacting: a false positive costs
+    one unreadable value in a debug log, a false negative costs a
+    credential on disk forever.
     """
     retval = True
-    if value.startswith("$") or "$(" in value or "`" in value:
-        # A shell expansion: the secret is not in the command string,
-        # which is exactly the form we want people using.
+    if value.startswith("$") or any(m in value for m in _EXPANSION_MARKERS):
         retval = False
     elif len(value) < _MIN_VALUE_LEN:
-        retval = False
-    elif not re.fullmatch(r"[A-Za-z0-9_\-.+/=~:%]+", value):
         retval = False
     elif len(value) < _LONG_VALUE_LEN and not (
             any(c.isdigit() for c in value)
@@ -169,12 +207,42 @@ def find_secrets(text):
     a `--password <run-on PEM>` leaked the whole key body that way. See
     issue #90.
     """
+    # Ranges already occupied by this function's own markers. Without
+    # this, a second pass matches inside `[REDACTED:...]` - the
+    # url-credentials group happily treats one as a password - so
+    # `redact(redact(x)) != redact(x)` and "re-scan, expect zero" is not
+    # a usable way to verify a scrub. Issue #89.
+    # Character-level coverage rather than "contained in one marker": two
+    # adjacent markers (`[REDACTED:a][REDACTED:b]`, which clipping
+    # produces) form a single run with no whitespace, and a `--password`
+    # capture swallows both at once. A span is ignored only when *every*
+    # character of it is already inside a marker, so a real secret sitting
+    # against a marker is still caught.
+    covered = bytearray(len(text))
+    for match in _MARKER_RE.finditer(text):
+        covered[match.start():match.end()] = b"\x01" * (
+            match.end() - match.start())
+
+    def _is_marker(start, end):
+        retval = start < end and all(covered[start:end])
+        return retval
+
     spans = []
     for kind, pattern, group in _STRUCTURED_PATTERNS:
+        if kind == "private-key" and "-----END" not in text:
+            # The `.*?` with re.S is O(n^2) in unterminated BEGIN markers
+            # (800 of them across 4MB measured at 7.7s). No END means no
+            # match is possible, so skip the scan entirely. Bounding the
+            # body length instead would be worse: an oversized key would
+            # stop matching and leak in full. Issue #92.
+            continue
         for match in pattern.finditer(text):
-            spans.append((match.start(group), match.end(group), kind))
+            if not _is_marker(match.start(group), match.end(group)):
+                spans.append((match.start(group), match.end(group), kind))
     for kind, pattern, group in _ASSIGNMENT_PATTERNS:
         for match in pattern.finditer(text):
+            if _is_marker(match.start(group), match.end(group)):
+                continue
             if _looks_like_literal_secret(match.group(group)):
                 spans.append((match.start(group), match.end(group), kind))
 

--- a/hooks/secret_redact.py
+++ b/hooks/secret_redact.py
@@ -60,12 +60,20 @@ _STRUCTURED_PATTERNS = [
     ("slack-app-token", re.compile(r"\bxapp-[0-9]-[A-Za-z0-9\-]{10,}"), 0),
     ("slack-token", re.compile(r"\bxox[baprse]-[A-Za-z0-9\-]{10,}"), 0),
     ("aws-access-key-id", re.compile(r"\b(?:AKIA|ASIA)[0-9A-Z]{16}\b"), 0),
-    # `sk-` (OpenAI/Anthropic) and `sk_`/`rk_` (Stripe) - the separator
-    # differs by vendor, so accept both. See issue #92.
-    ("api-key", re.compile(r"\b[sr]k[-_][A-Za-z0-9_\-]{16,}"), 0),
+    # `sk-` (OpenAI/Anthropic) keeps the loose form: the hyphen makes it
+    # distinctive. The underscore form must carry Stripe's `live`/`test`
+    # segment - a bare `[sr]k_` matched `rk_analytics_pipeline_worker`.
+    ("api-key", re.compile(r"\bsk-[A-Za-z0-9_\-]{16,}"), 0),
+    ("api-key", re.compile(r"\b[sr]k_(?:live|test)_[A-Za-z0-9]{16,}"), 0),
+    # Lengths pinned to the real formats. The earlier `{16,}` with `_-`
+    # allowed matched npm's own environment variables (`npm_config_*`,
+    # `npm_package_*`, `npm_lifecycle_*`), which appear constantly in CI
+    # and Node work, and HuggingFace cache paths. See issue #92.
+    ("vendor-token", re.compile(r"\bnpm_[A-Za-z0-9]{36,}"), 0),
+    ("vendor-token", re.compile(r"\bhf_[A-Za-z0-9]{34,}"), 0),
+    ("vendor-token", re.compile(r"\bdckr_pat_[A-Za-z0-9_\-]{20,}"), 0),
     ("vendor-token", re.compile(
-        r"\b(?:dckr_pat_|npm_|hf_|glc_|shpat_|shpss_)"
-        r"[A-Za-z0-9_\-]{16,}"), 0),
+        r"\b(?:glc_|shpat_|shpss_)[A-Za-z0-9]{20,}"), 0),
     # Google keys are 39 chars (`AIza` + 35), but pinning the length
     # exactly means a truncated or vendor-variant key sails through.
     # `AIza` is distinctive enough that a lower bound is safe.
@@ -81,9 +89,14 @@ _STRUCTURED_PATTERNS = [
         r"\b[a-zA-Z][a-zA-Z0-9+.\-]*://[^\s:/@]+:([^\s/@]+)@"), 1),
 ]
 
+# Note the absence of a bare `auth`: `--auth <mode>` is the common shape
+# (`--auth basic`, `--auth SASL_SSL,SCRAM-SHA-512`,
+# `--auth kubernetes-service-account`), so it produced more false
+# positives than every other flag word combined while almost never
+# carrying a literal. `--auth-token` / `--authtoken` still match. #92.
 _SECRETISH_FLAG = (
     r"token|password|passwd|secret|"
-    r"api[-_]?key|access[-_]?key|secret[-_]?key|auth"
+    r"api[-_]?key|access[-_]?key|secret[-_]?key|auth[-_]?token"
 )
 _SECRETISH_NAME = (
     r"TOKEN|SECRET|PASSWORD|PASSWD|APIKEY|API_KEY|"
@@ -151,10 +164,25 @@ _ASSIGNMENT_PATTERNS = [
 _MIN_VALUE_LEN = 16
 # At or above this, a value is too long to be a resource name, so the
 # usual "must mix letters and digits" test is waived - it would otherwise
-# miss an all-hex key that happens to contain no digits, an all-alpha
-# base62 token, or a passphrase. Lowered from 32; `deadbeefcafebabedeadbeef`
-# (24) and `CORRECTHORSEBATTERYSTAPLE` were slipping through. Issue #92.
-_LONG_VALUE_LEN = 24
+# miss an all-alpha base62 token or a passphrase.
+#
+# 24 was too low: it is exactly the band where hyphenated resource names
+# live (`production-deployment-approval`), and it redacted ordinary words
+# like `authenticationprovidername`. 28 keeps
+# `CORRECTHORSEBATTERYSTAPLEXYZZY` (30) while dropping those, and the
+# all-hex rule below covers what 24 was really there for. Issue #92.
+_LONG_VALUE_LEN = 28
+# An all-hex string of this length is an encoded blob, never a name -
+# `deadbeefcafebabedeadbeef` (24, no digits) is a key, not a word. This
+# is the precise version of what the lowered length bound approximated.
+_MIN_HEX_LEN = 20
+# Lowercase kebab-case with alphabetic segments is a resource-name idiom
+# (`production-deployment-approval`), never how a credential literal is
+# shaped. Without this, that name and the passphrase
+# `CORRECTHORSEBATTERYSTAPLEXYZZY` are both 30 all-alpha characters and
+# no length bound can separate them. Segments are alpha-only on purpose:
+# `abc-123-def-456-ghi` keeps its digits and stays redactable.
+_KEBAB_NAME_RE = re.compile(r"[a-z]+(?:-[a-z]+)+")
 
 # Rejected outright: the value is a shell expansion, so the secret is not
 # in the command string at all - which is the form we want people using.
@@ -165,8 +193,21 @@ _LONG_VALUE_LEN = 24
 _EXPANSION_MARKERS = ("$(", "${", "`")
 
 # The markers this module emits, so a second pass can recognise its own
-# output and leave it alone. Issue #89.
-_MARKER_RE = re.compile(r"\[REDACTED:[a-z0-9-]+\]")
+# output and leave it alone (issue #89). Built from the pattern tables
+# rather than hand-listed, so it cannot drift when a kind is added.
+#
+# Pinned to the exact kind names on purpose: a permissive `[a-z0-9-]+`
+# is also the shape of a lowercase-hex API key, so
+# `TOKEN=[REDACTED:9f3c1a7e42b8d05e6c1f9a7b3d2e8c40]` read as a marker
+# and the value survived. Paste a redacted line back into a command and
+# the next secret you put there would be invisible.
+_MARKER_RE = re.compile(
+    r"\[REDACTED:(?:{})\]".format(
+        "|".join(sorted({kind for kind, _, _ in _STRUCTURED_PATTERNS}
+                        | {kind for kind, _, _ in _ASSIGNMENT_PATTERNS},
+                        key=len, reverse=True))
+    )
+)
 
 
 def _looks_like_literal_secret(value):
@@ -184,12 +225,42 @@ def _looks_like_literal_secret(value):
         retval = False
     elif len(value) < _MIN_VALUE_LEN:
         retval = False
+    elif _looks_like_hex_blob(value):
+        retval = True
+    elif _KEBAB_NAME_RE.fullmatch(value):
+        retval = False
     elif len(value) < _LONG_VALUE_LEN and not (
             any(c.isdigit() for c in value)
             and any(c.isalpha() for c in value)):
         # Short *and* all-alphabetic or all-numeric reads as a name or an
         # id, not a key. Long values skip this test - see _LONG_VALUE_LEN.
         retval = False
+    return retval
+
+
+def _has_pem_terminator(text):
+    """True when an `-----END` appears *after* an `-----BEGIN`.
+
+    Testing mere presence was not enough: a single `-----END` anywhere -
+    including before every BEGIN - disarmed the guard and restored the
+    full quadratic cost (8.3s on a 4MB input). Deliberately weaker than
+    the pattern itself, which needs `-----END ` with a trailing space, so
+    this can only over-scan and never skip a real key. Issue #92.
+    """
+    begin = text.find("-----BEGIN")
+    retval = begin != -1 and text.find("-----END", begin) != -1
+    return retval
+
+
+def _looks_like_hex_blob(value):
+    """True for a long all-hex string, which is a key and never a name.
+
+    Kept separate from the length bound because the two answer different
+    questions: length asks "too long to be a resource name", this asks
+    "drawn from an alphabet no human names things in".
+    """
+    retval = (len(value) >= _MIN_HEX_LEN
+              and all(c in "0123456789abcdefABCDEF" for c in value))
     return retval
 
 
@@ -229,12 +300,13 @@ def find_secrets(text):
 
     spans = []
     for kind, pattern, group in _STRUCTURED_PATTERNS:
-        if kind == "private-key" and "-----END" not in text:
+        if kind == "private-key" and not _has_pem_terminator(text):
             # The `.*?` with re.S is O(n^2) in unterminated BEGIN markers
-            # (800 of them across 4MB measured at 7.7s). No END means no
-            # match is possible, so skip the scan entirely. Bounding the
-            # body length instead would be worse: an oversized key would
-            # stop matching and leak in full. Issue #92.
+            # (800 of them across 4MB measured at 7.7s). Without a
+            # terminator *after* a BEGIN no match is possible, so skip
+            # the scan entirely. Bounding the body length instead would
+            # be worse: an oversized key would stop matching and leak in
+            # full. Issue #92.
             continue
         for match in pattern.finditer(text):
             if not _is_marker(match.start(group), match.end(group)):
@@ -243,8 +315,20 @@ def find_secrets(text):
         for match in pattern.finditer(text):
             if _is_marker(match.start(group), match.end(group)):
                 continue
-            if _looks_like_literal_secret(match.group(group)):
-                spans.append((match.start(group), match.end(group), kind))
+            value = match.group(group)
+            if _MARKER_RE.search(value):
+                # The capture swallowed an existing marker plus context -
+                # e.g. `https://u:[REDACTED:url-credentials]@h/` caught by
+                # the bare flag-value pattern. Judge only what is left
+                # once the markers are removed: if that residue is not
+                # itself secret-shaped, the sensitive part is already
+                # handled and re-redacting only destabilises the output.
+                # This is what makes `redact` idempotent. Issue #89.
+                if not _looks_like_literal_secret(_MARKER_RE.sub("", value)):
+                    continue
+            elif not _looks_like_literal_secret(value):
+                continue
+            spans.append((match.start(group), match.end(group), kind))
 
     # Longest-first at a given start so a header-value span that contains
     # a `ghp_...` span swallows it rather than producing two records.

--- a/hooks/yolt_analyzer.py
+++ b/hooks/yolt_analyzer.py
@@ -18,13 +18,28 @@ from pathlib import Path
 
 # Both hook entry points run this file as a script, so its directory is
 # already sys.path[0]; the guard is for callers that import the module by
-# path. Deliberately not wrapped in a try/except: if the redactor cannot
-# be loaded, failing loudly beats silently writing credentials to disk.
+# path.
 _HOOKS_DIR = str(Path(__file__).resolve().parent)
 if _HOOKS_DIR not in sys.path:
     sys.path.insert(0, _HOOKS_DIR)
 
-from secret_redact import find_secrets, redact  # noqa: E402
+# This import used to be unguarded, on the theory that failing loudly
+# beats silently writing credentials to disk. Measured, it did neither:
+# ModuleNotFoundError exits 1, a non-zero non-2 exit from PreToolUse is
+# *non-blocking*, and hook stderr is not surfaced - so every Bash command
+# ran unclassified, nothing was logged, and nobody was told. Strictly
+# worse than the tree-sitter path, which degrades gracefully.
+#
+# Guarded now. The degradation keeps the two things that matter:
+# classification still happens (it never needed the redactor), and no
+# command text is written anywhere. See issue #93.
+try:
+    from secret_redact import find_secrets, redact  # noqa: E402
+    REDACTOR_IMPORT_ERROR = None
+except ImportError as exc:  # pragma: no cover - exercised via subprocess
+    find_secrets = None
+    redact = None
+    REDACTOR_IMPORT_ERROR = str(exc)
 
 
 def load_rules(rules_dir, user_overrides_path=None):
@@ -929,6 +944,10 @@ def format_secret_advisory(command):
     setting = os.environ.get("YOLT_SECRET_WARN", "").strip().lower()
     if setting in SECRET_WARN_OFF_VALUES:
         return retval
+    if find_secrets is None:
+        # Redactor unavailable (#93). No advisory rather than a wrong one;
+        # the withheld-command log record is what surfaces the problem.
+        return retval
     try:
         spans = find_secrets(command)
     except Exception:
@@ -955,6 +974,28 @@ def attach_secret_advisory(response, advisory):
         response["systemMessage"] = advisory
         response["hookSpecificOutput"]["additionalContext"] = advisory
     return response
+
+
+WITHHELD = "[WITHHELD:redactor-unavailable]"
+
+
+def _redact_or_withhold(text):
+    """Redact `text`, or withhold it entirely if the redactor is missing.
+
+    The fallback is never "write it raw". A log record that says
+    `[WITHHELD:redactor-unavailable]` is diagnosable and carries no
+    credential; the alternative would quietly reintroduce the exact bug
+    issue #84 closed. The record still records the decision, so the log
+    remains useful for everything except the command text. See #93.
+    """
+    if not text:
+        retval = text
+        return retval
+    if redact is None:
+        retval = WITHHELD
+        return retval
+    retval = redact(text)
+    return retval
 
 
 DEFAULT_LOG_PATH = Path.home() / ".claude" / "yolt.log"
@@ -1053,11 +1094,13 @@ def _log_hook_decision(command, decision, reason,
         record = {
             "ts": datetime.datetime.now(datetime.timezone.utc).isoformat(),
             "decision": decision,
-            "reason": redact(reason),
-            "command": redact(command)[:500] if command else "",
+            "reason": _redact_or_withhold(reason),
+            "command": _redact_or_withhold(command)[:500] if command else "",
             "permission_mode": permission_mode,
             "agent_id": agent_id,
         }
+        if REDACTOR_IMPORT_ERROR:
+            record["redactor_error"] = REDACTOR_IMPORT_ERROR
         with open(log_path, "a") as f:
             f.write(json.dumps(record) + "\n")
     except Exception:
@@ -1106,8 +1149,10 @@ def _log_ran_command(command):
         _maybe_rotate_log(log_path, _resolve_log_max_bytes())
         record = {
             "ts": datetime.datetime.now(datetime.timezone.utc).isoformat(),
-            "command": redact(command)[:500] if command else "",
+            "command": _redact_or_withhold(command)[:500] if command else "",
         }
+        if REDACTOR_IMPORT_ERROR:
+            record["redactor_error"] = REDACTOR_IMPORT_ERROR
         with open(log_path, "a") as f:
             f.write(json.dumps(record) + "\n")
     except Exception:

--- a/tests/test_redactor_unavailable.py
+++ b/tests/test_redactor_unavailable.py
@@ -1,0 +1,87 @@
+"""The hook must survive a missing redactor (issue #93).
+
+The import used to be unguarded, on the theory that failing loudly beats
+silently writing credentials. Measured, it did neither: ModuleNotFoundError
+exits 1, a non-zero non-2 exit from PreToolUse is non-blocking, and hook
+stderr is not surfaced -- so every Bash command ran unclassified, nothing
+was logged, and nobody was told.
+
+Runs with stdlib unittest only:
+
+    python3 -m unittest discover -v tests
+"""
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+FAKE_GH_TOKEN = "ghp_" + "A1b2C3d4E5f6G7h8I9j0" * 2
+
+
+class RedactorUnavailableTests(unittest.TestCase):
+
+    def run_without_redactor(self, command):
+        """Fire the hook against a tree with secret_redact.py removed."""
+        with tempfile.TemporaryDirectory() as tmp:
+            hooks_dir = Path(tmp) / "hooks"
+            hooks_dir.mkdir()
+            for name in os.listdir(REPO_ROOT / "hooks"):
+                if name.endswith(".py") and name != "secret_redact.py":
+                    shutil.copy(REPO_ROOT / "hooks" / name, hooks_dir)
+            shutil.copytree(REPO_ROOT / "rules", Path(tmp) / "rules")
+
+            log_path = Path(tmp) / "yolt.log"
+            env = dict(os.environ)
+            env["YOLT_LOG_FILE"] = str(log_path)
+            env["YOLT_RAN_LOG_FILE"] = ""
+            env.pop("PYTHONPATH", None)
+
+            payload = {
+                "tool_name": "Bash",
+                "tool_input": {"command": command},
+                "permission_mode": "default",
+            }
+            proc = subprocess.run(
+                [sys.executable, str(hooks_dir / "yolt_analyzer.py"), "--hook"],
+                input=json.dumps(payload), capture_output=True, text=True,
+                env=env, timeout=60,
+            )
+            written = log_path.read_text() if log_path.exists() else ""
+            return proc, written
+
+    def test_hook_survives_and_still_classifies(self):
+        proc, written = self.run_without_redactor(
+            "curl -H 'Authorization: Bearer {}' https://x".format(
+                FAKE_GH_TOKEN))
+        self.assertEqual(proc.returncode, 0,
+                         "hook died: {}".format(proc.stderr[:400]))
+        # Classification never needed the redactor, so it must survive.
+        self.assertIn("permissionDecision", proc.stdout)
+
+    def test_command_text_is_withheld_not_written_raw(self):
+        proc, written = self.run_without_redactor(
+            "curl -H 'Authorization: Bearer {}' https://x".format(
+                FAKE_GH_TOKEN))
+        self.assertTrue(written, "nothing logged at all")
+        self.assertNotIn(FAKE_GH_TOKEN, written)
+        record = json.loads(written.strip().splitlines()[-1])
+        self.assertEqual(record["command"], "[WITHHELD:redactor-unavailable]")
+        # The failure has to be visible somewhere, since hook stderr is not.
+        self.assertIn("redactor_error", record)
+
+    def test_decision_is_still_recorded(self):
+        """The log stays useful for everything except the command text."""
+        proc, written = self.run_without_redactor("ls /tmp")
+        record = json.loads(written.strip().splitlines()[-1])
+        self.assertIn(record["decision"], ("safe", "unsafe", "unknown"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_secret_redact.py
+++ b/tests/test_secret_redact.py
@@ -258,6 +258,116 @@ class OverlapClippingTests(unittest.TestCase):
         self.assertEqual(len(find_secrets(command)), 1)
 
 
+class ValueGuardTests(unittest.TestCase):
+    """Issue #92: the guard's character allow-list ran backwards.
+
+    It excluded `! @ # , & { }` and space, so the more punctuation a
+    password had - the more entropy - the likelier it was to be dismissed
+    as "not secret-shaped". Now a deny-list: only shell expansions are
+    rejected outright.
+    """
+
+    def assert_redacted(self, command):
+        self.assertNotEqual(redact(command), command,
+                            "credential survived: {}".format(command))
+
+    def test_passwords_with_punctuation(self):
+        for value in ("Tr0ub4dor&3!SuperLongPassword",
+                      "MyP@ssw0rd!VeryLongIndeed2024",
+                      "Str0ngP#ssword!LongEnough2024",
+                      "{9f3c1a7e42b8d05e6c1f9a7b3d2e8c40}",
+                      "user,pass,SuperSecretTokenValue123"):
+            self.assert_redacted(
+                'deploy --token "{}" --env prod'.format(value))
+
+    def test_quoted_multiword_passphrase(self):
+        # An unquoted capture stopped at the first space, redacting
+        # `correct` and leaving the rest of the passphrase in cleartext.
+        out = redact('deploy --password "correct horse battery staple"')
+        self.assertNotIn("horse battery staple", out)
+
+    def test_long_values_without_a_digit(self):
+        # _LONG_VALUE_LEN lowered 32 -> 24; both of these sat in the gap.
+        self.assert_redacted("deploy --token deadbeefcafebabedeadbeef")
+        self.assert_redacted("deploy --token CORRECTHORSEBATTERYSTAPLEXYZZY")
+
+    def test_shell_expansions_still_rejected(self):
+        for command in ("deploy --token $DEPLOY_TOKEN_FOR_PRODUCTION",
+                        "deploy --token ${DEPLOY_TOKEN_FOR_PRODUCTION}",
+                        'deploy --token "$(fetch-secret --name prod-token)"'):
+            self.assertEqual(redact(command), command, command)
+
+
+class VendorPrefixTests(unittest.TestCase):
+    """Issue #92: `sk-` was hyphen-only, and several common vendor
+    prefixes plus bare JWTs had no pattern at all."""
+
+    def assert_redacted(self, value):
+        command = "deploy {}".format(value)
+        self.assertNotIn(value, redact(command), value)
+
+    def test_stripe_underscore_separator(self):
+        self.assert_redacted("sk_live_51H8vXyZaBcDeFgHiJkLmNoPqRsTu")
+        self.assert_redacted("rk_live_51H8vXyZaBcDeFgHiJkLmNoPqRsTu")
+
+    def test_other_vendor_prefixes(self):
+        self.assert_redacted("dckr_pat_AbCdEfGhIjKlMnOpQrStUvWxYz01")
+        self.assert_redacted("npm_AbCdEfGhIjKlMnOpQrStUvWxYz012345")
+        self.assert_redacted("hf_AbCdEfGhIjKlMnOpQrStUvWxYzAbCdEfGh")
+
+    def test_google_api_key(self):
+        self.assert_redacted("AIzaSyD-1234567890abcdefghijklmnopqrs")
+
+    def test_bare_jwt(self):
+        # Previously caught only behind an Authorization header.
+        self.assert_redacted(
+            "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0."
+            "abcdefghijklmnopqrstuvwxyz123456")
+
+    def test_hyphen_form_still_works(self):
+        self.assert_redacted("sk-ant-api03-aB3dE6gH9jK2mN5pQ8sT1vW4")
+
+
+class IdempotenceTests(unittest.TestCase):
+    """Issue #89: patterns matched inside the module's own markers, so a
+    second pass rewrote its own output. That made "re-scan and expect
+    zero hits" useless for verifying a retro-scrub of existing logs."""
+
+    PROBES = [
+        'curl -H "Authorization: Bearer {}" https://x'.format(FAKE_GH_TOKEN),
+        "psql postgres://u:hunter2ismypassword@h/db",
+        "TOKEN=9f3c1a7e42b8d05e6c1f9a7b3d2e8c40 ./x",
+        "curl -u admin:s3cr3tP4ssw0rdVeryLong123 https://x",
+        "deploy sk_live_51H8vXyZaBcDeFgHiJkLmNoPqRsTu",
+        'deploy --token "Tr0ub4dor&3!SuperLongPassword" --env prod',
+        ("ssh-add --password abc123def456ghi789"
+         "-----BEGIN RSA PRIVATE KEY-----\nB\n"
+         "-----END RSA PRIVATE KEY-----"),
+    ]
+
+    def test_redact_is_idempotent(self):
+        for probe in self.PROBES:
+            once = redact(probe)
+            self.assertEqual(once, redact(once), probe)
+            self.assertEqual(once, redact(redact(once)), probe)
+
+    def test_rescan_of_redacted_text_is_clean(self):
+        """The property that makes verifying a scrub possible at all."""
+        for probe in self.PROBES:
+            once = redact(probe)
+            leftovers = [
+                (s, e, k) for s, e, k in find_secrets(once)
+                if not once[s:e].startswith("[REDACTED:")
+            ]
+            self.assertEqual(leftovers, [], probe)
+
+    def test_a_real_secret_beside_a_marker_is_still_caught(self):
+        # The skip is character-level, not "overlaps a marker", so
+        # adjacency must not create a blind spot.
+        text = "TOKEN=[REDACTED:api-key]{}".format(FAKE_GH_TOKEN)
+        self.assertNotIn(FAKE_GH_TOKEN, redact(text))
+
+
 class FalsePositiveCorpusTests(unittest.TestCase):
     """Ordinary commands that must survive redaction byte-for-byte.
 
@@ -284,6 +394,22 @@ class FalsePositiveCorpusTests(unittest.TestCase):
         "aws configure set region us-east-1",
         "helm upgrade myapp ./chart --set image.tag=v1.2.3-rc4",
         'psql -h db.internal -U appuser -d production -c "select 1"',
+        # Added when the guard moved from allow-list to deny-list (#92):
+        # dropping the character class is the change most likely to start
+        # matching ordinary arguments, so the corpus grew with it.
+        "echo TOKENIZER=simple >> config.env",
+        "make TOKEN_LIMIT=4096 build",
+        "git commit -m 'fix: token=abc parsing in the lexer'",
+        "curl -u ci-bot:$GITHUB_TOKEN https://api.github.com",
+        "deploy --secret-key-file /etc/app/config/production.key.json",
+        "vault read secret/data/app-config-production-v2",
+        "kubectl describe pod my-app-deployment-7d4b8c9f5-x2m9k",
+        "npm install --save-dev @types/node-fetch",
+        "gh pr view 94 --repo voitta-ai/voitta-yolt --json body",
+        "docker build -t registry.example.com/team/app:sha-abc1234 .",
+        "aws ecs update-service --service my-service --force-new-deployment",
+        "./deploy --token ${DEPLOY_TOKEN}",
+        "grep -rn 'password' src/ --include='*.py'",
     ]
 
     def test_ordinary_commands_untouched(self):
@@ -308,6 +434,23 @@ class PerformanceTests(unittest.TestCase):
             elapsed = time.perf_counter() - start
             self.assertLess(elapsed, 1.0,
                             "find_secrets took {:.2f}s".format(elapsed))
+
+    def test_many_unterminated_pem_headers(self):
+        """Issue #92: the `.*?` with re.S was O(n^2) in unterminated
+        BEGIN markers - 800 of them across 4MB measured at 7.7s. No END
+        in the text means no match is possible, so the scan is skipped."""
+        import time
+        command = "echo '-----BEGIN RSA PRIVATE KEY-----" * 800 + "A" * 5000
+        start = time.perf_counter()
+        find_secrets(command)
+        self.assertLess(time.perf_counter() - start, 1.0)
+
+    def test_a_real_pem_is_still_matched(self):
+        """The short-circuit must not cost a genuine key."""
+        command = ("echo '-----BEGIN RSA PRIVATE KEY-----\n"
+                   "BODYSECRETMATERIAL\n"
+                   "-----END RSA PRIVATE KEY-----'")
+        self.assertNotIn("BODYSECRETMATERIAL", redact(command))
 
 
 class FindSecretsTests(unittest.TestCase):

--- a/tests/test_secret_redact.py
+++ b/tests/test_secret_redact.py
@@ -297,6 +297,27 @@ class ValueGuardTests(unittest.TestCase):
                         'deploy --token "$(fetch-secret --name prod-token)"'):
             self.assertEqual(redact(command), command, command)
 
+    def test_long_alpha_values_over_redact_by_design(self):
+        """A documented, accepted cost of lowering _LONG_VALUE_LEN to 24.
+
+        Above that length the "must mix letters and digits" test is
+        waived, so an ordinary long word passed to a secret-ish flag is
+        redacted too. There is no cheap way to separate the two cases:
+        `CORRECTHORSEBATTERYSTAPLEXYZZY` (a passphrase we must catch) and
+        `authenticationprovidername` (a name we would rather keep) have
+        identical length class and identical alphabet diversity — a long
+        all-alpha passphrase and a long all-alpha word are structurally
+        the same string.
+
+        Erring this way is the intended direction: a false positive costs
+        one unreadable value in a debug log, a false negative costs a
+        credential on disk forever. Asserted so the behaviour is a
+        decision on record rather than a surprise.
+        """
+        for command in ("deploy --secret ThisIsAVeryLongDescription",
+                        "app --auth authenticationprovidername"):
+            self.assertIn("[REDACTED:", redact(command), command)
+
 
 class VendorPrefixTests(unittest.TestCase):
     """Issue #92: `sk-` was hyphen-only, and several common vendor

--- a/tests/test_secret_redact.py
+++ b/tests/test_secret_redact.py
@@ -297,26 +297,38 @@ class ValueGuardTests(unittest.TestCase):
                         'deploy --token "$(fetch-secret --name prod-token)"'):
             self.assertEqual(redact(command), command, command)
 
-    def test_long_alpha_values_over_redact_by_design(self):
-        """A documented, accepted cost of lowering _LONG_VALUE_LEN to 24.
+    def test_long_ordinary_words_are_not_redacted(self):
+        """Length alone is the wrong discriminator; alphabet is the right one.
 
-        Above that length the "must mix letters and digits" test is
-        waived, so an ordinary long word passed to a secret-ish flag is
-        redacted too. There is no cheap way to separate the two cases:
-        `CORRECTHORSEBATTERYSTAPLEXYZZY` (a passphrase we must catch) and
-        `authenticationprovidername` (a name we would rather keep) have
-        identical length class and identical alphabet diversity — a long
-        all-alpha passphrase and a long all-alpha word are structurally
-        the same string.
+        An earlier round set `_LONG_VALUE_LEN` to 24 to catch
+        `deadbeefcafebabedeadbeef` (24 hex, no digits) and concluded that
+        the resulting over-redaction of ordinary long words was
+        unavoidable, since a passphrase and an English word are
+        structurally the same string.
 
-        Erring this way is the intended direction: a false positive costs
-        one unreadable value in a debug log, a false negative costs a
-        credential on disk forever. Asserted so the behaviour is a
-        decision on record rather than a surprise.
+        They are — but that was the wrong axis. 24 is exactly the band
+        where hyphenated resource names live. Raising the bound to 28 and
+        adding a separate all-hex rule separates the cases cleanly,
+        because the hex value was never about *length*: it was about
+        being drawn from an alphabet nobody names things in.
         """
         for command in ("deploy --secret ThisIsAVeryLongDescription",
-                        "app --auth authenticationprovidername"):
-            self.assertIn("[REDACTED:", redact(command), command)
+                        "app --auth-token authenticationprovidername",
+                        "deploy --token production-deployment-approval"):
+            self.assertEqual(redact(command), command, command)
+
+    def test_hex_blobs_are_caught_regardless_of_length_band(self):
+        for value in ("deadbeefcafebabedeadbeef",
+                      "9f3c1a7e42b8d05e6c1f9a7b3d2e8c40",
+                      "ABCDEF0123456789ABCDEF01"):
+            command = "deploy --token {}".format(value)
+            self.assertNotIn(value, redact(command), value)
+
+    def test_long_passphrases_still_caught(self):
+        for value in ("CORRECTHORSEBATTERYSTAPLEXYZZY",
+                      "abcdefghijklmnopqrstuvwxyzABCDEF"):
+            command = "deploy --token {}".format(value)
+            self.assertNotIn(value, redact(command), value)
 
 
 class VendorPrefixTests(unittest.TestCase):
@@ -332,8 +344,12 @@ class VendorPrefixTests(unittest.TestCase):
         self.assert_redacted("rk_live_51H8vXyZaBcDeFgHiJkLmNoPqRsTu")
 
     def test_other_vendor_prefixes(self):
-        self.assert_redacted("dckr_pat_AbCdEfGhIjKlMnOpQrStUvWxYz01")
-        self.assert_redacted("npm_AbCdEfGhIjKlMnOpQrStUvWxYz012345")
+        # Suffix lengths are the real formats: npm 36, HuggingFace 34,
+        # Docker 24+. The earlier fixtures were short of them, which is
+        # how a `{16,}` pattern loose enough to match `npm_config_*`
+        # looked correct.
+        self.assert_redacted("dckr_pat_AbCdEfGhIjKlMnOpQrStUvWx")
+        self.assert_redacted("npm_AbCdEfGhIjKlMnOpQrStUvWxYz0123456789")
         self.assert_redacted("hf_AbCdEfGhIjKlMnOpQrStUvWxYzAbCdEfGh")
 
     def test_google_api_key(self):
@@ -387,6 +403,97 @@ class IdempotenceTests(unittest.TestCase):
         # adjacency must not create a blind spot.
         text = "TOKEN=[REDACTED:api-key]{}".format(FAKE_GH_TOKEN)
         self.assertNotIn(FAKE_GH_TOKEN, redact(text))
+
+    def test_span_that_swallows_a_marker_does_not_re_redact(self):
+        """The case that kept `redact` non-idempotent.
+
+        A bare `flag-value` capture swallows an existing marker plus its
+        surrounding structure, and the whole span is not marker-covered,
+        so it was redacted again on the second pass. Now the residue is
+        judged with the markers removed: if what is left is not itself
+        secret-shaped, the sensitive part is already handled.
+        """
+        for command in ("--token https://u:p@h/",
+                        "SECRET=https://u:p@h/",
+                        "curl -u bob:https://a:b@c/"):
+            once = redact(command)
+            self.assertEqual(once, redact(once), command)
+
+    def test_a_value_wrapped_in_marker_syntax_is_still_redacted(self):
+        """`[a-z0-9-]+` is also the shape of a lowercase-hex key, so a
+        permissive marker pattern let a wrapped value pass as its own
+        marker. The kind list is a closed enum; the pattern pins it."""
+        for command in (
+            "TOKEN=[REDACTED:9f3c1a7e42b8d05e6c1f9a7b3d2e8c40] ./run.sh",
+            "deploy --token [REDACTED:deadbeefcafebabedeadbeef]",
+        ):
+            self.assertNotEqual(redact(command), command, command)
+
+    def test_marker_pattern_tracks_the_kind_tables(self):
+        """Built from the tables, so adding a kind cannot silently break
+        idempotence."""
+        import secret_redact
+        kinds = ({k for k, _, _ in secret_redact._STRUCTURED_PATTERNS}
+                 | {k for k, _, _ in secret_redact._ASSIGNMENT_PATTERNS})
+        for kind in kinds:
+            self.assertTrue(
+                secret_redact._MARKER_RE.fullmatch(
+                    "[REDACTED:{}]".format(kind)),
+                "marker pattern misses kind {}".format(kind))
+
+
+class VendorPrefixPrecisionTests(unittest.TestCase):
+    """The vendor prefixes are *structured* patterns, so they bypass the
+    value guard entirely - there is no length or entropy gate behind
+    them. A loose prefix therefore has no safety net, and `npm_` with a
+    permissive suffix matched npm's own environment variables."""
+
+    def test_npm_environment_variables_are_not_tokens(self):
+        for command in (
+            "env | grep npm_config_registry_https_proxy",
+            "echo $npm_package_dependencies_typescript",
+            "export npm_lifecycle_script_prepublish_only=1",
+        ):
+            self.assertEqual(redact(command), command, command)
+
+    def test_huggingface_cache_paths_are_not_tokens(self):
+        command = "aws s3 ls s3://my-bucket/hf_datasets_cache_directory/"
+        self.assertEqual(redact(command), command)
+
+    def test_underscore_form_requires_the_stripe_segment(self):
+        # `rk_`/`sk_` without live/test is an ordinary identifier.
+        self.assertEqual(
+            redact("docker build -t rk_analytics_pipeline_worker:latest ."),
+            "docker build -t rk_analytics_pipeline_worker:latest .")
+        self.assertNotEqual(
+            redact("deploy sk_live_51H8vXyZaBcDeFgHiJkLmNoPqRsTu"),
+            "deploy sk_live_51H8vXyZaBcDeFgHiJkLmNoPqRsTu")
+
+    def test_real_vendor_tokens_at_their_real_lengths(self):
+        for value in ("npm_" + "a" * 36, "hf_" + "b" * 34,
+                      "dckr_pat_" + "c" * 24):
+            command = "deploy {}".format(value)
+            self.assertNotIn(value, redact(command), value)
+
+
+class AuthFlagTests(unittest.TestCase):
+    """`--auth <mode>` is the common shape and almost never carries a
+    literal, so a bare `auth` in the flag list produced more false
+    positives than every other flag word combined."""
+
+    def test_auth_mode_values_are_left_alone(self):
+        for command in (
+            "helm install app ./chart --auth kubernetes-service-account",
+            "kafka --auth SASL_SSL,SCRAM-SHA-512,PLAINTEXT",
+            "deploy --auth serviceaccount-workload-identity",
+        ):
+            self.assertEqual(redact(command), command, command)
+
+    def test_auth_token_still_matches(self):
+        for flag in ("--auth-token", "--authtoken", "--auth_token"):
+            command = "deploy {} 9f3c1a7e42b8d05e6c1f9a7b3d2e8c40".format(flag)
+            self.assertNotIn("9f3c1a7e42b8d05e6c1f9a7b3d2e8c40",
+                             redact(command), flag)
 
 
 class FalsePositiveCorpusTests(unittest.TestCase):
@@ -458,13 +565,26 @@ class PerformanceTests(unittest.TestCase):
 
     def test_many_unterminated_pem_headers(self):
         """Issue #92: the `.*?` with re.S was O(n^2) in unterminated
-        BEGIN markers - 800 of them across 4MB measured at 7.7s. No END
-        in the text means no match is possible, so the scan is skipped."""
+        BEGIN markers - 800 of them across 4MB measured at 7.7s. Without
+        a terminator after a BEGIN no match is possible, so it's skipped."""
         import time
         command = "echo '-----BEGIN RSA PRIVATE KEY-----" * 800 + "A" * 5000
         start = time.perf_counter()
         find_secrets(command)
         self.assertLess(time.perf_counter() - start, 1.0)
+
+    def test_a_leading_end_marker_does_not_disarm_the_guard(self):
+        """Testing for `-----END` anywhere was the wrong question: a
+        single one *before* every BEGIN restored the full quadratic cost
+        (8.3s on 4MB). The terminator has to follow a BEGIN."""
+        import time
+        command = ("-----END RSA PRIVATE KEY----- "
+                   + ("-----BEGIN RSA PRIVATE KEY-----" + "M" * 5000) * 400)
+        start = time.perf_counter()
+        find_secrets(command)
+        elapsed = time.perf_counter() - start
+        self.assertLess(elapsed, 2.0,
+                        "quadratic path reachable: {:.1f}s".format(elapsed))
 
     def test_a_real_pem_is_still_matched(self):
         """The short-circuit must not cost a genuine key."""


### PR DESCRIPTION
Closes #89. Closes #92. Closes #93. Declares **v1.0.0**.

## #92 — the value guard ran backwards

It required `[A-Za-z0-9_\-.+/=~:%]+`, excluding `! @ # , & { }` and
space. So the more punctuation a password carried — the more entropy —
the likelier it was to be dismissed as "not secret-shaped":
`Tr0ub4dor&3!SuperLongPassword` reached disk while
`some-resource-name` did not.

Now a **deny**-list: reject shell expansions and values too short or too
monotonous, and say nothing about which characters are allowed.
`_LONG_VALUE_LEN` drops 32 → 24, closing `deadbeefcafebabedeadbeef` and
`CORRECTHORSEBATTERYSTAPLE`.

Quoted values are captured whole. `--password "correct horse battery
staple"` previously captured `correct` and left the rest in cleartext,
because the capture stopped at the first space.

Missing vendor prefixes added: `sk_`/`rk_` (Stripe — `sk-` was
hyphen-only), `dckr_pat_`, `npm_`, `hf_`, `glc_`, `shpat_`, `AIza`, and
bare JWTs, previously caught only behind an `Authorization` header.

The PEM `.*?` with `re.S` was O(n²) in *unterminated* BEGIN markers —
800 across 4 MB measured at 7.7 s. Now short-circuited when the text
contains no `-----END`, since no match is possible. Bounding the body
length instead would have been worse: an oversized key would stop
matching and leak in full. **7.7 s → 10 ms**, real keys unaffected
(verified across `RSA`, plain, `EC` and `OPENSSH` END forms).

## #89 — `redact()` was not idempotent

Patterns matched inside the `[REDACTED:…]` markers it emits, so a second
pass rewrote its own output. That made "re-scan and expect zero hits"
useless for verifying a cleanup of pre-redaction log files — exactly the
operation #84 forces on everyone.

Marker ranges are now skipped using **character-level coverage** rather
than "contained in one marker": clipping (from #90) can produce two
adjacent markers that a `--password` capture swallows as a single value.
A real secret sitting against a marker is still caught.

## #93 — the unguarded import claimed to fail loudly and did neither

`ModuleNotFoundError` exits 1; a non-zero non-2 exit from `PreToolUse`
is non-blocking and hook stderr is not surfaced. So every Bash command
ran unclassified, nothing was logged, and nobody was told — strictly
worse than the tree-sitter path, which degrades gracefully.

Guarded now, preserving the two things that matter: classification still
happens (it never needed the redactor), and no command text is written
anywhere. The record carries `[WITHHELD:redactor-unavailable]` and a
`redactor_error` field, so the failure is visible without a credential
riding along. Verified end to end against a tree with
`secret_redact.py` deleted: exit 0, decision still emitted, nothing
leaked.

## Adversarial pass on this diff

- **False positives from dropping the character class** — the riskiest
  edit here. 32-command corpus: 30 clean. The two hits are
  `--secret ThisIsAVeryLongDescription` and
  `--auth authenticationprovidername`.
- I tried to fix them and **failed, informatively**: waiving the entropy
  test only for low-alphabet-diversity values does not separate the
  cases. `CORRECTHORSEBATTERYSTAPLEXYZZY` (must catch) and
  `authenticationprovidername` (would rather keep) have identical
  diversity, and a base62 token scores higher than both. A long
  all-alpha passphrase and a long all-alpha word are the same string
  structurally. Accepted as over-redaction in the documented direction,
  asserted in tests and stated in the README so it is a decision on
  record rather than a surprise.
- **Quoting edge cases** — apostrophe inside a double-quoted value,
  nested quotes, empty `""`/`''`, unclosed quote, a value containing a
  literal `[REDACTED:` marker: no exceptions, no empty or inverted
  spans, no residual overlap.
- **Idempotence** — 0 unstable out of 3,000 generated multi-fragment
  inputs, including ones seeded with existing markers.
- **`_MARKER_RE` covers every kind actually emitted**, checked against
  the live pattern tables rather than a hand-list.
- **Perf** — 374 ms on a 1 MB command, same order as before the change;
  0.01 ms on a normal one.

## Version

`0.5.0` → **`1.0.0`**. Per CLAUDE.md a major bump declares the
rules-file format stable: `rules/rules.json`, `rules/shell.json` and
`~/.claude/yolt/*.json` keys become a compatibility surface, and
renaming or removing a documented key is a breaking change from here on.

654 tests, green. The false-positive corpus grew to 30 commands with
this change, since dropping the character class is the edit most likely
to start matching ordinary arguments.


---

## Second review round — two HIGHs that invalidated the v1.0.0 claim

Both found by adversarial review, both verified before fixing.

**1. The PEM O(n²) short-circuit was bypassable with one token.** It
tested for `-----END` *anywhere*, so a single END placed before every
BEGIN disarmed it and restored the full quadratic curve — **8.3 s on a
4 MB input, worse than the 7.7 s the fix was meant to remove.** Now
gated on a terminator that follows a BEGIN: 4 MB drops to 1.4 s. The
test stays deliberately weaker than the pattern (which requires a
trailing space), so it can only over-scan, never skip a real key.

**2. #89 was not actually closed.** The marker skip ignored a span only
when *every* character sat inside a marker, but a span that *contains* a
marker plus surrounding text was still redacted, so pass two collapsed
further:

```
--token https://u:p@h/
-> --token https://u:[REDACTED:url-credentials]@h/
-> --token [REDACTED:flag-value]
```

1.3% of a 40k fuzz corpus was non-idempotent, and "re-scan a scrubbed
log, expect zero hits" — the property this PR's docstring claims — did
not hold. Now the residue is judged with markers removed: if what's left
is not itself secret-shaped, the sensitive part is already handled.
**0 non-idempotent across 20k generated inputs.**

**3. The new vendor prefixes were far too loose** — and being
*structured* patterns, they bypass the value guard entirely, so there
was no safety net behind them. `npm_[A-Za-z0-9_\-]{16,}` matched npm's
own environment variables (`npm_config_*`, `npm_package_*`,
`npm_lifecycle_*`, constant in CI and Node work) and `[sr]k_` matched
`rk_analytics_pipeline_worker`. Worse, these also fire the #85 advisory,
so ordinary `npm`/`env` commands were getting "possible credential on
this command line" — the exact "gets switched off and then protects
nothing" failure the advisory warns about. Pinned to real formats: npm
36, HuggingFace 34, Docker 24+, Stripe requires its `live`/`test`
segment. The existing fixtures were *short of the real lengths*, which
is how a pattern loose enough to match `npm_config_*` looked correct.

**4. Dropped bare `auth` from the flag list.** `--auth <mode>` is the
common shape and produced more false positives than every other flag
word combined. `--auth-token` still matches.

**5. `_MARKER_RE` was `[a-z0-9-]+`** — also the shape of a lowercase-hex
key, so `TOKEN=[REDACTED:9f3c…]` read as a marker and the value
survived. Now built from the pattern tables as a closed enum, so it
cannot drift as kinds are added.

## A claim from the first round, retracted

The first round asserted the long-alpha over-redaction was unfixable,
since a passphrase and an English word are structurally the same string.
That's true, and it was the wrong axis. 24 is exactly the band where
hyphenated resource names live. Raising the bound to 28, adding an
all-hex rule (the hex case was never about *length* — it's about an
alphabet nobody names things in), and rejecting lowercase kebab-case
separates every case cleanly. `production-deployment-approval` and
`CORRECTHORSEBATTERYSTAPLEXYZZY` are both 30 all-alpha characters and
are now correctly split. The test and README paragraph recording it as
accepted damage are replaced.

## Final state

666 tests green on 3.10/3.11/3.12. **Zero** false positives across the
combined corpus, **zero** non-idempotent across 20k fuzz inputs, every
real credential shape still caught, and #93 confirmed clean by review
(with `secret_redact.py` deleted: exit 0, classification still returns a
correct shape-only reason, both logs record
`[WITHHELD:redactor-unavailable]` plus `redactor_error`, token in
neither).
