### PR TITLE
docs: correct the positioning for auto mode; bump to 1.0.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -3,12 +3,12 @@
   "owner": {
     "name": "voitta-ai"
   },
-  "description": "YOLT - You Only Live Twice. Bash safety analyzer for Claude Code.",
+  "description": "YOLT - You Only Live Twice. Deterministic pre-execution guard and credential hygiene for Claude Code.",
   "plugins": [
     {
       "name": "yolt",
       "source": "./",
-      "description": "Static safety analyzer for Bash invocations - auto-allows read-only commands and prompts for mutating ones."
+      "description": "Deterministic pre-execution guard for Bash, plus credential detection and log redaction. Narrowing to deny-only in v2.0.0."
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "yolt",
-  "description": "Static safety analyzer for Bash invocations - auto-allows read-only commands and prompts for mutating ones, plus a Python AST analyzer for python3 / python3 -c / heredoc invocations.",
-  "version": "1.0.0",
+  "description": "Deterministic pre-execution guard for Bash: decomposes compound commands, heredocs and command substitutions with tree-sitter, analyzes inline Python by AST, flags credentials on the command line, and redacts them from its own logs. Narrowing to deny-only in v2.0.0 now that Claude Code auto mode vets tool calls.",
+  "version": "1.0.1",
   "author": {
     "name": "voitta-ai"
   },

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "yolt",
   "version": "0.1.0",
-  "description": "Static safety analyzer for Bash invocations - auto-allows read-only commands and prompts for mutating ones, plus a Python AST analyzer for python3 / python3 -c / heredoc invocations.",
+  "description": "Deterministic pre-execution guard for Bash: decomposes compound commands, heredocs and command substitutions with tree-sitter, analyzes inline Python by AST, flags credentials on the command line, and redacts them from its own logs. Narrowing to deny-only in v2.0.0 now that Claude Code auto mode vets tool calls.",
   "author": {
     "name": "voitta-ai"
   },

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 
 ## Contents
 
+- [Status: Claude Code auto mode changed what this is for](#status-claude-code-auto-mode-changed-what-this-is-for)
 - [Introduction](#introduction)
 - [Example use cases](#example-use-cases)
 - [How it works](#how-it-works)
@@ -35,13 +36,52 @@
 - [Analysis boundaries](#analysis-boundaries)
 - [Design principles](#design-principles)
 
+## Status: Claude Code auto mode changed what this is for
+
+Claude Code now ships **auto mode** as its default permission mode: a
+classifier vets every tool call — not just Bash — and decides whether it
+runs. That is the job the first half of this README describes YOLT doing,
+and the platform now does it for every tool, with no rules to maintain.
+
+**What that means for YOLT.** The auto-allow half is superseded. YOLT is
+being narrowed to two things the platform does not do:
+
+- a **deny-only** guard over a short list of decisions that should not be
+  delegated to a probabilistic classifier — it will withhold approval and
+  never grant it;
+- **credential hygiene** — catching secrets on a command line before they
+  are scattered across transcripts, logs and history, and keeping them out
+  of YOLT's own records. See
+  [Credentials in the command line](#credentials-in-the-command-line-advisory)
+  and [Credential redaction](#credential-redaction).
+
+The realignment is tracked in
+[#102](https://github.com/voitta-ai/voitta-yolt/issues/102) and lands in
+v2.0.0.
+
+> **If you run auto mode today, know this.** This version still returns
+> `allow` for commands it classifies as safe, and Claude Code honors a
+> hook's decision. So on those commands YOLT answers *instead of* auto
+> mode's classifier — the same bypass that `/auto-mode-setup` looks for in
+> your `permissions.allow` and offers to remove, except a hook is invisible
+> to that check. Removing it is the first change in v2.0.0
+> ([#98](https://github.com/voitta-ai/voitta-yolt/issues/98)). Until then,
+> if you want every command vetted by auto mode, uninstall the plugin.
+
+Everything below this section describes the tool as it is **today**, not as
+it will be after v2.0.0.
+
 ## Introduction
 
 A Claude Code hook that statically analyzes script invocations before
 execution, auto-allowing read-only ones and flagging mutating ones for
 review.
 
-YOLT closes two gaps in Claude Code's built-in whitelist matcher:
+> **Superseded framing.** The two gaps below were real when the built-in
+> whitelist matcher was the only thing standing between an agent and a
+> command. Auto mode closes both of them by reading intent rather than
+> matching patterns — there is no whitelist to widen. They are kept here
+> because they explain why the code is shaped the way it is.
 
 1. **Arbitrary-execution wrappers.** Interpreters (`bash`, `python3`,
    `node`, ...) and dual-use CLIs (`gh api`, `curl`, `kubectl`, ...) can't
@@ -51,6 +91,11 @@ YOLT closes two gaps in Claude Code's built-in whitelist matcher:
    (`for`, `while`, `bash -c "..."`, `$(...)`), not the inner commands it
    runs, so loops and command substitutions prompt even when every inner
    command would be whitelisted on its own.
+
+The decomposition those gaps motivated is not going away. Seeing into a
+`bash -c`, a heredoc or a `$(...)` is how a credential hidden inside one
+gets found, so the grammar walker outlives the classification job it was
+built for.
 
 The hook entry is one piece, with two specialized followers:
 
@@ -81,10 +126,16 @@ the same shape and registering it in `rules/shell.json`.
 
 ## Example use cases
 
-- **Stop prompt fatigue on read-only work.** Read-only exploration —
-  `git status`, `ls -la`, `kubectl get pods`, `aws s3 ls` — is auto-allowed
-  and runs without a prompt, while a mutating `git push --force` or
-  `aws s3 rm s3://bucket --recursive` still stops for review.
+> These describe current behavior. The first one is the auto-allow half that
+> v2.0.0 removes — see [Status](#status-claude-code-auto-mode-changed-what-this-is-for).
+> The rest survive, because they are about *seeing into* a command rather
+> than about approving it.
+
+- **Stop prompt fatigue on read-only work.** *(superseded by auto mode.)*
+  Read-only exploration — `git status`, `ls -la`, `kubectl get pods`,
+  `aws s3 ls` — is auto-allowed and runs without a prompt, while a mutating
+  `git push --force` or `aws s3 rm s3://bucket --recursive` still stops for
+  review.
 - **See into wrapper commands the built-in allowlist can't.** A
   `for f in *.log; do rm "$f"; done` loop, a `bash -c "..."`, a piped
   `curl ... | sh`, or a heredoc is decomposed to its inner commands, so the


### PR DESCRIPTION
Closes #101. Straight to master — deliberately **not** part of the `feature/auto-mode-realignment` stack.

## Why this one goes first and alone

Claude Code now ships **auto mode** as its default permission mode: a classifier vets every tool call, not just Bash. That is the job the README's first half describes YOLT doing.

YOLT is public, on this repo's own marketplace, and submitted to the Anthropic community catalog — under the strategy review its retained value *is* proof and distribution. So a false premise in the README is a live cost, not documentation debt.

## Scope: positioning only

The rules documentation is untouched on purpose. It describes behavior that Phase 3 (#100) deletes; rewriting it now means rewriting it twice.

- **New `Status` section** at the top — auto mode is the default, the auto-allow half is superseded, and what YOLT is narrowing to (deny-only guard + credential hygiene), pointing at #102 and #98.
- **It warns users honestly.** This build still returns `allow`, and Claude Code honors a hook's decision — so on those commands YOLT answers *instead of* auto mode's classifier. That is the same bypass `/auto-mode-setup` hunts for in `permissions.allow` and offers to remove, except a hook is invisible to that check. The section says plainly: if you want every command vetted by auto mode, uninstall until v2.0.0.
- **The "two gaps" framing is marked superseded, not deleted.** It explains why the code is shaped the way it is, and the decomposition it motivated outlives the classification job — seeing into a `bash -c`, a heredoc or a `$(...)` is how a credential hidden inside one gets found.
- **"Stop prompt fatigue on read-only work"** marked superseded. The other use cases stand: they are about seeing *into* a command rather than approving it.
- **Manifest descriptions** no longer lead with "auto-allows read-only commands" — catalog-facing text, and the most misleading copy we ship. Updated in all three manifests (`.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, `.codex-plugin/plugin.json`).

## Version

`1.0.0` -> `1.0.1`. Patch per CLAUDE.md — nothing a user could observe at a permission prompt. The stack's own 2.0.0 bump rides the umbrella -> master PR later; no collision.

## Testing

Docs and manifests only; no code paths touched. All three manifests re-validated as JSON, and the `.codex-plugin` keywords array was restored to its original one-line form so the diff stays limited to the description.