### PR TITLE
Phase 1: stop emitting `allow` — YOLT withholds approval, never grants it

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
   - [Releasing (maintainers)](#releasing-maintainers)
   - [Migrating from manual to plugin install](#migrating-from-manual-to-plugin-install)
   - [Manual install (without the plugin system)](#manual-install-without-the-plugin-system)
-- [User whitelist as a secondary upgrade pass](#user-whitelist-as-a-secondary-upgrade-pass)
+- [User whitelist (removed in the auto-mode realignment)](#user-whitelist-removed-in-the-auto-mode-realignment)
 - [Dependencies](#dependencies)
 - [What the grammar classifier handles](#what-the-grammar-classifier-handles)
 - [SQL CLIs](#sql-clis)
@@ -47,8 +47,8 @@ and the platform now does it for every tool, with no rules to maintain.
 being narrowed to two things the platform does not do:
 
 - a **deny-only** guard over a short list of decisions that should not be
-  delegated to a probabilistic classifier — it will withhold approval and
-  never grant it;
+  delegated to a probabilistic classifier — it withholds approval and
+  never grants it;
 - **credential hygiene** — catching secrets on a command line before they
   are scattered across transcripts, logs and history, and keeping them out
   of YOLT's own records. See
@@ -59,23 +59,25 @@ The realignment is tracked in
 [#102](https://github.com/voitta-ai/voitta-yolt/issues/102) and lands in
 v2.0.0.
 
-> **If you run auto mode today, know this.** This version still returns
-> `allow` for commands it classifies as safe, and Claude Code honors a
-> hook's decision. So on those commands YOLT answers *instead of* auto
-> mode's classifier — the same bypass that `/auto-mode-setup` looks for in
-> your `permissions.allow` and offers to remove, except a hook is invisible
-> to that check. Removing it is the first change in v2.0.0
-> ([#98](https://github.com/voitta-ai/voitta-yolt/issues/98)). Until then,
-> if you want every command vetted by auto mode, uninstall the plugin.
+> **The classifier bypass is gone.** Up to v1.0.1 YOLT returned `allow`
+> for commands it classified as safe, and Claude Code honors a hook's
+> decision — so on those commands YOLT answered *instead of* auto mode's
+> classifier. That is the same bypass `/auto-mode-setup` looks for in your
+> `permissions.allow` and offers to remove, except a hook is invisible to
+> that check. As of
+> [#98](https://github.com/voitta-ai/voitta-yolt/issues/98) YOLT never
+> emits `allow` from any path, and no longer reads your settings files at
+> all. Every command it does not object to is vetted by auto mode.
 
-Everything below this section describes the tool as it is **today**, not as
-it will be after v2.0.0.
+The remaining phases shrink the rule set and widen the guard past `Bash`;
+until they land, the rules documentation below still describes the full
+classifier.
 
 ## Introduction
 
 A Claude Code hook that statically analyzes script invocations before
-execution, auto-allowing read-only ones and flagging mutating ones for
-review.
+execution and flags mutating ones for review. It withholds approval; it
+never grants it.
 
 > **Superseded framing.** The two gaps below were real when the built-in
 > whitelist matcher was the only thing standing between an agent and a
@@ -126,14 +128,14 @@ the same shape and registering it in `rules/shell.json`.
 
 ## Example use cases
 
-> These describe current behavior. The first one is the auto-allow half that
-> v2.0.0 removes — see [Status](#status-claude-code-auto-mode-changed-what-this-is-for).
-> The rest survive, because they are about *seeing into* a command rather
-> than about approving it.
+> The first entry is kept for the record only — it describes what YOLT did
+> before [#98](https://github.com/voitta-ai/voitta-yolt/issues/98). The rest
+> are current, because they are about *seeing into* a command rather than
+> about approving it.
 
-- **Stop prompt fatigue on read-only work.** *(superseded by auto mode.)*
-  Read-only exploration — `git status`, `ls -la`, `kubectl get pods`,
-  `aws s3 ls` — is auto-allowed and runs without a prompt, while a mutating
+- **~~Stop prompt fatigue on read-only work.~~** *(removed in #98 — auto
+  mode does this.)* Read-only exploration used to be auto-allowed by YOLT;
+  it now falls through to the host untouched. A mutating
   `git push --force` or `aws s3 rm s3://bucket --recursive` still stops for
   review.
 - **See into wrapper commands the built-in allowlist can't.** A
@@ -143,11 +145,12 @@ the same shape and registering it in `rules/shell.json`.
   rubber-stamped.
 - **Catch destructive SQL inside CLI flags.** `psql -c "DROP TABLE users"`
   or `athena ... "DELETE FROM ..."` is flagged for review, while a
-  `SELECT ...` query is auto-allowed.
+  `SELECT ...` query classifies safe and passes through silently.
 - **Analyze inline Python by AST, not string match.** `python3 -c "..."`
   and `python3 <<EOF` snippets are walked with the stdlib `ast` module: a
-  read-only `json.load` + `print` is auto-allowed, while a snippet that
-  writes a file, calls `os.system`, or spawns a subprocess prompts.
+  read-only `json.load` + `print` classifies safe and passes through
+  silently, while a snippet that writes a file, calls `os.system`, or
+  spawns a subprocess prompts.
 
 ## How it works
 
@@ -192,7 +195,11 @@ the AST. Visitor dispatch:
 After visiting, decisions are aggregated with precedence
 `unsafe > unknown > safe`, and the hook emits one of:
 
-- `safe` → `permissionDecision: allow` with a short reason.
+- `safe` → **nothing.** The hook exits silently and the host decides,
+  exactly as for `unknown`. YOLT withholds approval; it does not grant it
+  ([#98](https://github.com/voitta-ai/voitta-yolt/issues/98)). The `safe`
+  classification is still written to the decision log, where it is what
+  the classifier's accuracy is measured from.
 - `unsafe` → `permissionDecision: ask` with the specific reason — or
   `deny` when the hook payload carries an `agent_id`, i.e. the call came
   from a background subagent. No operator is reachable there, so an `ask`
@@ -330,34 +337,27 @@ Add to `~/.claude/settings.json`:
 > `Bash(aws ecs list-services*)`) are fine; they just short-circuit YOLT
 > for the matching subset.
 
-## User whitelist as a secondary upgrade pass
+## User whitelist (removed in the auto-mode realignment)
 
-YOLT reads your `permissions.allow` Bash() entries from
-`~/.claude/settings.json`, the project's `.claude/settings.json`, and
-`.claude/settings.local.json`. After the rule classifier runs on each
-AST `command` node, any node that would otherwise be `unknown` or
-`unsafe` is upgraded to `safe` if its reconstructed argv matches one
-of those patterns.
+YOLT used to read your `permissions.allow` Bash() entries from
+`~/.claude/settings.json` and the project settings, and upgrade any
+matching `unknown` or `unsafe` node to `safe`. That was the second way it
+granted approval — sourced from your config rather than its own rules, but
+a grant all the same.
 
-This earns its keep on compound forms. The built-in matcher only sees
-the outer wrapper, so a `for ... do CMD; done` whose `CMD` you've
-already whitelisted (`Bash(mycli list*)`) still prompts. YOLT walks
-into the loop body and matches each command against the whitelist.
+It is gone
+([#98](https://github.com/voitta-ai/voitta-yolt/issues/98)). Under auto
+mode a hook that answers on the host's behalf is a classifier bypass the
+host cannot see, and that is as true of a grant you configured as of one
+YOLT decided. **YOLT no longer reads your settings files at all.**
 
-Two rules apply:
+Your `permissions.allow` entries still work — Claude Code honors them
+itself, which is the appropriate place for them.
 
-- The match uses `fnmatch` glob semantics — the same semantics Claude
-  Code's outer matcher uses. `Bash(env)` matches `env` exactly;
-  `Bash(aws s3 ls*)` matches anything that starts with `aws s3 ls`.
-- A match is an explicit user override. Keep patterns narrow:
-  `Bash(aws ecs list-services*)` is fine; `Bash(git *)` or
-  `Bash(gh *)` will allow matching mutating commands anywhere YOLT
-  reconstructs the same argv, including inside compound forms.
-
-For common self-PR workflow writes (`git push`, `git commit`,
-`gh issue create`, `gh pr comment`, ...), YOLT's `ask` message now
-includes a paste-ready `Bash(...)` suggestion when no allow pattern
-matched yet.
+For common workflow writes (`git push`, `git commit`, `gh issue create`,
+`gh pr comment`, ...), YOLT's `ask` message still includes a paste-ready
+`Bash(...)` suggestion. It is advice to you, not a grant: nothing happens
+until you add it yourself, and Claude Code — not YOLT — is what acts on it.
 
 ## Dependencies
 

--- a/hooks/grammar_classifier.py
+++ b/hooks/grammar_classifier.py
@@ -27,9 +27,7 @@ from rule_classifier import (
     SUBSTITUTION_PLACEHOLDER,
     RuleClassifier,
     aggregate_decisions,
-    load_allow_patterns,
     load_shell_rules,
-    match_allow_patterns,
 )
 
 
@@ -51,10 +49,9 @@ class GrammarClassifier:
 
     MAX_RECURSION_DEPTH = 8
 
-    def __init__(self, rules, python_analyzer_factory=None, allow_patterns=None):
+    def __init__(self, rules, python_analyzer_factory=None):
         self.rules = rules
         self.python_analyzer_factory = python_analyzer_factory
-        self.allow_patterns = list(allow_patterns) if allow_patterns else []
         self.safe_write_targets = list(rules.get("safe_write_targets", ["/dev/null"]))
         self.unsafe_write_targets = list(rules.get("unsafe_write_targets", []))
         self._rules = RuleClassifier(
@@ -160,18 +157,16 @@ class GrammarClassifier:
             None,
         )
         if unsafe_target is not None:
-            seg = self._slice(node, src)
-            decisions.append(self._maybe_allow(
-                seg, (DECISION_UNSAFE,
-                      "writes to protected path '{}' via redirection".format(
-                          unsafe_target)),
-            ))
+            decisions.append(
+                (DECISION_UNSAFE,
+                 "writes to protected path '{}' via redirection".format(
+                     unsafe_target)),
+            )
             return
         if any(not self._target_is_safe_write(t) for t in write_targets):
-            seg = self._slice(node, src)
-            decisions.append(self._maybe_allow(
-                seg, (DECISION_UNKNOWN, "writes to a file via redirection"),
-            ))
+            decisions.append(
+                (DECISION_UNKNOWN, "writes to a file via redirection"),
+            )
             return
         # All write targets safe (or none): fall through and classify the
         # command itself.
@@ -220,9 +215,7 @@ class GrammarClassifier:
         for c in node.children:
             self._collect_substitutions(c, src, sub_decisions, _depth + 1)
 
-        match_string = " ".join(argv)
         result = self._rules.classify_tokens(argv)
-        result = self._maybe_allow(match_string, result)
         if sub_decisions:
             return aggregate_decisions(sub_decisions + [result])
         return result
@@ -373,15 +366,6 @@ class GrammarClassifier:
         """Used by RuleClassifier for `bash -c <script>` interpreters."""
         return self.classify(script, _depth=depth)
 
-    def _maybe_allow(self, match_string, result):
-        decision, reason = result
-        if decision == DECISION_SAFE:
-            return result
-        match = match_allow_patterns(match_string, self.allow_patterns)
-        if match is None:
-            return result
-        return (DECISION_SAFE, "matches user allow pattern '{}'".format(match))
-
     @staticmethod
     def _suggest_allow_pattern_from_argv(argv):
         cmd_name = os.path.basename(argv[0])
@@ -467,12 +451,11 @@ class GrammarClassifier:
         return None
 
 
-def classify_command(command, rules, python_analyzer_factory=None, allow_patterns=None):
+def classify_command(command, rules, python_analyzer_factory=None):
     """Module-level convenience wrapper."""
     classifier = GrammarClassifier(
         rules,
         python_analyzer_factory=python_analyzer_factory,
-        allow_patterns=allow_patterns,
     )
     return classifier.classify(command)
 
@@ -489,13 +472,6 @@ def run_cli():
         rules_dir=yolt_dir / "rules",
         user_overrides_path=Path.home() / ".claude" / "yolt" / "shell.json",
     )
-
-    cwd = Path.cwd()
-    allow_patterns = load_allow_patterns([
-        Path.home() / ".claude" / "settings.json",
-        cwd / ".claude" / "settings.json",
-        cwd / ".claude" / "settings.local.json",
-    ])
 
     # Python analyzer factory — lazy import so this CLI works without
     # the rule data dir for python rules.
@@ -514,7 +490,6 @@ def run_cli():
         command,
         rules,
         python_analyzer_factory=factory,
-        allow_patterns=allow_patterns,
     )
 
     print(json.dumps({"decision": decision, "reason": reason}, indent=2))

--- a/hooks/yolt_analyzer.py
+++ b/hooks/yolt_analyzer.py
@@ -1197,7 +1197,10 @@ def run_hook():
          wrappers, interpreters, heredocs uniformly). The classifier
          delegates python3 inline / script analysis to SafetyAnalyzer.
       3. Map classifier decision -> hook response:
-           safe    -> permissionDecision: allow
+           safe    -> exit silently, same as unknown. YOLT does not
+                      grant permission; see issue #98. The decision is
+                      still recorded in the log, where it is what the
+                      classification is measured from.
            unsafe  -> permissionDecision: ask (with explanation), or
                       deny when the payload carries an `agent_id` (the
                       hook fired inside a subagent, where no operator
@@ -1248,9 +1251,9 @@ def run_hook():
             sys.path.insert(0, str(hooks_dir))
         from grammar_classifier import GrammarClassifier
         from rule_classifier import (
-            DECISION_SAFE, DECISION_UNSAFE,
+            DECISION_UNSAFE,
             ShellRulesValidationError,
-            load_allow_patterns, load_shell_rules,
+            load_shell_rules,
         )
     except ImportError as e:
         _log_hook_decision(command, "import-error", str(e),
@@ -1267,21 +1270,12 @@ def run_hook():
                            permission_mode, agent_id)
         sys.exit(0)
 
-    cwd_str = hook_input.get("cwd") or os.getcwd()
-    cwd = Path(cwd_str)
-    allow_patterns = load_allow_patterns([
-        Path.home() / ".claude" / "settings.json",
-        cwd / ".claude" / "settings.json",
-        cwd / ".claude" / "settings.local.json",
-    ])
-
     def _python_factory():
         return SafetyAnalyzer(py_rules)
 
     classifier = GrammarClassifier(
         shell_rules,
         python_analyzer_factory=_python_factory,
-        allow_patterns=allow_patterns,
     )
     decision, reason = classifier.classify(command)
     _log_hook_decision(command, decision, reason, permission_mode, agent_id)
@@ -1291,10 +1285,6 @@ def run_hook():
     # rides along with whatever decision was reached. Issue #85.
     advisory = format_secret_advisory(command)
 
-    if decision == DECISION_SAFE:
-        response = make_hook_response("allow", "YOLT: {}".format(reason))
-        print(json.dumps(attach_secret_advisory(response, advisory)))
-        sys.exit(0)
     if decision == DECISION_UNSAFE:
         allow_hint = classifier.suggest_allow_pattern(command)
         message = format_unsafe_reason(reason, allow_hint)
@@ -1312,10 +1302,15 @@ def run_hook():
         print(json.dumps(attach_secret_advisory(response, advisory)))
         sys.exit(0)
 
-    # decision == DECISION_UNKNOWN: let Claude Code handle it. Emit a
-    # response only when there is an advisory to carry — omitting
-    # `permissionDecision` leaves Claude Code's default prompt intact,
-    # so the warning costs the fallthrough nothing.
+    # decision is DECISION_SAFE or DECISION_UNKNOWN: say nothing and let
+    # the host decide. `safe` is still recorded in the log — it is a
+    # classification, not a grant — but it no longer produces a
+    # `permissionDecision`, so auto mode's classifier is never
+    # short-circuited by this hook. Issue #98.
+    #
+    # Emit a response only when there is an advisory to carry: omitting
+    # `permissionDecision` leaves the host's own handling intact, so the
+    # warning costs the fallthrough nothing.
     if advisory:
         response = {"hookSpecificOutput": {"hookEventName": "PreToolUse"}}
         print(json.dumps(attach_secret_advisory(response, advisory)))

--- a/tests/test_adversarial_regressions.py
+++ b/tests/test_adversarial_regressions.py
@@ -8,9 +8,12 @@ should be added here when their fix lands.
 Every test goes through the same end-to-end path Claude Code uses in
 production: `python3 hooks/yolt_analyzer.py --hook`, fed a synthetic
 `PreToolUse` payload on stdin. The assertion is on the
-`permissionDecision` value (`allow` / `ask`) or on a silent exit
-(`None`) for inputs that intentionally fall through to Claude Code's
-default-prompt path.
+`permissionDecision` value (`ask`) or on a silent exit (`None`) for
+inputs that fall through to Claude Code's own handling. Since issue #98
+the hook never emits `allow`, so repros that assert a command must stay
+*safe* go through `classification_for`, which reads the classifier
+directly — a stricter check than the old `allow`, because it cannot be
+satisfied by an `unknown`.
 
 Catalogue layout:
 
@@ -32,7 +35,7 @@ Catalogue layout:
   routes the path through the same white list redirects use.
 - `TestIssue28UnsafeWriteTargets` -- redirect / command writes to
   dotfile / config / startup paths (closes #28). The headline repro
-  is `echo pwn > ~/.claude/settings.json`, which classified `allow`
+  is `echo pwn > ~/.claude/settings.json`, which classified safe
   before the fix because `~/.claude/*` is a safe-write target even
   though settings.json can disable this hook. The deny list is
   checked before the safe list, so it now asks.
@@ -75,6 +78,26 @@ class _Hook:
         last_line = stdout.splitlines()[-1]
         response = json.loads(last_line)
         retval = response["hookSpecificOutput"]["permissionDecision"]
+        return retval
+
+    @staticmethod
+    def classification_for(command):
+        """Classifier decision (`safe` / `unsafe` / `unknown`).
+
+        Issue #98 stopped the hook emitting `allow`, so a safe command is
+        now silent and indistinguishable at the hook boundary from an
+        unknown one. The safe-side repros in this catalogue care about
+        exactly that distinction — "this must stay classified safe" — so
+        they assert here instead, which is a stricter check than the
+        `allow` they used to make.
+        """
+        result = subprocess.run(
+            [sys.executable, str(HOOKS_DIR / "grammar_classifier.py"), command],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        retval = json.loads(result.stdout)["decision"]
         return retval
 
 
@@ -283,21 +306,21 @@ class TestIssue17NestedCliVerbs(unittest.TestCase):
     # Bare reads that must remain safe
 
     def test_bare_git_tag_safe(self):
-        self.assertEqual(_Hook.decision_for("git tag"), "allow")
+        self.assertEqual(_Hook.classification_for("git tag"), "safe")
 
     def test_git_tag_list_safe(self):
-        self.assertEqual(_Hook.decision_for("git tag -l"), "allow")
+        self.assertEqual(_Hook.classification_for("git tag -l"), "safe")
 
     def test_docker_image_ls_safe(self):
-        self.assertEqual(_Hook.decision_for("docker image ls"), "allow")
+        self.assertEqual(_Hook.classification_for("docker image ls"), "safe")
 
     def test_kubectl_config_view_safe(self):
         self.assertEqual(
-            _Hook.decision_for("kubectl config view"), "allow"
+            _Hook.classification_for("kubectl config view"), "safe"
         )
 
     def test_helm_repo_list_safe(self):
-        self.assertEqual(_Hook.decision_for("helm repo list"), "allow")
+        self.assertEqual(_Hook.classification_for("helm repo list"), "safe")
 
 
 class TestIssue27FindWriteFlags(unittest.TestCase):
@@ -316,8 +339,8 @@ class TestIssue27FindWriteFlags(unittest.TestCase):
 
     def test_fprint_to_tmp_is_safe(self):
         self.assertEqual(
-            _Hook.decision_for("find / -fprint /tmp/list.txt"),
-            "allow",
+            _Hook.classification_for("find / -fprint /tmp/list.txt"),
+            "safe",
         )
 
     def test_fprintf_to_etc_is_unsafe(self):
@@ -328,8 +351,8 @@ class TestIssue27FindWriteFlags(unittest.TestCase):
 
     def test_fprintf_to_tmp_is_safe(self):
         self.assertEqual(
-            _Hook.decision_for("find / -fprintf /tmp/list.txt '%p\\n'"),
-            "allow",
+            _Hook.classification_for("find / -fprintf /tmp/list.txt '%p\\n'"),
+            "safe",
         )
 
     def test_fls_to_var_log_is_unsafe(self):
@@ -340,8 +363,8 @@ class TestIssue27FindWriteFlags(unittest.TestCase):
 
     def test_fls0_to_tmp_is_safe(self):
         self.assertEqual(
-            _Hook.decision_for("find / -fls0 /tmp/list.bin"),
-            "allow",
+            _Hook.classification_for("find / -fls0 /tmp/list.bin"),
+            "safe",
         )
 
 
@@ -373,8 +396,8 @@ class TestIssue28UnsafeWriteTargets(unittest.TestCase):
         # The carve-out is settings.json only; the rest of ~/.claude/*
         # stays a safe-write target so legitimate cache writes don't ask.
         self.assertEqual(
-            _Hook.decision_for("echo x > ~/.claude/cache.json"),
-            "allow",
+            _Hook.classification_for("echo x > ~/.claude/cache.json"),
+            "safe",
         )
 
     def test_redirect_to_bashrc_asks(self):
@@ -405,8 +428,8 @@ class TestIssue28UnsafeWriteTargets(unittest.TestCase):
     def test_redirect_to_tmp_still_allowed(self):
         # Control: a benign temp write is unaffected.
         self.assertEqual(
-            _Hook.decision_for("echo x > /tmp/scratch.txt"),
-            "allow",
+            _Hook.classification_for("echo x > /tmp/scratch.txt"),
+            "safe",
         )
 
     def test_safe_first_redirect_does_not_mask_unsafe_second(self):

--- a/tests/test_grammar_classifier.py
+++ b/tests/test_grammar_classifier.py
@@ -10,7 +10,6 @@ calls in production. Coverage targets:
   - Quoting: bash `'\\''` close-escape-open idiom, `$'...'` ANSI-C strings,
     concatenated strings.
   - Heredocs (with python body), redirects, process substitution.
-  - User whitelist upgrade, including explicit overrides of unsafe atoms.
 
 Runs with stdlib unittest plus tree-sitter / tree-sitter-bash:
 
@@ -38,7 +37,7 @@ from rule_classifier import (  # noqa: E402
 from yolt_analyzer import SafetyAnalyzer, load_rules as load_py_rules  # noqa: E402
 
 
-def _make_classifier(allow_patterns=None):
+def _make_classifier():
     shell_rules = load_shell_rules(REPO_ROOT / "rules")
     py_rules = load_py_rules(REPO_ROOT / "rules")
 
@@ -48,7 +47,6 @@ def _make_classifier(allow_patterns=None):
     return GrammarClassifier(
         shell_rules,
         python_analyzer_factory=factory,
-        allow_patterns=allow_patterns or [],
     )
 
 
@@ -890,12 +888,12 @@ class TestUnsafeWriteTargets(unittest.TestCase):
         self.assertIn("~/.bashrc", reason)
         self.assertIn("protected", reason)
 
-    def test_whitelist_still_overrides_unsafe_redirect(self):
-        # Consistent with every other unsafe atom: an explicit user allow
-        # pattern upgrades the deny-path write to safe.
-        clf = _make_classifier(allow_patterns=["echo *"])
-        d, _ = clf.classify("echo x > /etc/profile")
-        self.assertEqual(d, DECISION_SAFE)
+    def test_protected_redirect_is_not_overridable(self):
+        # Issue #98 removed the user-allow-pattern upgrade, so nothing in
+        # the user's settings can talk a protected-path write back down
+        # to safe. This used to be the one deny-path escape hatch.
+        d, _ = _make_classifier().classify("echo x > /etc/profile")
+        self.assertEqual(d, DECISION_UNSAFE)
 
     def test_safe_first_redirect_does_not_mask_unsafe_second(self):
         # Every write redirect is evaluated, not just the first: a safe
@@ -921,53 +919,12 @@ class TestUnsafeWriteTargets(unittest.TestCase):
         self.assertDecision("echo x > /tmp/a > /tmp/b", DECISION_SAFE)
 
 
-class TestClassifierAllowPatterns(unittest.TestCase):
-    """Whitelist upgrades unknown and unsafe matches to safe."""
+class TestAllowHintSuggestions(unittest.TestCase):
+    """`suggest_allow_pattern` still produces the hint shown alongside an
+    `ask`, even though issue #98 removed the classifier's own honoring of
+    user allow patterns. The hint is advice to the operator, not a grant."""
 
-    def test_unknown_command_upgraded_to_safe(self):
-        clf = _make_classifier(allow_patterns=["mycli *"])
-        d, r = clf.classify("mycli foo --bar")
-        self.assertEqual(d, DECISION_SAFE)
-        self.assertIn("mycli *", r)
-
-    def test_unknown_aws_op_upgraded(self):
-        clf = _make_classifier(allow_patterns=["aws * weird-op*"])
-        d, _ = clf.classify("aws ec2 weird-op --flag")
-        self.assertEqual(d, DECISION_SAFE)
-
-    def test_unsafe_overridden_by_whitelist(self):
-        clf = _make_classifier(allow_patterns=["aws *"])
-        d, _ = clf.classify("aws iam delete-user --user-name foo")
-        self.assertEqual(d, DECISION_SAFE)
-
-    def test_unsafe_in_compound_overridden(self):
-        clf = _make_classifier(allow_patterns=["aws *", "rm *"])
-        d, _ = clf.classify("aws s3 ls && rm -rf /etc")
-        self.assertEqual(d, DECISION_SAFE)
-
-    def test_no_whitelist_match_stays_unknown(self):
-        clf = _make_classifier(allow_patterns=["aws *"])
-        d, _ = clf.classify("somecommand_unknown")
-        self.assertEqual(d, DECISION_UNKNOWN)
-
-    def test_decomposed_atoms_match_whitelist(self):
-        # The outer `for` wrapper would not match `Bash(aws s3 ls*)`, but
-        # the grammar walker classifies each iteration body separately.
-        clf = _make_classifier(allow_patterns=["aws s3 ls*"])
-        d, _ = clf.classify("for b in foo bar; do aws s3 ls s3://$b/; done")
-        self.assertEqual(d, DECISION_SAFE)
-
-    def test_writes_to_file_upgraded_when_whitelisted(self):
-        clf = _make_classifier(allow_patterns=["echo *"])
-        d, _ = clf.classify("echo x > /etc/profile")
-        self.assertEqual(d, DECISION_SAFE)
-
-    def test_empty_allow_patterns_unchanged_behavior(self):
-        clf = _make_classifier(allow_patterns=[])
-        d, _ = clf.classify("somecommand_unknown")
-        self.assertEqual(d, DECISION_UNKNOWN)
-
-    def test_suggested_allow_hints_round_trip(self):
+    def test_suggested_allow_hints(self):
         cases = [
             ("git -C /tmp/wt add file.txt", "Bash(git -C * add*)"),
             (
@@ -978,9 +935,17 @@ class TestClassifierAllowPatterns(unittest.TestCase):
         for command, expected_hint in cases:
             hint = _make_classifier().suggest_allow_pattern(command)
             self.assertEqual(hint, expected_hint)
-            inner = hint[len("Bash("):-1]
-            d, _ = _make_classifier(allow_patterns=[inner]).classify(command)
-            self.assertEqual(d, DECISION_SAFE, command)
+
+    def test_allow_pattern_no_longer_upgrades_a_decision(self):
+        # The whole point of #98: whatever the user has in
+        # permissions.allow, this classifier does not read it and does
+        # not turn an unsafe or unknown command into a safe one.
+        clf = _make_classifier()
+        self.assertEqual(clf.classify("mycli foo --bar")[0], DECISION_UNKNOWN)
+        self.assertEqual(
+            clf.classify("aws iam delete-user --user-name foo")[0],
+            DECISION_UNSAFE,
+        )
 
 
 class TestSqlCli(unittest.TestCase):

--- a/tests/test_grammar_classifier.py
+++ b/tests/test_grammar_classifier.py
@@ -27,7 +27,10 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 HOOKS_DIR = REPO_ROOT / "hooks"
 sys.path.insert(0, str(HOOKS_DIR))
 
-from grammar_classifier import GrammarClassifier  # noqa: E402
+from grammar_classifier import (  # noqa: E402
+    GrammarClassifier,
+    classify_command,
+)
 from rule_classifier import (  # noqa: E402
     DECISION_SAFE,
     DECISION_UNKNOWN,
@@ -888,10 +891,14 @@ class TestUnsafeWriteTargets(unittest.TestCase):
         self.assertIn("~/.bashrc", reason)
         self.assertIn("protected", reason)
 
-    def test_protected_redirect_is_not_overridable(self):
-        # Issue #98 removed the user-allow-pattern upgrade, so nothing in
-        # the user's settings can talk a protected-path write back down
-        # to safe. This used to be the one deny-path escape hatch.
+    def test_protected_redirect_is_unsafe(self):
+        # Pre-existing behaviour, restated after #98 removed the one
+        # escape hatch that could override it. Deliberately NOT claiming
+        # to pin the removal: with no patterns supplied this assertion
+        # holds on the old code too. The removal is pinned end-to-end in
+        # test_yolt_hook.TestHookIgnoresUserAllowPatterns, which writes a
+        # real settings file, and structurally by
+        # TestAllowHintSuggestions.test_classifier_refuses_allow_patterns_outright.
         d, _ = _make_classifier().classify("echo x > /etc/profile")
         self.assertEqual(d, DECISION_UNSAFE)
 
@@ -936,16 +943,17 @@ class TestAllowHintSuggestions(unittest.TestCase):
             hint = _make_classifier().suggest_allow_pattern(command)
             self.assertEqual(hint, expected_hint)
 
-    def test_allow_pattern_no_longer_upgrades_a_decision(self):
-        # The whole point of #98: whatever the user has in
-        # permissions.allow, this classifier does not read it and does
-        # not turn an unsafe or unknown command into a safe one.
-        clf = _make_classifier()
-        self.assertEqual(clf.classify("mycli foo --bar")[0], DECISION_UNKNOWN)
-        self.assertEqual(
-            clf.classify("aws iam delete-user --user-name foo")[0],
-            DECISION_UNSAFE,
-        )
+    def test_classifier_refuses_allow_patterns_outright(self):
+        # The classifier-level pin for #98. Asserting "an unknown stays
+        # unknown" here would be vacuous — it passes on the old code too,
+        # because the old constructor defaulted to no patterns. The
+        # non-vacuous statement is that the parameter is gone, so no
+        # caller can reintroduce the upgrade by passing one.
+        shell_rules = load_shell_rules(REPO_ROOT / "rules")
+        with self.assertRaises(TypeError):
+            GrammarClassifier(shell_rules, allow_patterns=["aws *"])
+        with self.assertRaises(TypeError):
+            classify_command("aws s3 ls", shell_rules, allow_patterns=["aws *"])
 
 
 class TestSqlCli(unittest.TestCase):

--- a/tests/test_redactor_unavailable.py
+++ b/tests/test_redactor_unavailable.py
@@ -63,7 +63,13 @@ class RedactorUnavailableTests(unittest.TestCase):
         self.assertEqual(proc.returncode, 0,
                          "hook died: {}".format(proc.stderr[:400]))
         # Classification never needed the redactor, so it must survive.
-        self.assertIn("permissionDecision", proc.stdout)
+        # Since issue #98 a safe command produces no stdout, so the proof
+        # that classification ran is the decision in the log record —
+        # anything other than an error sentinel means the classifier was
+        # reached with the redactor missing.
+        self.assertTrue(written, "nothing logged at all")
+        record = json.loads(written.strip().splitlines()[-1])
+        self.assertIn(record["decision"], ("safe", "unsafe", "unknown"))
 
     def test_command_text_is_withheld_not_written_raw(self):
         proc, written = self.run_without_redactor(

--- a/tests/test_yolt_hook.py
+++ b/tests/test_yolt_hook.py
@@ -66,12 +66,14 @@ class TestHookEndToEnd(unittest.TestCase):
         retval = resp["hookSpecificOutput"]["permissionDecision"]
         return retval
 
-    def test_safe_ls_returns_allow(self):
-        self.assertEqual(self._decision("ls /tmp"), "allow")
+    def test_safe_ls_emits_no_decision(self):
+        # Issue #98: YOLT does not grant. A safe command is silent, which
+        # is indistinguishable to the host from unknown.
+        self.assertIsNone(self._decision("ls /tmp"))
 
     def test_aws_describe_returns_allow(self):
         self.assertEqual(
-            self._decision("aws ec2 describe-instances"), "allow"
+            self._decision("aws ec2 describe-instances"), None
         )
 
     def test_unsafe_rm_returns_ask(self):
@@ -94,18 +96,16 @@ class TestHookEndToEnd(unittest.TestCase):
         # prompt.
         self.assertEqual(self._decision("echo x > /etc/profile"), "ask")
 
-    def test_compound_aws_loop_returns_allow(self):
+    def test_compound_aws_loop_emits_no_decision(self):
         cmd = (
             'for svc in $(aws ecs list-services --cluster X); do '
             'aws ecs describe-services --cluster X --services "$svc"; '
             "done"
         )
-        self.assertEqual(self._decision(cmd), "allow")
+        self.assertIsNone(self._decision(cmd))
 
-    def test_python3_dash_c_safe_returns_allow(self):
-        self.assertEqual(
-            self._decision('python3 -c "print(1+1)"'), "allow"
-        )
+    def test_python3_dash_c_safe_emits_no_decision(self):
+        self.assertIsNone(self._decision('python3 -c "print(1+1)"'))
 
     def test_python3_dash_c_destructive_returns_ask(self):
         self.assertEqual(
@@ -115,24 +115,22 @@ class TestHookEndToEnd(unittest.TestCase):
             "ask",
         )
 
-    def test_heredoc_safe_returns_allow(self):
+    def test_heredoc_safe_emits_no_decision(self):
         cmd = 'python3 <<EOF\nimport os\nprint(os.listdir("/tmp"))\nEOF\n'
-        self.assertEqual(self._decision(cmd), "allow")
+        self.assertIsNone(self._decision(cmd))
 
     def test_heredoc_destructive_returns_ask(self):
         cmd = 'python3 <<EOF\nimport os\nos.system("rm -rf /tmp/x")\nEOF\n'
         self.assertEqual(self._decision(cmd), "ask")
 
-    def test_python3_script_file_safe_returns_allow(self):
+    def test_python3_script_file_safe_emits_no_decision(self):
         with tempfile.NamedTemporaryFile(
             mode="w", suffix=".py", delete=False
         ) as f:
             f.write("import json\nprint(json.dumps({'ok': True}))\n")
             path = f.name
         try:
-            self.assertEqual(
-                self._decision("python3 {}".format(path)), "allow"
-            )
+            self.assertIsNone(self._decision("python3 {}".format(path)))
         finally:
             os.unlink(path)
 
@@ -244,11 +242,10 @@ class TestHookSubagentDeny(unittest.TestCase):
             resp["hookSpecificOutput"]["permissionDecision"], "ask"
         )
 
-    def test_safe_in_subagent_still_allows(self):
+    def test_safe_in_subagent_exits_silently(self):
+        # Issue #98: safe no longer grants anywhere, subagent included.
         resp = self._run("ls /tmp", agent_id="agent_abc123")
-        self.assertEqual(
-            resp["hookSpecificOutput"]["permissionDecision"], "allow"
-        )
+        self.assertIsNone(resp)
 
     def test_unknown_in_subagent_still_exits_silently(self):
         resp = self._run(
@@ -257,12 +254,18 @@ class TestHookSubagentDeny(unittest.TestCase):
         self.assertIsNone(resp)
 
 
-class TestHookWhitelistDiscovery(unittest.TestCase):
-    """The hook reads the user's settings.json `permissions.allow` Bash()
-    entries and uses them as an explicit override for unknown and unsafe
-    atoms.
-    Tests scope the lookup via the `cwd` field in the hook payload so
-    they don't depend on the real test runner's home directory."""
+class TestHookIgnoresUserAllowPatterns(unittest.TestCase):
+    """Issue #98 removed the `permissions.allow` upgrade path.
+
+    The hook used to read the user's settings and turn a matching unknown
+    or unsafe command into a grant. Under auto mode that is a classifier
+    bypass the host cannot see, so the settings are no longer read at all.
+    These tests pin that: an entry that previously forced `allow` now
+    changes nothing.
+
+    They also keep the suite hermetic (issue #75) — the hook no longer
+    consults the developer's real ~/.claude/settings.json, so a local
+    allowlist cannot flip an expected `ask` into an `allow`."""
 
     def setUp(self):
         self._tmp = tempfile.mkdtemp(prefix="yolt-hook-cwd-")
@@ -290,20 +293,19 @@ class TestHookWhitelistDiscovery(unittest.TestCase):
         retval = resp["hookSpecificOutput"]["permissionDecision"]
         return retval
 
-    def test_unknown_atom_upgraded_via_cwd_settings(self):
+    def test_matching_allow_entry_does_not_grant_an_unknown(self):
         self._write_settings(["Bash(yolt_test_mycli *)"])
-        self.assertEqual(self._decision("yolt_test_mycli foo bar"), "allow")
-
-    def test_unknown_atom_without_match_stays_silent(self):
-        self._write_settings(["Bash(yolt_test_othertool *)"])
         self.assertIsNone(self._decision("yolt_test_mycli foo bar"))
 
-    def test_whitelist_overrides_unsafe(self):
+    def test_matching_allow_entry_does_not_downgrade_an_unsafe(self):
         self._write_settings(["Bash(git push origin feature/*)"])
         self.assertEqual(
-            self._decision("git push origin feature/issue-35"),
-            "allow",
+            self._decision("git push origin feature/issue-35"), "ask",
         )
+
+    def test_unknown_without_match_still_silent(self):
+        self._write_settings(["Bash(yolt_test_othertool *)"])
+        self.assertIsNone(self._decision("yolt_test_mycli foo bar"))
 
 
 class TestBootstrapShell(unittest.TestCase):
@@ -593,7 +595,7 @@ class TestHookLogFile(unittest.TestCase):
             [sys.executable, str(HOOKS_DIR / "yolt_analyzer.py"), "--hook"],
             input=json.dumps({
                 "tool_name": "Bash",
-                "tool_input": {"command": "ls /tmp"},
+                "tool_input": {"command": "rm -rf /tmp/foo"},
             }),
             capture_output=True,
             text=True,
@@ -601,7 +603,9 @@ class TestHookLogFile(unittest.TestCase):
             env=env,
         )
         self.assertEqual(result.returncode, 0)
-        # Decision is still emitted on stdout.
+        # Decision is still emitted on stdout. The probe is a mutating
+        # command on purpose: since issue #98 a safe one is silent, so it
+        # could not tell a healthy hook from a broken one.
         self.assertIn("hookSpecificOutput", result.stdout)
 
 


### PR DESCRIPTION
Phase 1 of #102. **Targets `feature/auto-mode-realignment`, not master.** Closes #98, and #75 as a verified side effect.

## What

Two grant paths existed. Both are gone.

**1. `safe` -> `permissionDecision: allow`.** Now a silent exit, identical to `unknown`. The classification is still written to the decision log — that is what Phase 1's measurement reads — it just stops being an answer given on the host's behalf.

**2. The user-allow-pattern upgrade.** `GrammarClassifier` read `permissions.allow` from `~/.claude/settings.json` and the project settings and promoted any matching `unknown` or `unsafe` node to `safe`. That is sourced from your config rather than YOLT's rules, but it is a grant all the same — and after change 1 its only remaining effect would have been to **mislabel the log, corrupting the very measurement this phase exists to take.**

`load_allow_patterns` / `match_allow_patterns` stay in `rule_classifier` with their unit tests; only the wiring is removed. Deleting the rest is Phase 3 cleanup.

## Why

Auto mode deliberately ignores broad pre-approvals in `permissions.allow`, and `/auto-mode-setup` offers to delete them as "classifier-bypassing". A hook returning `allow` is the identical bypass and that audit cannot see it. The local decision log showed **794 approvals granted this way while auto mode was active**.

## #75 confirmed, not assumed

#98 predicted this would fall out. It did. The suite was non-hermetic because the hook resolved allow patterns from the developer's real `~/.claude/settings.json` *during the test run*, so a local `Bash(...)` entry turned an expected `ask` into an `allow`. Nothing reads those files now:

| | result |
|---|---|
| fake `$HOME` | **659 passed** |
| real `$HOME` (366 allow entries) | **659 passed** — previously ~19 phantom failures |

## Tests were re-pointed, not deleted

Worth reading, because two of these are places where the obvious edit would have made the suite weaker:

- Safe-path hook tests assert **no `permissionDecision` at all** rather than `allow`.
- `TestClassifierAllowPatterns` and `TestHookWhitelistDiscovery` tested the removed upgrade. Replaced with the **inverse** assertion — a matching `permissions.allow` entry must *not* change a decision — so the removal is pinned rather than merely untested.
- The adversarial catalogue's safe-side repros asserted hook `allow` as a proxy for "classified safe". Mechanically that becomes `assertIsNone` — but an `unknown` satisfies that too, so the repro would silently stop testing what it was written for. They now assert the classifier decision directly via a new `classification_for` probe, which is **stricter** than what it replaced.
- `test_hook_survives_and_still_classifies` and `test_unwritable_log_path_does_not_break_hook` used a *safe* command to prove the hook still produced output. A safe probe can no longer tell a healthy hook from a broken one, so they use a mutating probe and the log record respectively.
- The one deny-path escape hatch is pinned closed: `echo x > /etc/profile` can no longer be talked down to safe by any user setting.

## README

Decision mapping, the whitelist section, the intro line and the superseded use case are corrected, and the #103 warning block is rewritten now that the bypass is actually gone. The deeper rules documentation is untouched — Phase 3 deletes it.

## Version

None. Phase PRs merge into the umbrella and do not ship; the umbrella -> master PR carries the single `1.0.1` -> `2.0.0`.

## Next

**This PR is the gate.** Once it is on the umbrella, run a working day against it and record the result on #98 before Phase 3 (#100) starts. Phase 2 (#99) and Phase 4 (#97) are not blocked.