### PR TITLE
ci: run on PRs into long-lived umbrella branches, not just master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,14 @@ on:
   push:
     branches: [master]
   pull_request:
-    branches: [master]
+    # Long-lived umbrella branches too, not just master. A stacked stack
+    # (see the multi-phase-feature-pr-worktrees convention) has every
+    # phase PR targeting an umbrella branch, so a master-only filter
+    # means each phase merges with ZERO CI and the first real run
+    # happens at the umbrella -> master PR, with all phases entangled.
+    branches:
+      - master
+      - 'feature/**'
 
 jobs:
   test:


### PR DESCRIPTION
Found while adversarially reviewing #104: `gh pr checks 104` reported **"no checks reported on the 'phase-1-no-allow' branch"**.

The workflow filters `pull_request` to `branches: [master]`. Every phase PR in the #102 stack targets `feature/auto-mode-realignment`, so **none of them run CI**.

The real cost is not one unverified PR. It is that the first CI run would be the umbrella -> master PR, with all four phases entangled — a red suite at that point tells you nothing about which phase broke it, which defeats the reason for stacking in the first place.

Adds `feature/**` to the `pull_request` branch filter. `push` stays master-only, so the cost is one run per phase PR.

Maintainer-only file — no version bump per CLAUDE.md ("changes that do not need their own bump, because users never execute them: `tests/`, `.github/` ...").