### PR TITLE
Phase 2: widen PreToolUse past Bash to every tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 - [Introduction](#introduction)
 - [Example use cases](#example-use-cases)
 - [How it works](#how-it-works)
+- [Tools other than Bash](#tools-other-than-bash)
 - [Install](#install)
   - [Updating](#updating)
   - [Releasing (maintainers)](#releasing-maintainers)
@@ -218,6 +219,51 @@ is safe but `python3 -m pip install` is unsafe); known CLIs use their
 `rules/shell.json` spec; wrappers (`time`, `xargs`, `timeout`, `env`,
 `nice`, `watch`, ...) re-classify the wrapped command; anything else →
 unknown.
+
+## Tools other than Bash
+
+The PreToolUse matcher is `*`, not `Bash`
+([#99](https://github.com/voitta-ai/voitta-yolt/issues/99)). The reason is
+empirical rather than tidy: the subagent wedge investigated in
+[#80](https://github.com/voitta-ai/voitta-yolt/issues/80) hung on a
+`Write`, so YOLT was never in its path. A guard registered on one tool is
+not a guard.
+
+A structured tool has no argv, no shell and no rule lookup, so exactly two
+things happen for it:
+
+1. **The agent-steering write check.** If the call writes to a path in
+   `rules/shell.json#unsafe_write_targets` — settings, hooks, skills,
+   commands, agents, memory, MCP config — it is `unsafe`. That is the
+   self-modification shape, and it is the one thing on the non-delegable
+   list a structured tool can reach today.
+2. **The credential advisory**, over every string in the payload, so a
+   token in a `Write` body or an MCP argument is caught the same as one on
+   a command line. The wording drops the `argv` / `ps` framing there,
+   because neither applies.
+
+Everything else is `unknown` and the host decides.
+
+The write-target field list is **closed** — `Write`, `Edit`, `MultiEdit`
+and `NotebookEdit`, by their documented path fields. Guessing which field
+of an arbitrary MCP payload is a write target eventually guesses wrong,
+and a wrong guess is a false `deny` inside a subagent, which is the exact
+failure this is meant to prevent. This is deliberately not a second
+classifier for structured tools: the host's own vetting covers the general
+case.
+
+> **“YOLT denies in subagents” is not “subagent wedges are handled.”**
+> The deny converts *YOLT's own* `ask` into a fast failure. Any other
+> gated call in a background subagent still hangs with no prompt and no
+> timeout — 2h37m with no result in the #80 probe. The general fix belongs
+> in Claude Code, where a subagent permission request should surface or
+> time out rather than hang.
+
+The conversion is skipped under `bypassPermissions` and `dontAsk`, where
+the operator blanket-authorised ahead of time and there was no prompt to
+hang on. It is **not** skipped under `auto`: auto mode delegates the
+decision to a classifier, it does not put an operator behind a hook's
+`ask`, so a subagent that receives one still has nobody to answer it.
 
 ## Install
 

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -2,7 +2,7 @@
   "hooks": {
     "PreToolUse": [
       {
-        "matcher": "Bash",
+        "matcher": "*",
         "hooks": [
           {
             "type": "command",

--- a/hooks/yolt_analyzer.py
+++ b/hooks/yolt_analyzer.py
@@ -873,6 +873,195 @@ SUBAGENT_DENY_PREFIX = (
     "the main session, or add a matching permissions.allow entry.\n\n"
 )
 
+# Permission modes in which the operator has blanket-authorised ahead of
+# time, so an `ask` from this hook is not a question anybody was going to
+# be asked. Converting it to `deny` inside a subagent would override an
+# explicit pre-authorisation rather than protect against a hang. Issue
+# #80, gap 1.
+#
+# `auto` is deliberately NOT in this set, which departs from the list in
+# #80. Auto mode delegates the *decision* to a classifier; it does not
+# put an operator behind a hook's `ask`, so a subagent that receives one
+# still has nobody to answer it. The costs are wildly asymmetric — a
+# wrong deny fails in seconds with a reason the agent can report upward,
+# a wrong ask wedged an agent for 2h37m in the #80 probe — so `auto`
+# keeps the deny.
+SUBAGENT_DENY_EXEMPT_MODES = frozenset({"bypassPermissions", "dontAsk"})
+
+# Tools whose input carries a filesystem path the tool writes to.
+#
+# Deliberately a closed list. Guessing which field of an arbitrary MCP
+# payload is a write target will eventually guess wrong, and the failure
+# mode of a wrong guess is a false `deny` in a subagent, which is exactly
+# the wedge this hook exists to avoid. An unlisted tool falls through to
+# `unknown` and the host decides. Issue #99.
+TOOL_WRITE_PATH_FIELDS = {
+    "Write": ("file_path",),
+    "Edit": ("file_path",),
+    "MultiEdit": ("file_path",),
+    "NotebookEdit": ("notebook_path",),
+}
+
+
+def tool_input_text(tool_input):
+    """Flatten a tool input to the text the credential scanner reads.
+
+    Every string anywhere in the payload, joined. A credential can ride
+    in a `Write` body, a `WebFetch` url, or an arbitrary MCP argument,
+    and enumerating the field that carries it per tool is the same
+    losing game as enumerating write-target fields — except here the
+    cost of over-reaching is a false warning rather than a false deny,
+    so this one reaches everywhere.
+    """
+    parts = []
+
+    def walk(value):
+        if isinstance(value, str):
+            parts.append(value)
+        elif isinstance(value, dict):
+            for item in value.values():
+                walk(item)
+        elif isinstance(value, (list, tuple)):
+            for item in value:
+                walk(item)
+
+    walk(tool_input)
+    retval = "\n".join(parts)
+    return retval
+
+
+def make_gated_response(message, permission_mode, agent_id):
+    """Build the response for a decision YOLT objects to.
+
+    `ask` normally, `deny` inside a subagent — no operator is reachable
+    from a background subagent, so the approval dialog never surfaces and
+    nothing times out; the agent wedges indefinitely (observed at 2h37m
+    in #80). `deny` is strictly more restrictive than `ask` and fails in
+    seconds with a reason the agent can report upward. Issues #76, #77.
+
+    The subagent conversion is skipped in the modes listed in
+    `SUBAGENT_DENY_EXEMPT_MODES`, where the operator pre-authorised and
+    there was no prompt to hang on. Issue #80, gap 1.
+    """
+    if agent_id and permission_mode not in SUBAGENT_DENY_EXEMPT_MODES:
+        retval = make_hook_response("deny", SUBAGENT_DENY_PREFIX + message)
+        return retval
+    retval = make_hook_response("ask", message)
+    return retval
+
+
+def _run_hook_non_bash(tool_name, tool_input, permission_mode, agent_id):
+    """PreToolUse path for every tool that is not Bash. Always exits.
+
+    The matcher covers `*` as of #99, because the wedge #80 observed was
+    a `Write`, not a Bash call — a guard registered on one tool is not a
+    guard. Two things happen here and nothing else:
+
+      1. the agent-steering write check (`classify_tool_input`), and
+      2. the credential advisory, over every string in the payload.
+
+    There is no shell parsing, no rule lookup and no argv: a structured
+    tool has none of those. Anything not covered by (1) falls through to
+    `unknown` so the host decides.
+    """
+    text = tool_input_text(tool_input)
+    advisory = format_secret_advisory(text, tool_name=tool_name or "tool")
+
+    try:
+        hooks_dir = Path(__file__).resolve().parent
+        if str(hooks_dir) not in sys.path:
+            sys.path.insert(0, str(hooks_dir))
+        from grammar_classifier import GrammarClassifier
+        from rule_classifier import DECISION_UNSAFE, load_shell_rules
+        yolt_dir = hooks_dir.parent
+        shell_rules = load_shell_rules(
+            rules_dir=yolt_dir / "rules",
+            user_overrides_path=Path.home() / ".claude" / "yolt" / "shell.json",
+        )
+    except Exception as e:
+        # Broad on purpose. `ShellRulesValidationError` cannot be named
+        # here — it is imported inside this same try, so an ImportError
+        # would leave the except clause itself undefined.
+        # The write-target list lives in the shell rules, so without them
+        # there is no check to make. Carry the advisory if there is one
+        # and let the host decide the rest — never fail the tool call.
+        _log_hook_decision(_tool_log_subject(tool_name, tool_input),
+                           "rules-unavailable", str(e),
+                           permission_mode, agent_id, tool_name=tool_name)
+        _emit_advisory_only(advisory)
+        sys.exit(0)
+
+    classifier = GrammarClassifier(shell_rules)
+    decision, reason = classify_tool_input(
+        tool_name, tool_input, classifier._target_is_unsafe_write,
+    )
+    _log_hook_decision(_tool_log_subject(tool_name, tool_input),
+                       decision, reason, permission_mode, agent_id,
+                       tool_name=tool_name)
+
+    if decision == DECISION_UNSAFE:
+        response = make_gated_response(reason, permission_mode, agent_id)
+        print(json.dumps(attach_secret_advisory(response, advisory)))
+        sys.exit(0)
+
+    _emit_advisory_only(advisory)
+    sys.exit(0)
+
+
+def _emit_advisory_only(advisory):
+    """Emit a response carrying only the advisory, or nothing at all.
+
+    Omitting `permissionDecision` leaves the host's own handling intact,
+    so a warning costs the fallthrough nothing.
+    """
+    if advisory:
+        response = {"hookSpecificOutput": {"hookEventName": "PreToolUse"}}
+        print(json.dumps(attach_secret_advisory(response, advisory)))
+
+
+def _tool_log_subject(tool_name, tool_input):
+    """What goes in the log record's `command` field for a non-Bash call.
+
+    A path when the tool has one, the tool name otherwise. Deliberately
+    not the payload: a `Write` body can be a megabyte, and the log is
+    append-only.
+    """
+    for field in TOOL_WRITE_PATH_FIELDS.get(tool_name, ()):
+        target = tool_input.get(field)
+        if isinstance(target, str) and target.strip():
+            retval = "{} {}".format(tool_name, target)
+            return retval
+    retval = str(tool_name or "(no tool)")
+    return retval
+
+
+def classify_tool_input(tool_name, tool_input, is_unsafe_write):
+    """Decide a non-Bash tool call. Returns `(decision, reason)`.
+
+    Exactly one question is asked: does this write to a path that steers
+    the agent — settings, hooks, skills, commands, agents, memory, MCP
+    config — as listed in `rules/shell.json#unsafe_write_targets`? That
+    is the self-modification shape, and it is the one thing on the
+    non-delegable list that a non-Bash tool can reach today.
+
+    Everything else is `unknown`. This is not a second classifier for
+    structured tools and must not grow into one: the host's own vetting
+    covers the general case, and a rule set that tries to out-guess it
+    per tool is the treadmill this realignment exists to end. Issue #99.
+    """
+    from rule_classifier import DECISION_UNKNOWN, DECISION_UNSAFE
+
+    for field in TOOL_WRITE_PATH_FIELDS.get(tool_name, ()):
+        target = tool_input.get(field)
+        if isinstance(target, str) and target.strip() and is_unsafe_write(target):
+            retval = (
+                DECISION_UNSAFE,
+                "{} writes to protected path '{}'".format(tool_name, target),
+            )
+            return retval
+    retval = (DECISION_UNKNOWN, "no rule: {}".format(tool_name or "(no tool)"))
+    return retval
+
 
 def format_unsafe_reason(reason, allow_hint=None):
     from rule_classifier import UNANALYZABLE_INLINE_PYTHON_PREFIX
@@ -914,6 +1103,16 @@ SECRET_ADVISORY_HEADER = (
     "https://service/endpoint'"
 )
 
+# Non-Bash tools have no argv and no `ps` exposure, so the Bash remedy
+# does not apply and quoting it would be noise. The persistence half of
+# the warning is the half that still holds. Issue #99.
+SECRET_ADVISORY_HEADER_TOOL = (
+    "YOLT: possible credential in this {} call ({}). Not blocked.\n"
+    "It will persist in the transcript and in session memory, which "
+    "outlive the call. Pass it by reference (an env var, a secret-manager "
+    "lookup) rather than by value where the tool allows it."
+)
+
 # Any of these disables the warning. An exact `== "0"` test looks precise
 # and behaves as a trap: a user who reaches for `false` or `off` to
 # silence a noisy control sees no change and concludes it is broken.
@@ -922,8 +1121,14 @@ SECRET_WARN_OFF_VALUES = frozenset(
 )
 
 
-def format_secret_advisory(command):
+def format_secret_advisory(command, tool_name=None):
     """Build the credential warning for `command`, or None if clean.
+
+    `tool_name` selects the wording. Left unset (the Bash path) the
+    message keeps the `argv` / `ps` framing and the shell remedy. Set to
+    a non-Bash tool it drops both, because neither applies and advice
+    that does not apply is how a control earns its way into being
+    ignored. Issue #99.
 
     Advisory only — this never changes YOLT's decision. A control that
     false-positives on legitimate work gets switched off and then
@@ -957,7 +1162,10 @@ def format_secret_advisory(command):
     found = ", ".join(
         "{} at char {}".format(kind, start) for start, _, kind in spans
     )
-    retval = SECRET_ADVISORY_HEADER.format(found)
+    if tool_name:
+        retval = SECRET_ADVISORY_HEADER_TOOL.format(tool_name, found)
+    else:
+        retval = SECRET_ADVISORY_HEADER.format(found)
     return retval
 
 
@@ -1055,7 +1263,8 @@ def _maybe_rotate_log(log_path, max_bytes):
 
 
 def _log_hook_decision(command, decision, reason,
-                       permission_mode=None, agent_id=None):
+                       permission_mode=None, agent_id=None,
+                       tool_name="Bash"):
     """Append a JSON-line record of this hook fire to the resolved log
     path. Logs by default to `~/.claude/yolt.log`; the user can override
     with `YOLT_LOG_FILE=<path>` or opt out with `YOLT_LOG_FILE=""`.
@@ -1098,6 +1307,7 @@ def _log_hook_decision(command, decision, reason,
             "command": _redact_or_withhold(command)[:500] if command else "",
             "permission_mode": permission_mode,
             "agent_id": agent_id,
+            "tool_name": tool_name,
         }
         if REDACTOR_IMPORT_ERROR:
             record["redactor_error"] = REDACTOR_IMPORT_ERROR
@@ -1226,18 +1436,21 @@ def run_hook():
         sys.exit(0)
 
     tool_name = hook_input.get("tool_name", "")
-    if tool_name != "Bash":
-        sys.exit(0)
-
-    command = hook_input.get("tool_input", {}).get("command", "")
-    if not command.strip():
-        sys.exit(0)
+    tool_input = hook_input.get("tool_input") or {}
 
     # `agent_id` is present only when the hook fires inside a subagent
     # call; `permission_mode` is always present. Both are logged, and
     # `agent_id` also flips `ask` -> `deny` below. See issue #76.
     permission_mode = hook_input.get("permission_mode")
     agent_id = hook_input.get("agent_id")
+
+    if tool_name != "Bash":
+        _run_hook_non_bash(tool_name, tool_input, permission_mode, agent_id)
+        return  # unreachable; _run_hook_non_bash always exits
+
+    command = tool_input.get("command", "")
+    if not command.strip():
+        sys.exit(0)
 
     yolt_dir = Path(__file__).resolve().parent.parent
     py_rules = load_rules(
@@ -1288,17 +1501,7 @@ def run_hook():
     if decision == DECISION_UNSAFE:
         allow_hint = classifier.suggest_allow_pattern(command)
         message = format_unsafe_reason(reason, allow_hint)
-        if agent_id:
-            # No operator is reachable from a background subagent: the
-            # `ask` dialog never surfaces and nothing times out, so the
-            # agent wedges indefinitely. `deny` is strictly more
-            # restrictive than `ask` and fails in seconds with a reason
-            # the agent can report upward. Issue #76.
-            response = make_hook_response(
-                "deny", SUBAGENT_DENY_PREFIX + message
-            )
-        else:
-            response = make_hook_response("ask", message)
+        response = make_gated_response(message, permission_mode, agent_id)
         print(json.dumps(attach_secret_advisory(response, advisory)))
         sys.exit(0)
 

--- a/tests/test_non_bash_tools.py
+++ b/tests/test_non_bash_tools.py
@@ -1,0 +1,335 @@
+"""PreToolUse on tools other than Bash (issue #99).
+
+The matcher widened from `Bash` to `*` because the subagent wedge #80
+observed was a `Write`, not a Bash call — a guard registered on one tool
+is not a guard.
+
+Only two things happen on the non-Bash path, and these tests pin both
+plus the boundary between them:
+
+  1. the agent-steering write check, over a **closed** list of
+     path-carrying fields;
+  2. the credential advisory, over every string in the payload.
+
+Everything else falls through to the host. The negative tests matter more
+than the positive ones here: this path must not grow into a second
+classifier for structured tools.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+HOOKS_DIR = REPO_ROOT / "hooks"
+sys.path.insert(0, str(HOOKS_DIR))
+
+from yolt_analyzer import (  # noqa: E402
+    TOOL_WRITE_PATH_FIELDS,
+    classify_tool_input,
+    tool_input_text,
+)
+
+FAKE_TOKEN = "ghp_" + "D" * 36
+PROTECTED = "~/.claude/settings.json"
+
+
+def run_hook(payload, env=None):
+    """Fire the PreToolUse hook and return the parsed response, or None."""
+    run_env = dict(os.environ)
+    if env:
+        run_env.update(env)
+    result = subprocess.run(
+        [sys.executable, str(HOOKS_DIR / "yolt_analyzer.py"), "--hook"],
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env=run_env,
+    )
+    assert result.returncode == 0, result.stderr[:500]
+    out = result.stdout.strip()
+    if not out:
+        retval = None
+        return retval
+    retval = json.loads(out.splitlines()[-1])
+    return retval
+
+
+def decision_of(response):
+    if response is None:
+        retval = None
+        return retval
+    retval = response.get("hookSpecificOutput", {}).get("permissionDecision")
+    return retval
+
+
+def protected_path():
+    retval = str(Path.home() / ".claude" / "settings.json")
+    return retval
+
+
+class TestAgentSteeringWrites(unittest.TestCase):
+    """A write to a path that steers the agent is the one thing this path
+    objects to. It is the self-modification shape, and it is reachable
+    from a structured tool without any shell involved."""
+
+    def test_write_to_protected_path_asks(self):
+        resp = run_hook({
+            "tool_name": "Write",
+            "tool_input": {"file_path": protected_path(), "content": "x"},
+        })
+        self.assertEqual(decision_of(resp), "ask")
+        self.assertIn(
+            "protected path",
+            resp["hookSpecificOutput"]["permissionDecisionReason"],
+        )
+
+    def test_write_to_ordinary_path_is_silent(self):
+        resp = run_hook({
+            "tool_name": "Write",
+            "tool_input": {"file_path": "/tmp/ordinary.txt", "content": "x"},
+        })
+        self.assertIsNone(resp)
+
+    def test_every_listed_tool_and_field_is_wired(self):
+        # Guards the table itself: a field added to TOOL_WRITE_PATH_FIELDS
+        # without the classifier honouring it would be silently inert.
+        for tool, fields in TOOL_WRITE_PATH_FIELDS.items():
+            for field in fields:
+                resp = run_hook({
+                    "tool_name": tool,
+                    "tool_input": {field: protected_path()},
+                })
+                self.assertEqual(
+                    decision_of(resp), "ask",
+                    "{}.{} did not gate a protected write".format(tool, field),
+                )
+
+    def test_home_relative_form_is_matched(self):
+        resp = run_hook({
+            "tool_name": "Write",
+            "tool_input": {"file_path": PROTECTED, "content": "x"},
+        })
+        self.assertEqual(decision_of(resp), "ask")
+
+
+class TestClosedFieldList(unittest.TestCase):
+    """The write-target field list is closed on purpose. Guessing which
+    field of an arbitrary payload is a write target eventually guesses
+    wrong, and a wrong guess here is a false `deny` in a subagent — the
+    wedge this hook exists to avoid."""
+
+    def test_unlisted_tool_falls_through_even_with_a_protected_path(self):
+        resp = run_hook({
+            "tool_name": "SomeOtherTool",
+            "tool_input": {"file_path": protected_path()},
+        })
+        self.assertIsNone(resp)
+
+    def test_unlisted_field_on_a_listed_tool_falls_through(self):
+        resp = run_hook({
+            "tool_name": "Write",
+            "tool_input": {"destination": protected_path(), "content": "x"},
+        })
+        self.assertIsNone(resp)
+
+    def test_mcp_tool_with_a_pathlike_argument_falls_through(self):
+        resp = run_hook({
+            "tool_name": "mcp__fs__write_file",
+            "tool_input": {"path": protected_path(), "contents": "x"},
+        })
+        self.assertIsNone(resp)
+
+    def test_classify_is_pure_and_defaults_to_unknown(self):
+        never = lambda target: False  # noqa: E731
+        decision, reason = classify_tool_input(
+            "Write", {"file_path": protected_path()}, never,
+        )
+        self.assertEqual(decision, "unknown")
+        self.assertIn("no rule", reason)
+
+
+class TestSubagentModeAwareness(unittest.TestCase):
+    """#80 gap 1. `ask` becomes `deny` in a subagent because nothing can
+    answer an ask there — except in modes where the operator already
+    blanket-authorised, where the conversion would override them."""
+
+    def _decision(self, mode, agent_id="agent_probe"):
+        payload = {
+            "tool_name": "Write",
+            "tool_input": {"file_path": protected_path(), "content": "x"},
+            "permission_mode": mode,
+        }
+        if agent_id:
+            payload["agent_id"] = agent_id
+        retval = decision_of(run_hook(payload))
+        return retval
+
+    def test_main_session_asks_in_every_mode(self):
+        for mode in ("default", "acceptEdits", "plan", "auto",
+                     "bypassPermissions", "dontAsk"):
+            self.assertEqual(self._decision(mode, agent_id=None), "ask", mode)
+
+    def test_subagent_denies_in_prompting_modes(self):
+        for mode in ("default", "acceptEdits", "plan"):
+            self.assertEqual(self._decision(mode), "deny", mode)
+
+    def test_subagent_asks_where_operator_pre_authorised(self):
+        # bypassPermissions / dontAsk: there was no prompt to hang on, so
+        # converting to deny would override an explicit authorisation
+        # rather than protect anything.
+        for mode in ("bypassPermissions", "dontAsk"):
+            self.assertEqual(self._decision(mode), "ask", mode)
+
+    def test_subagent_under_auto_still_denies(self):
+        # Deliberate deviation from the mode list in #80. Auto mode
+        # delegates the decision to a classifier; it does not put an
+        # operator behind a hook's `ask`, so a subagent receiving one has
+        # nobody to answer it. A wrong deny costs seconds; the wrong ask
+        # wedged an agent for 2h37m in the #80 probe.
+        self.assertEqual(self._decision("auto"), "deny")
+
+    def test_absent_permission_mode_denies_in_a_subagent(self):
+        # Fail toward the restrictive side when the payload omits it.
+        self.assertEqual(self._decision(None), "deny")
+
+
+class TestCredentialAdvisory(unittest.TestCase):
+    """The advisory follows the payload, not the shell."""
+
+    def _advisory(self, payload):
+        resp = run_hook(payload)
+        retval = (resp or {}).get("systemMessage")
+        return retval
+
+    def test_fires_on_a_credential_in_a_write_body(self):
+        adv = self._advisory({
+            "tool_name": "Write",
+            "tool_input": {
+                "file_path": "/tmp/cfg.env",
+                "content": "GH_TOKEN={}\n".format(FAKE_TOKEN),
+            },
+        })
+        self.assertIsNotNone(adv)
+        self.assertIn("Write", adv)
+
+    def test_fires_on_a_credential_nested_in_an_mcp_payload(self):
+        adv = self._advisory({
+            "tool_name": "mcp__svc__call",
+            "tool_input": {
+                "args": {"headers": [{"Authorization": "Bearer " + FAKE_TOKEN}]},
+            },
+        })
+        self.assertIsNotNone(adv)
+
+    def test_never_echoes_the_value(self):
+        # A warning that quotes the secret puts the secret into the
+        # transcript it is warning about.
+        resp = run_hook({
+            "tool_name": "Write",
+            "tool_input": {"file_path": "/tmp/x", "content": FAKE_TOKEN},
+        })
+        self.assertNotIn(FAKE_TOKEN, json.dumps(resp))
+
+    def test_wording_drops_the_argv_advice(self):
+        # `argv` and `ps` do not apply to a structured tool, and advice
+        # that does not apply is how a control earns its way into being
+        # ignored.
+        adv = self._advisory({
+            "tool_name": "Write",
+            "tool_input": {"file_path": "/tmp/x", "content": FAKE_TOKEN},
+        })
+        self.assertNotIn("argv", adv)
+        self.assertNotIn("ps", adv.split("\n")[0])
+
+    def test_bash_wording_is_unchanged(self):
+        adv = self._advisory({
+            "tool_name": "Bash",
+            "tool_input": {
+                "command": "curl -H 'Authorization: Bearer {}' https://x".format(
+                    FAKE_TOKEN),
+            },
+        })
+        self.assertIn("argv", adv)
+        self.assertIn("command line", adv)
+
+    def test_does_not_change_the_decision(self):
+        # Same call with and without a credential must decide identically.
+        clean = run_hook({
+            "tool_name": "Write",
+            "tool_input": {"file_path": protected_path(), "content": "x"},
+        })
+        dirty = run_hook({
+            "tool_name": "Write",
+            "tool_input": {"file_path": protected_path(),
+                           "content": FAKE_TOKEN},
+        })
+        self.assertEqual(decision_of(clean), decision_of(dirty))
+        self.assertIsNotNone(dirty.get("systemMessage"),
+                             "vacuous: the credential case did not warn")
+
+    def test_kill_switch_applies_to_the_tool_path_too(self):
+        adv = self._advisory({
+            "tool_name": "Write",
+            "tool_input": {"file_path": "/tmp/x", "content": FAKE_TOKEN},
+        })
+        self.assertIsNotNone(adv)
+        resp = run_hook(
+            {"tool_name": "Write",
+             "tool_input": {"file_path": "/tmp/x", "content": FAKE_TOKEN}},
+            env={"YOLT_SECRET_WARN": "off"},
+        )
+        self.assertIsNone(resp)
+
+
+class TestToolInputFlattening(unittest.TestCase):
+    def test_walks_dicts_lists_and_scalars(self):
+        text = tool_input_text({
+            "a": "one",
+            "b": ["two", {"c": "three"}],
+            "d": 4,
+            "e": None,
+        })
+        for expected in ("one", "two", "three"):
+            self.assertIn(expected, text)
+
+    def test_empty_input_is_empty_text(self):
+        self.assertEqual(tool_input_text({}), "")
+
+
+class TestLogRecord(unittest.TestCase):
+    def test_record_carries_tool_name_and_a_bounded_subject(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            log = Path(tmp) / "yolt.log"
+            run_hook(
+                {"tool_name": "Write",
+                 "tool_input": {"file_path": "/tmp/ordinary.txt",
+                                "content": "y" * 5000}},
+                env={"YOLT_LOG_FILE": str(log)},
+            )
+            record = json.loads(log.read_text().strip().splitlines()[-1])
+        self.assertEqual(record["tool_name"], "Write")
+        # The payload is not the subject: a Write body can be a megabyte
+        # and this log is append-only.
+        self.assertIn("/tmp/ordinary.txt", record["command"])
+        self.assertNotIn("yyyy", record["command"])
+
+    def test_bash_records_still_say_bash(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            log = Path(tmp) / "yolt.log"
+            run_hook(
+                {"tool_name": "Bash", "tool_input": {"command": "ls /tmp"}},
+                env={"YOLT_LOG_FILE": str(log)},
+            )
+            record = json.loads(log.read_text().strip().splitlines()[-1])
+        self.assertEqual(record["tool_name"], "Bash")
+        self.assertEqual(record["decision"], "safe")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Phase 2 of #102. **Targets `feature/auto-mode-realignment`, not master.** Closes #80.

## Why widen — the empirical version

Not symmetry with auto mode. **The subagent wedge in #80 hung on a `Write`**, so YOLT was never in its path; same in skillz#127, where six wedged agents never issued a Bash call at all. Across both observed incidents YOLT's deny would have fired in **neither**. A guard registered on one tool is not a guard.

## What the non-Bash path does — and what it deliberately does not

A structured tool has no argv, no shell, no rule lookup. Two things happen:

1. **Agent-steering write check** — a write to a path in `unsafe_write_targets` is `unsafe`. The self-modification shape, and the one thing on the non-delegable list a structured tool can reach today.
2. **Credential advisory** over every string in the payload, so a token in a `Write` body or nested in an MCP argument is caught like one on a command line. The wording drops the `argv` / `ps` framing — neither applies, and advice that does not apply is how a control earns its way into being ignored.

Everything else is `unknown`; the host decides.

`TOOL_WRITE_PATH_FIELDS` is a **closed list** (`Write`, `Edit`, `MultiEdit`, `NotebookEdit`). Guessing which field of an arbitrary MCP payload is a write target eventually guesses wrong, and a wrong guess is a false `deny` inside a subagent — the exact failure this exists to prevent. Four tests pin the closure, including an `mcp__fs__write_file` payload with a `path` argument pointing at a protected file, which correctly falls through.

**This must not become a second classifier for structured tools.** The host's own vetting covers the general case; a per-tool rule set is the treadmill the realignment is ending.

## #80 gap 1 — with a deliberate deviation

The `ask` -> `deny` conversion was gated on `agent_id` alone, so it fired in modes where the operator had blanket-authorised and no prompt could have hung. Now skipped under `bypassPermissions` and `dontAsk`.

**`auto` is not exempt, which departs from the mode list in the issue.** Auto mode delegates the *decision* to a classifier; it does not put an operator behind a hook's `ask`, so a subagent receiving one still has nobody to answer it. The costs are asymmetric — a wrong deny fails in seconds with a reason the agent reports upward; the wrong ask wedged an agent for **2h37m** in the #80 probe. Absent `permission_mode` denies for the same reason. Flagging it rather than quietly following the issue.

## Tests — verified non-vacuous

24 new tests. Run against the **pre-change** code, **16 of 24 fail**. The 8 that pass are fall-through guards (unlisted tool stays silent, ordinary path stays silent) which correctly hold on both sides — they pin the boundary, not the change. Saying so explicitly because the #104 review found me claiming pins that were not.

Also pinned: the advisory does not alter the decision (same call with and without a credential decides identically, with a vacuity guard requiring the credential case to actually warn), never echoes the value, and the `YOLT_SECRET_WARN` kill switch reaches the new path.

**683 tests, green.**

## Logging

Records gain `tool_name`. For non-Bash the `command` field carries the target path, not the payload — a `Write` body can be a megabyte and this log is append-only.

## README

Documents the new surface, and states the thing #80 asked for explicitly: **"YOLT denies in subagents" is not "subagent wedges are handled"**. The deny only converts YOLT's own ask; any other gated call in a background subagent still hangs, and that fix belongs upstream in Claude Code.

## Version

None — phase PRs merge into the umbrella and do not ship.