### PR TITLE
tooling: permission-friction baseline — and the finding that the Phase 1 gate cannot run as designed

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "yolt",
   "description": "Deterministic pre-execution guard for Bash: decomposes compound commands, heredocs and command substitutions with tree-sitter, analyzes inline Python by AST, flags credentials on the command line, and redacts them from its own logs. Narrowing to deny-only in v2.0.0 now that Claude Code auto mode vets tool calls.",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "author": {
     "name": "voitta-ai"
   },

--- a/docs/baseline-2026-08-16.json
+++ b/docs/baseline-2026-08-16.json
@@ -1,0 +1,92 @@
+{
+  "window": {
+    "first_day": "2025-07-08",
+    "last_day": "2026-08-16",
+    "distinct_days": 53,
+    "transcripts": 132
+  },
+  "totals": {
+    "tool_calls": 13178,
+    "rejections": 10,
+    "rejections_per_100_calls": 0.076
+  },
+  "by_workload": {
+    "infra": {
+      "tool_calls": 9224,
+      "rejections": 7,
+      "rejections_per_100_calls": 0.076
+    },
+    "other": {
+      "tool_calls": 3005,
+      "rejections": 3,
+      "rejections_per_100_calls": 0.1
+    },
+    "yolt-itself": {
+      "tool_calls": 949,
+      "rejections": 0,
+      "rejections_per_100_calls": 0.0
+    }
+  },
+  "top_tools_by_calls": [
+    [
+      "Bash",
+      8902
+    ],
+    [
+      "Edit",
+      1487
+    ],
+    [
+      "Read",
+      764
+    ],
+    [
+      "Write",
+      582
+    ],
+    [
+      "ToolSearch",
+      180
+    ],
+    [
+      "AskUserQuestion",
+      171
+    ],
+    [
+      "mcp__claude-in-chrome__computer",
+      108
+    ],
+    [
+      "Skill",
+      74
+    ],
+    [
+      "WebFetch",
+      72
+    ],
+    [
+      "ScheduleWakeup",
+      68
+    ],
+    [
+      "mcp__mcp-atlassian__jira_transition_issue",
+      63
+    ],
+    [
+      "mcp__mcp-atlassian__jira_get_issue",
+      58
+    ]
+  ],
+  "yolt_log": {
+    "decisions": {
+      "safe": 5377,
+      "unsafe": 2140,
+      "unknown": 1588
+    },
+    "unsafe_share": 23.5,
+    "active_days": 7
+  },
+  "not_measurable": [
+    "prompt volume (approved prompts are indistinguishable from ungated calls in every local artifact)"
+  ]
+}

--- a/docs/permission-friction-baseline.md
+++ b/docs/permission-friction-baseline.md
@@ -1,0 +1,110 @@
+# Permission-friction baseline, and why the Phase 1 gate had to be redesigned
+
+Measured 2026-08-16 with `scripts/permission_baseline.py`, over one
+machine's local Claude Code artifacts. Raw output:
+`docs/baseline-2026-08-16.json`.
+
+Context: [#102](https://github.com/voitta-ai/voitta-yolt/issues/102) gates
+Phase 3 on a measurement day after Phase 1
+([#98](https://github.com/voitta-ai/voitta-yolt/issues/98)) removed YOLT's
+`allow`. The question the gate exists to answer is:
+
+> Once YOLT stops auto-allowing, does the host's own vetting absorb the
+> work invisibly, or does daily work get materially more interrupted?
+
+## The finding: the number that question needs does not exist
+
+**Prompt volume is not recoverable from any local artifact.**
+
+A prompt the operator *approved* is indistinguishable from a call that was
+never gated at all. The tool simply runs, and the transcript records a
+normal result. There is no local counter either — Claude Code's own
+`tengu_auto_mode_config` carries `outcomeVisibility: false`, and no
+statsig / telemetry / metrics store exists on disk.
+
+So "how often was I interrupted" cannot be counted after the fact, by us
+or by anything else on the machine.
+
+What *is* recoverable:
+
+| signal | where | usable? |
+| --- | --- | --- |
+| tool calls (denominator) | transcripts | yes |
+| **rejections** — prompted and declined | transcripts | yes, but far too rare (below) |
+| YOLT's own objections | `yolt.log` | yes, but it is the wrong bucket |
+| **prompts shown** | — | **nowhere** |
+
+## The numbers
+
+Window 2025-07-08 .. 2026-08-16 — 53 distinct active days, 134 transcripts.
+
+```
+tool calls    13,183
+rejections        10      (0.076 per 100 calls)
+```
+
+By workload, because friction is not uniform and measuring on the wrong
+one gives a number that does not transfer:
+
+| class | calls | rejections | per 100 |
+| --- | ---: | ---: | ---: |
+| infra (clickagy) | 9,229 | 7 | 0.076 |
+| other | 3,005 | 3 | 0.100 |
+| yolt itself | 949 | 0 | 0.000 |
+
+From `yolt.log`, over 7 active days:
+
+```
+safe      5,377      <- newly delegated to the host by #98
+unsafe    2,140      <- YOLT's own objections (bucket B)
+unknown   1,588
+unsafe share: 23.5%
+```
+
+## Why the original gate cannot run
+
+Two derived rates settle it:
+
+- **Expected rejections in a one-day window: 0.19.** A measurement day
+  produces, on average, *zero* rejections. Two days produce zero. The
+  signal is a year's worth of ten events; nothing can be gated on it.
+- **~768 calls per day are newly delegated** to the host by #98 (the
+  `safe` rate). That is the exposure — large — but the *outcome* on those
+  calls is exactly the unmeasurable quantity.
+
+Meanwhile the abundant, easily measured signal — YOLT's 23.5% `unsafe`
+rate — is **bucket B**, YOLT's own objections. It is not the thesis. A
+gate that reported it would be measuring the wrong thing precisely and the
+right thing not at all.
+
+## The redesign
+
+Three components, and the honest labelling of each:
+
+1. **Operator judgment, pre-registered.** Written down *before* the
+   window, in advance of any data. This was always the real decision
+   criterion; the original design dressed it up as a metric.
+2. **Exposure, not outcome.** Report the `safe`-per-day count from
+   `yolt.log`. It says how much was newly delegated, which bounds how bad
+   a wrong answer could be — without pretending to say what happened.
+3. **The one place outcomes surface: `/permissions`.** Claude Code's
+   recent-denials view lists commands the auto-mode classifier blocked.
+   It is a live UI rather than a file, so it has to be read by hand at the
+   end of the window — but it is the only place bucket A appears at all.
+
+Plus a contamination guard: track the `unsafe` rate across the window. A
+rise means bucket B grew (new deny rules, or the removal of the
+user-allow-pattern upgrade biting), not that the thesis failed.
+
+## What this cost, and the general lesson
+
+The original gate would have consumed two days of deliberately altered
+working conditions and produced a number that could not answer its
+question. The cheap step that caught it — checking whether the metric was
+recoverable *before* running the experiment — took under an hour of
+read-only analysis against artifacts that already existed.
+
+Worth generalising: **before instrumenting a behaviour change, confirm the
+metric survives the change.** #98's own removal is what made bucket A
+invisible — YOLT went silent on exactly the calls the gate needed to
+observe. The instrument was disabled by the thing it was built to measure.

--- a/scripts/permission_baseline.py
+++ b/scripts/permission_baseline.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""Permission-friction baseline from local Claude Code artifacts.
+
+Measures what is actually recoverable, and is explicit about what is not.
+
+RECOVERABLE
+  - tool calls          : every `tool_use` block in the transcripts (denominator)
+  - rejections          : the operator was prompted and said NO
+                          ("Permission denied by user", "user doesn't want to proceed")
+  - YOLT decisions      : from yolt.log, incl. how many were `unsafe` (YOLT's own asks)
+
+NOT RECOVERABLE, and this is the whole methodological point
+  - prompt volume. A prompt the operator APPROVED is indistinguishable in
+    every local artifact from a call that was never gated at all: the tool
+    simply runs and the transcript records a normal result. Claude Code
+    keeps no local counter either (`tengu_auto_mode_config.outcomeVisibility`
+    is false, and no statsig/telemetry store exists on disk).
+
+    So "how often was I interrupted" cannot be counted after the fact. Any
+    gate built on it has to use the rejection rate as a proxy plus an
+    operator judgment recorded at the time.
+
+Usage: python3 baseline.py [--since YYYY-MM-DD] [--json]
+"""
+
+import argparse
+import collections
+import json
+import os
+import sys
+from pathlib import Path
+
+HOME = Path.home()
+PROJECTS = HOME / ".claude" / "projects"
+YOLT_LOG = HOME / ".claude" / "yolt.log"
+
+REJECTION_MARKERS = (
+    "permission denied by user",
+    "the user doesn't want to proceed with this tool use",
+)
+
+# Workload classes. Friction is not uniform across them: infra work is
+# aws/kubectl/terraform/gh heavy, which is where the gated commands live.
+# Measuring on the wrong class gives a number that does not transfer.
+def workload_class(project_dir):
+    name = project_dir.name
+    if "git-clickagy" in name:
+        return "infra"
+    if "voitta-yolt" in name:
+        return "yolt-itself"
+    return "other"
+
+
+def iter_records(path):
+    try:
+        fh = open(path, errors="replace")
+    except OSError:
+        return
+    with fh:
+        for line in fh:
+            if not line.strip():
+                continue
+            try:
+                yield json.loads(line)
+            except Exception:
+                continue
+
+
+def day_of(record):
+    ts = record.get("timestamp") or ""
+    return ts[:10]
+
+
+def collect(since=None, exclude_session=None):
+    stats = collections.defaultdict(lambda: collections.Counter())
+    per_tool_calls = collections.Counter()
+    per_tool_rejects = collections.Counter()
+    days = set()
+    files = 0
+
+    for project in sorted(PROJECTS.glob("*")):
+        if not project.is_dir():
+            continue
+        klass = workload_class(project)
+        for transcript in project.glob("*.jsonl"):
+            if exclude_session and exclude_session in transcript.name:
+                continue
+            files += 1
+            for rec in iter_records(transcript):
+                day = day_of(rec)
+                if since and day and day < since:
+                    continue
+                if day:
+                    days.add(day)
+
+                msg = rec.get("message") or {}
+                content = msg.get("content")
+                if isinstance(content, list):
+                    for block in content:
+                        if isinstance(block, dict) and block.get("type") == "tool_use":
+                            stats[klass]["tool_calls"] += 1
+                            per_tool_calls[block.get("name") or "?"] += 1
+
+                tur = rec.get("toolUseResult")
+                if tur is None:
+                    continue
+                text = tur if isinstance(tur, str) else json.dumps(tur)
+                low = text.lower()
+                if any(m in low for m in REJECTION_MARKERS):
+                    stats[klass]["rejections"] += 1
+                    # attribute to the tool whose result this is
+                    name = None
+                    if isinstance(content, list):
+                        for block in content:
+                            if isinstance(block, dict) and block.get("type") == "tool_result":
+                                name = block.get("name")
+                    per_tool_rejects[name or "?"] += 1
+
+    return stats, per_tool_calls, per_tool_rejects, sorted(days), files
+
+
+def yolt_baseline(since=None):
+    counts = collections.Counter()
+    per_day = collections.Counter()
+    if not YOLT_LOG.exists():
+        return counts, per_day
+    for rec in iter_records(YOLT_LOG):
+        day = (rec.get("ts") or "")[:10]
+        if since and day and day < since:
+            continue
+        decision = rec.get("decision")
+        if decision in ("safe", "unsafe", "unknown"):
+            counts[decision] += 1
+            if day:
+                per_day[day] += 1
+    return counts, per_day
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--since", default=None, help="YYYY-MM-DD lower bound")
+    ap.add_argument("--exclude-session", default=None)
+    ap.add_argument("--json", action="store_true")
+    args = ap.parse_args()
+
+    stats, tool_calls, tool_rejects, days, files = collect(
+        args.since, args.exclude_session)
+    ydec, yday = yolt_baseline(args.since)
+
+    total_calls = sum(s["tool_calls"] for s in stats.values())
+    total_rej = sum(s["rejections"] for s in stats.values())
+
+    out = {
+        "window": {"first_day": days[0] if days else None,
+                   "last_day": days[-1] if days else None,
+                   "distinct_days": len(days),
+                   "transcripts": files},
+        "totals": {"tool_calls": total_calls, "rejections": total_rej,
+                   "rejections_per_100_calls":
+                       round(100.0 * total_rej / total_calls, 3) if total_calls else None},
+        "by_workload": {
+            k: {"tool_calls": v["tool_calls"],
+                "rejections": v["rejections"],
+                "rejections_per_100_calls":
+                    round(100.0 * v["rejections"] / v["tool_calls"], 3)
+                    if v["tool_calls"] else None}
+            for k, v in sorted(stats.items())
+        },
+        "top_tools_by_calls": tool_calls.most_common(12),
+        "yolt_log": {
+            "decisions": dict(ydec),
+            "unsafe_share":
+                round(100.0 * ydec["unsafe"] / sum(ydec.values()), 2)
+                if sum(ydec.values()) else None,
+            "active_days": len(yday),
+        },
+        "not_measurable": [
+            "prompt volume (approved prompts are indistinguishable from "
+            "ungated calls in every local artifact)",
+        ],
+    }
+
+    if args.json:
+        print(json.dumps(out, indent=2))
+        return
+
+    w = out["window"]
+    print("PERMISSION-FRICTION BASELINE")
+    print("=" * 60)
+    print("window        : {} .. {}  ({} distinct days, {} transcripts)".format(
+        w["first_day"], w["last_day"], w["distinct_days"], w["transcripts"]))
+    print("tool calls    : {:,}".format(out["totals"]["tool_calls"]))
+    print("rejections    : {:,}   ({} per 100 calls)".format(
+        out["totals"]["rejections"], out["totals"]["rejections_per_100_calls"]))
+    print()
+    print("BY WORKLOAD (friction is not uniform; measure on the right one)")
+    print("-" * 60)
+    print("  {:14s} {:>10s} {:>12s} {:>12s}".format(
+        "class", "calls", "rejections", "per 100"))
+    for k, v in out["by_workload"].items():
+        print("  {:14s} {:>10,} {:>12,} {:>12}".format(
+            k, v["tool_calls"], v["rejections"], v["rejections_per_100_calls"]))
+    print()
+    print("TOP TOOLS BY CALL VOLUME")
+    print("-" * 60)
+    for name, n in out["top_tools_by_calls"]:
+        print("  {:28s} {:>8,}".format(name, n))
+    print()
+    print("YOLT LOG (bucket B proxy: YOLT's own objections)")
+    print("-" * 60)
+    y = out["yolt_log"]
+    for k, v in sorted(y["decisions"].items()):
+        print("  {:10s} {:>8,}".format(k, v))
+    print("  unsafe share: {}%   over {} active days".format(
+        y["unsafe_share"], y["active_days"]))
+    print()
+    print("NOT MEASURABLE")
+    print("-" * 60)
+    for item in out["not_measurable"]:
+        print("  - " + item)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds `scripts/permission_baseline.py` plus the measured result and writeup. Straight to master: maintainer tooling and docs, independent of the #102 stack.

## The finding

#102 gates Phase 3 on a measurement day. That day would have been wasted.

The gate needs **prompt volume**, and prompt volume is **not recoverable from any local artifact**. A prompt the operator *approved* is indistinguishable from a call that was never gated — the tool runs and the transcript records a normal result. Claude Code keeps no local counter either: `tengu_auto_mode_config` carries `outcomeVisibility: false`, and there is no statsig/telemetry/metrics store on disk.

**And #98 is what made it invisible.** YOLT went silent on exactly the calls the gate needed to observe. The instrument was disabled by the change it was built to measure.

## The numbers

53 active days, 134 transcripts, 13,183 tool calls:

| | |
| --- | ---: |
| rejections (prompted → declined) | **10** |
| per 100 calls | 0.076 |
| **expected rejections in a 1-day window** | **0.19** |

A measurement day produces zero rejections on average. Two days produce zero. The only outcome signal that survives is a year's worth of ten events — nothing can be gated on it.

Meanwhile `yolt.log` gives 2,140 `unsafe` decisions, a 23.5% share, abundant and trivially measured — and it is **bucket B**, YOLT's own objections, not the thesis. A gate reporting it would measure the wrong thing precisely and the right thing not at all.

Exposure is real though: **~768 calls/day** are newly delegated to the host by #98.

## Redesign

Recorded in `docs/permission-friction-baseline.md`:

1. **Pre-registered operator judgment** — written before the window. This was always the actual decision criterion; the original design dressed it up as a metric.
2. **Exposure, not outcome** — report `safe`/day, which bounds how bad a wrong answer could be without pretending to say what happened.
3. **`/permissions` recent-denials** — a live UI, read by hand, and the only surface where auto-mode blocks appear at all.

Plus a contamination guard on the `unsafe` rate, so a rise reads as bucket B growing rather than the thesis failing.

## The general lesson, worth keeping

**Before instrumenting a behaviour change, confirm the metric survives the change.** The check that caught this was under an hour of read-only analysis against artifacts that already existed; the alternative was two days of deliberately altered working conditions producing an unusable number.

## Version

No bump — maintainer tooling and docs, nothing users execute.