### PR TITLE
ci: tag and cut releases automatically from the plugin version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,84 @@
+name: release
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    # Deliberately master-only, unlike ci.yml. A phase PR into a
+    # 'feature/**' umbrella branch is not a shipping merge, and demanding a
+    # version bump on each phase would just produce a stack of dead
+    # intermediate versions.
+    branches: [master]
+    # The bump exemption from CLAUDE.md, expressed as a path filter rather
+    # than a skip label: users never execute these, so a PR touching only
+    # them is not shipping anything. A PR that also touches shipped files
+    # runs the gate normally.
+    paths-ignore:
+      - '.github/**'
+      - 'tests/**'
+      - 'HANDOFF.md'
+      - 'CLAUDE.md'
+
+permissions:
+  contents: read
+
+env:
+  VERSION_FILE: .claude-plugin/plugin.json
+
+jobs:
+  # PR side. Nothing ships without a version bump: the version is the cache
+  # key for ~/.claude/plugins/cache/<marketplace>/<plugin>/<version>/, so an
+  # unchanged version means no install ever re-extracts and every user keeps
+  # running the old build, with no error reported anywhere.
+  version-bumped:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Version must advance
+        env:
+          BASE: ${{ github.base_ref }}
+        run: |
+          git fetch --no-tags --depth=1 origin "$BASE"
+          old=$(git show "FETCH_HEAD:$VERSION_FILE" | jq -r .version)
+          new=$(jq -r .version "$VERSION_FILE")
+          if [ "$old" = "$new" ]; then
+            echo "::error::$VERSION_FILE#version is still $old - bump it."
+            exit 1
+          fi
+          if [ "$(printf '%s\n%s\n' "$old" "$new" | sort -V | head -1)" != "$old" ]; then
+            echo "::error::$new does not advance past $old."
+            exit 1
+          fi
+          echo "$old -> $new"
+
+  # master side. The version is new by the time we get here, so cut the tag
+  # and the release. Notes come from the merged PR titles since the previous
+  # tag - that IS the changelog, which is why there is no CHANGELOG.md to
+  # keep in sync. gh creates the tag itself at --target, so it lands on
+  # master's squash commit rather than on a feature-branch commit that never
+  # reaches master.
+  tag-and-release:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Tag and release if the version is new
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          version=$(jq -r .version "$VERSION_FILE")
+          if git rev-parse -q --verify "refs/tags/v$version" >/dev/null; then
+            echo "v$version is already tagged; nothing to release."
+            exit 0
+          fi
+          gh release create "v$version" \
+            --title "v$version" \
+            --generate-notes \
+            --target "$GITHUB_SHA"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,29 +43,33 @@ The plugin is pre-1.0, so the compatibility contract being versioned is
 
 When a single PR mixes levels, take the highest one.
 
-### Tagging, and why `scripts/release.sh` only half-fits
+### Tagging and release notes are automatic
 
-`scripts/release.sh <version>` rewrites `plugin.json`, commits
-`Release v<version>`, and tags. The commit-and-tag half does not fit this
-repo: master takes squash merges, so a tag created on a feature branch
-points at a commit that never lands on master.
+Do not tag by hand. `.github/workflows/release.yml` owns both halves:
 
-Sequence that works:
+1. On a PR into master, the `version-bumped` job fails the PR unless
+   `.claude-plugin/plugin.json#version` advances past master's. That is the
+   enforcement behind "every shipping merge bumps" above. The exemption
+   above is a `paths-ignore` on the workflow's `pull_request` trigger: a PR
+   touching only `.github/`, `tests/`, `HANDOFF.md` or `CLAUDE.md` skips
+   the gate. Keep the two lists in sync.
+2. On the resulting push to master, the `tag-and-release` job reads the
+   version, and if `v<version>` is not already a tag, creates the tag and a
+   GitHub release at master's squash commit with `--generate-notes`.
 
-1. Edit `.claude-plugin/plugin.json#version` as part of the PR's own
-   changes. (`scripts/release.sh` is still handy for the rewrite+validation
-   — it refuses a non-semver or non-advancing version — but drop its commit
-   and tag, or just edit the field by hand.)
-2. Merge the PR (squash).
-3. Tag master's squash commit and push:
+So the only manual step is editing the version field inside the PR.
+`scripts/release.sh <version>` is still useful for that rewrite — it
+refuses a non-semver or non-advancing version — but drop its commit and
+tag, or just edit the field by hand.
 
-   ```
-   git tag -a v0.3.0 -m "Release v0.3.0" <squash-sha>
-   git push origin v0.3.0
-   ```
+Two consequences worth knowing:
 
-Tagging creates no commit, so this respects the "no direct commits to
-master" rule.
+- **Release notes are the merged PR titles** since the previous tag. There
+  is no CHANGELOG.md to keep in sync, which means a lazy PR title is a
+  lazy release note. Write the title as the line you want users to read.
+- Tagging on master's squash commit is why this is a workflow and not a
+  local `git tag`: a tag made on a feature branch points at a commit that
+  never lands on master.
 
 ### Verifying an install actually updated
 


### PR DESCRIPTION
Six tags, zero releases, and a hand-tagging sequence in CLAUDE.md that only works if you remember it. This makes both halves automatic.

**PR side** — `version-bumped` fails a PR into master unless `.claude-plugin/plugin.json#version` advances. The version is the cache key for `~/.claude/plugins/cache/<marketplace>/<plugin>/<version>/`, so an unchanged version means no install re-extracts and every user keeps running the old build, with no error reported anywhere. CLAUDE.md already required the bump; nothing enforced it.

**master side** — `tag-and-release` creates tag `v<version>` and a GitHub release at master's squash commit with `--generate-notes`. Release notes are the merged PR titles since the previous tag, so there is no CHANGELOG.md to keep in sync. `gh` creates the tag itself at `--target`, which is exactly the problem the manual sequence existed to dodge.

CLAUDE.md's bump exemption (`.github/`, `tests/`, `HANDOFF.md`) is carried as a `paths-ignore` on the `pull_request` trigger rather than a skip label — so this PR, touching only exempt paths, correctly skips its own gate and ships no bump. The first release fires on the next shipping merge.

Idempotent: if the tag already exists the job exits 0, so re-runs and concurrent merges converge rather than collide.

Existing tags v0.2.0..v1.0.1 stay releaseless. Backfill if wanted: `gh release create v1.0.0 --generate-notes --verify-tag` per tag.
