### PR TITLE
ci: gate the codex manifest too, and realign it

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "yolt",
   "description": "Deterministic pre-execution guard for Bash: decomposes compound commands, heredocs and command substitutions with tree-sitter, analyzes inline Python by AST, flags credentials on the command line, and redacts them from its own logs. Narrowing to deny-only in v2.0.0 now that Claude Code auto mode vets tool calls.",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "author": {
     "name": "voitta-ai"
   },

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "yolt",
-  "version": "0.1.0",
+  "version": "1.0.4",
   "description": "Deterministic pre-execution guard for Bash: decomposes compound commands, heredocs and command substitutions with tree-sitter, analyzes inline Python by AST, flags credentials on the command line, and redacts them from its own logs. Narrowing to deny-only in v2.0.0 now that Claude Code auto mode vets tool calls.",
   "author": {
     "name": "voitta-ai"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,12 @@ permissions:
 
 env:
   VERSION_FILE: .claude-plugin/plugin.json
+  # Codex pins on its own manifest's version string exactly as Claude Code does,
+  # so the two must move together or Codex installs freeze on a cached copy.
+  # Nothing guarded this before, which is how .codex-plugin drifted to 0.1.0
+  # while .claude-plugin was at 1.0.3. See claude-code-codex-plugin-parity in
+  # voitta-ai/skillz.
+  CODEX_VERSION_FILE: .codex-plugin/plugin.json
 
 jobs:
   # PR side. Nothing ships without a version bump: the version is the cache
@@ -39,7 +45,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Version must advance
+      - name: Version must advance, and both manifests must agree
         env:
           BASE: ${{ github.base_ref }}
         run: |
@@ -54,7 +60,12 @@ jobs:
             echo "::error::$new does not advance past $old."
             exit 1
           fi
-          echo "$old -> $new"
+          codex=$(jq -r .version "$CODEX_VERSION_FILE")
+          if [ "$codex" != "$new" ]; then
+            echo "::error::$CODEX_VERSION_FILE is $codex, expected $new - bump both manifests."
+            exit 1
+          fi
+          echo "$old -> $new (claude + codex in sync)"
 
   # master side. The version is new by the time we get here, so cut the tag
   # and the release. Notes come from the merged PR titles since the previous


### PR DESCRIPTION
Closes #112

`release.yml` gates on `.claude-plugin/plugin.json#version` only. Nothing checks
`.codex-plugin/plugin.json`, so the two manifests can drift silently - and they
have:

| manifest | version on master |
|---|---|
| `.claude-plugin/plugin.json` | 1.0.3 |
| `.codex-plugin/plugin.json` | **0.1.0** |

Codex pins on its own manifest's version string exactly as Claude Code does. The
version is the install cache key, so a Codex install sitting on 0.1.0 never
re-extracts and every Codex user keeps running an old build, with no error
reported anywhere. Claude Code users have been getting 1.0.1, 1.0.2, 1.0.3;
Codex users have been frozen since 0.1.0.

This matters now because the postmortem post (hq#136) points readers at YOLT, so
new installs are about to arrive on both hosts.

Fix: add `CODEX_VERSION_FILE` to the workflow and require the two manifests to
match, mirroring how voitta-ai/skillz does it, then bring codex up to the claude
version line.

---

Both manifests go to **1.0.4**. The gate had to be satisfied by this PR itself: it touches `.codex-plugin/plugin.json`, which is a shipped file and therefore not in `paths-ignore`, so the claude version had to advance too.

No change to the existing paths-ignore list or the tag-and-release job - both were already right.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TSkDoPbqDGU6CYEbZJMJLn
