### PR TITLE
Keep the newlines when rebuilding a multi-line double-quoted argument

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "yolt",
   "description": "Deterministic pre-execution guard for Bash: decomposes compound commands, heredocs and command substitutions with tree-sitter, analyzes inline Python by AST, flags credentials on the command line, and redacts them from its own logs. Narrowing to deny-only in v2.0.0 now that Claude Code auto mode vets tool calls.",
-  "version": "1.0.4",
+  "version": "1.1.0",
   "author": {
     "name": "voitta-ai"
   },

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "yolt",
-  "version": "1.0.4",
+  "version": "1.1.0",
   "description": "Deterministic pre-execution guard for Bash: decomposes compound commands, heredocs and command substitutions with tree-sitter, analyzes inline Python by AST, flags credentials on the command line, and redacts them from its own logs. Narrowing to deny-only in v2.0.0 now that Claude Code auto mode vets tool calls.",
   "author": {
     "name": "voitta-ai"

--- a/hooks/grammar_classifier.py
+++ b/hooks/grammar_classifier.py
@@ -289,8 +289,30 @@ class GrammarClassifier:
         return self._slice(node, src)
 
     def _reconstruct_string(self, node, src):
+        """Rebuild the value of a double-quoted string from its children.
+
+        The bytes between two adjacent children are part of the string and
+        have to be carried across (#115). tree-sitter-bash ends a
+        `string_content` run at a newline and starts a fresh one after it,
+        so a multi-line `"..."` arrives as one child per line with the
+        newlines belonging to no child at all. Concatenating only the
+        children welds every line onto the next: a multi-line
+        `python3 -c "..."` reached the Python analyzer as a single line,
+        `ast.parse` raised on it, and the inline path turned that into
+        "could not statically analyze inline python3 -c script (parser
+        bailed at line 1)" -- for every such command, since after the weld
+        there is only ever a line 1. The gate then parked read-only scripts
+        for a human, which is the safe direction but the wrong answer.
+
+        Gap bytes are copied verbatim rather than normalized to "\n": what
+        is uncovered is literal string text, and the analyzer downstream
+        wants it exactly as the shell would pass it."""
         out = []
+        prev_end = None
         for c in node.children:
+            if prev_end is not None and c.start_byte > prev_end:
+                out.append(src[prev_end:c.start_byte].decode("utf-8", "replace"))
+            prev_end = c.end_byte
             if c.type == '"':
                 continue
             if c.type in ("command_substitution", "process_substitution",

--- a/tests/test_grammar_classifier.py
+++ b/tests/test_grammar_classifier.py
@@ -415,6 +415,81 @@ class TestMultilineHandling(unittest.TestCase):
         self.assertDecision("# nothing to do", DECISION_SAFE)
 
 
+class TestMultilineDoubleQuotedString(unittest.TestCase):
+    """A double-quoted argument spanning lines keeps its newlines (#115).
+
+    tree-sitter-bash ends a `string_content` run at each newline, and the
+    newline itself is covered by no child -- so rebuilding the string from
+    its children alone welds the lines together. Nothing noticed for a long
+    time because the multi-line arguments already under test were SQL, where
+    a lost newline is still valid SQL. Python is where it shows: the welded
+    source raises in `ast.parse`, the inline `-c` path reports "parser bailed
+    at line 1" (always line 1 -- after the weld there is no other line), and
+    a read-only script is parked for a human to approve.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.clf = _make_classifier()
+
+    def assertDecision(self, cmd, expected):
+        d, r = self.clf.classify(cmd)
+        self.assertEqual(d, expected, msg="cmd={!r}, reason={}".format(cmd, r))
+
+    def test_read_only_inline_python_is_classified_by_content(self):
+        cmd = (
+            'python3 -c "\n'
+            "import json,sys\n"
+            "d=json.load(sys.stdin)\n"
+            "for m in d.get('messages',[]):\n"
+            "    print(m.get('ts'))\n"
+            '"'
+        )
+        self.assertDecision(cmd, DECISION_SAFE)
+
+    def test_destructive_inline_python_still_unsafe(self):
+        cmd = (
+            'python3 -c "\n'
+            "import shutil\n"
+            "shutil.rmtree('/Users/x/project')\n"
+            '"'
+        )
+        self.assertDecision(cmd, DECISION_UNSAFE)
+
+    def test_pipeline_into_multiline_python(self):
+        cmd = (
+            'curl -s "https://example.com/x.json" | python3 -c "\n'
+            "import json,sys\n"
+            "print(json.load(sys.stdin))\n"
+            '"'
+        )
+        self.assertDecision(cmd, DECISION_SAFE)
+
+    def test_newlines_survive_reconstruction_verbatim(self):
+        """The bytes between children are copied as they are, not normalized.
+
+        Asserted on the rebuilt argv rather than on a decision, because a
+        decision only shows that the source parsed -- it would still pass if
+        the newlines came back as a space or as an escape."""
+        cmd = 'python3 -c "\nimport os\nprint(os.getcwd())\n"'
+        src = cmd.encode("utf-8")
+        tree = self.clf._parser.parse(src)
+        commands = []
+        self.clf._collect_primary_command_nodes(tree.root_node, commands)
+        argv = self.clf._argv_from_command(commands[0], src)
+        self.assertEqual(argv[-1], "\nimport os\nprint(os.getcwd())\n")
+
+    def test_substitution_inside_multiline_string_is_still_masked(self):
+        """Gap-filling must not hand a command substitution back as text."""
+        cmd = 'echo "line one\n$(rm -rf /tmp/x)\nline three"'
+        src = cmd.encode("utf-8")
+        tree = self.clf._parser.parse(src)
+        commands = []
+        self.clf._collect_primary_command_nodes(tree.root_node, commands)
+        argv = self.clf._argv_from_command(commands[0], src)
+        self.assertNotIn("rm -rf", argv[-1])
+        self.assertEqual(argv[-1].count("\n"), 2)
+
 class TestValuelessGlobalFlags(unittest.TestCase):
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
Closes #115.

## The bug

`GrammarClassifier._reconstruct_string` rebuilt a double-quoted string by
concatenating the slices of the string node's children. tree-sitter-bash ends
a `string_content` run at each newline and starts a fresh one after it, and
the newline byte belongs to no child -- so every line got welded onto the
next.

Where that mattered is inline Python. A multi-line `python3 -c "..."` reached
`SafetyAnalyzer.analyze` as a single line, `ast.parse` raised at the seam, and
`classify_python_source`'s inline path turned that into:

```
could not statically analyze inline python3 -c script (parser bailed at line 1)
```

Always line 1 -- after the weld there is no other line -- and for every
multi-line inline script, read-only ones included. Fail-closed, so the answer
was safe in direction and wrong in substance: read-only inspection scripts got
parked for human approval.

## The fix

Carry the bytes between adjacent children across, verbatim. They are literal
string text, and the analyzer downstream wants them exactly as the shell would
pass them -- normalizing to `\n` would be a guess. The gap fill runs before the
per-child dispatch rather than instead of it, so a command substitution inside
a multi-line string is still masked with the placeholder.

Only double-quoted strings were affected; a `raw_string` (`python3 -c '...'`)
is taken as one slice.

## Before / after

| command | before | after |
| --- | --- | --- |
| `curl … \| python3 -c "<multi-line read-only>"` | unsafe -- parser bailed at line 1 | `safe` -- `curl: read-only; python: python3 -c ...` |
| `cd … && python3 -c "<multi-line read-only>"` | unsafe -- parser bailed at line 1 | `safe` -- `builtin: cd; python: python3 -c ...` |
| `python3 -c "<multi-line shutil.rmtree>"` | unsafe | unsafe (now on the finding, not the parse error) |

## Tests

Five in a new `TestMultilineDoubleQuotedString`. Four fail on master; the
fifth is the guard that a destructive multi-line script stays unsafe once it
does parse. Two assert on the rebuilt argv rather than on a decision, since a
decision only proves the source parsed -- it would still pass if the newlines
came back as spaces.

Full run: 200/200 in `test_grammar_classifier`. The suite-wide run has
pre-existing failures in `test_yolt_hook` that reproduce on master and are
#75 (the tests read the developer's real `~/.claude/settings.json`).

## Version

`1.0.4` -> `1.1.0`. Minor: this flips a real class of command from unsafe to
safe, which is user-visible at the permission prompt.

## Where it was found

voitta-ai/shmobster gates shell commands through this classifier and posts an
approval card to Slack for anything not `safe`. Three cards in one thread, two
of them this bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DrsoG6XaCr9VvWHfpqcMVX
