### PR TITLE
Phase 4: reuse #82's git predicates deny-side, with the failure semantics inverted

### DIFF
--- a/hooks/git_policy.py
+++ b/hooks/git_policy.py
@@ -334,6 +334,10 @@ class GitDenyPolicy:
             targets = _push_targets(argv, state.get("branch"))
             if not targets:
                 return None
+            if "*" in targets:
+                return ("pushes every branch (--all/--mirror), which "
+                        "includes the default branch ({})".format(
+                            default_branch))
             if default_branch in targets:
                 return "would push to the default branch ({})".format(
                     default_branch
@@ -371,21 +375,27 @@ def _push_targets(argv, current_branch):
     """Every branch a `git push` would land on, or None if argv cannot say.
 
     Returns a set. A push can name several refspecs at once, and taking only
-    the last one -- as an earlier version of this did -- lets
-    `git push origin master feature/x` slip past the default-branch guard,
-    because the guard only ever looked at `feature/x`.
+    the last one -- as the first version of this did -- let
+    `git push origin master feature/x` slip past the default-branch guard.
 
-    With no refspec, git pushes the current branch, so the answer comes from
-    repository state rather than the command. None means unresolvable, which
-    denies nothing:
+    The bulk flags are not interchangeable and must not be handled as one
+    group, which was the second bug here:
 
-    - `--all` / `--mirror` / `--tags` push a whole namespace rather than a
-      named branch, so the destination set is not derivable from argv.
-    - a variable, a glob, or a `refs/` ref outside `refs/heads/`.
+    - `--all` and `--mirror` push every branch, so they necessarily include
+      the default branch when it exists. They are a target, not an unknown.
+    - `--tags` pushes tags *in addition to* whatever refspecs are given. It
+      says nothing about branches, so it must not suppress parsing of an
+      explicit `master` sitting next to it -- `git push origin master --tags`
+      is still a push at the default branch.
+
+    With no refspec and no bulk flag, git pushes the current branch, so the
+    answer comes from repository state rather than the command. None means
+    unresolvable, which denies nothing.
     """
-    for bulk in ("--all", "--mirror", "--tags"):
-        if bulk in argv:
-            return None
+    if "--all" in argv or "--mirror" in argv:
+        # Pushes every branch. The default branch is in that set by
+        # definition, so this resolves rather than being unknown.
+        return {current_branch, "*"} if current_branch else {"*"}
 
     positionals = [
         tok for tok in argv[1:]
@@ -393,6 +403,9 @@ def _push_targets(argv, current_branch):
     ]
     refspecs = positionals[1:]
     if not refspecs:
+        if "--tags" in argv:
+            # Tags only, no branch touched.
+            return None
         return {current_branch} if current_branch else None
 
     targets = set()
@@ -473,23 +486,3 @@ def _resolve_directory(c_target, directory):
 
 def _has_expansion(token):
     return "$" in token or "`" in token or "*" in token
-
-
-def _pushes_elsewhere(argv, branch):
-    """True when a `git push` names a ref other than the current branch.
-
-    `git push` and `git push origin <current-branch>` stay inside the
-    policy; `git push origin master` or any `src:dst` refspec is a push at
-    something the predicates never examined, so it falls back to `ask`.
-    """
-    positionals = [
-        tok for tok in argv[1:]
-        if not tok.startswith("-") and tok != "push"
-    ]
-    # positionals[0] is the remote; anything after it is a refspec.
-    for refspec in positionals[1:]:
-        if ":" in refspec:
-            return True
-        if refspec != branch:
-            return True
-    return False

--- a/hooks/git_policy.py
+++ b/hooks/git_policy.py
@@ -1,0 +1,479 @@
+"""Policy layer: upgrade `unsafe` to `deny` for git writes we refuse outright.
+
+The rest of YOLT is a static checker -- it answers "does this command mutate
+anything?" from syntax alone. That question has no good answer for `git push`:
+pushing a feature branch you opened five minutes ago and force-pushing over
+someone else's commits on the default branch are different acts, and the argv
+can be byte-identical. Measured on a 12-day corpus, 24 of 76 observed pushes
+carried no refspec at all -- including `git push -f` -- so they push whatever
+happens to be checked out, which argv cannot know.
+
+So this module answers a different question -- "is this write one we refuse to
+delegate to a probabilistic classifier?" -- and it needs repository state to do
+it, which means shelling out to `git`. That is a deliberate, scoped exception
+to the no-subprocess design principle:
+
+- It runs only when the static classifier already said `unsafe` AND the argv
+  head matches a configured policy entry, so the common path never forks.
+- It can only turn `unsafe` into `deny`. It never makes a safe command unsafe,
+  and it never sees a command the classifier did not already flag.
+- Every probe is read-only `git`, with a timeout.
+
+INVERTED FAILURE SEMANTICS -- the one thing that could not be ported
+
+Its ancestor (#82) used these same probes to *grant* approval, where every
+probe failure meant "predicate not satisfied", the grant did not happen, and
+the original `ask` stood. Failure degraded toward more friction, which is
+safe, so that code was free to collapse "definitely not" and "cannot tell"
+into a single False.
+
+Denying inverts that. Collapsed the same way, an unset `git config user.email`
+or an unfetched `origin/master` reads as "not solo" and would **deny every
+force push in the repository**. A git outage or a slow network filesystem
+would brick the session. That is the failure mode #97 names, and porting the
+predicate verbatim would have shipped it.
+
+So authorship is tri-state here -- SOLO / SHARED / UNDETERMINED -- and every
+probe failure resolves to UNDETERMINED, which produces no opinion. The
+invariant, asserted by the tests: **no probe failure can ever produce a deny.**
+"""
+
+import os
+import subprocess
+
+# Read-only probes, but a hung git (network filesystem, index.lock
+# contention, a filter process) must not hang the permission prompt.
+_GIT_TIMEOUT_SECONDS = 3
+
+_DEFAULT_BRANCH_FALLBACKS = ("main", "master")
+
+# Authorship states. UNDETERMINED is not a failure to be retried or a
+# pessimistic default -- it is a first-class answer meaning "no opinion", and
+# it is what every probe failure resolves to.
+SOLO = "solo"
+SHARED = "shared"
+UNDETERMINED = "undetermined"
+
+# Predicate names a policy entry may list in its `refuse_when` array. Each is
+# a condition under which the command is DENIED. A predicate that cannot be
+# evaluated never fires.
+PREDICATES = ("default_branch_target", "shared_history", "primary_checkout")
+
+
+class GitProbe:
+    """Read-only `git` queries about one directory, memoized per instance.
+
+    One hook invocation classifies one Bash command, but that command may
+    be `git add ... && git commit ... && git push`, which asks the same
+    questions of the same directory three times. Memoizing keeps that at
+    one round of probes.
+    """
+
+    def __init__(self, runner=None):
+        # Injectable for tests; signature mirrors `_run_git`.
+        self._runner = runner or _run_git
+        self._cache = {}
+
+    def state(self, directory):
+        """Return a dict of facts about `directory`, or None if it is not
+        usable as a git working tree."""
+        if directory is None:
+            return None
+        key = os.path.abspath(directory)
+        if key not in self._cache:
+            self._cache[key] = self._probe(key)
+        return self._cache[key]
+
+    def _probe(self, directory):
+        if not os.path.isdir(directory):
+            return None
+
+        out = self._runner(
+            directory,
+            ["rev-parse", "--git-dir", "--git-common-dir", "--abbrev-ref", "HEAD"],
+        )
+        if out is None:
+            return None
+        lines = out.splitlines()
+        if len(lines) < 3:
+            return None
+        git_dir, git_common_dir, branch = lines[0], lines[1], lines[2]
+
+        # In a linked worktree these differ: --git-dir points at
+        # <main>/.git/worktrees/<name> while --git-common-dir points at
+        # <main>/.git. In the primary checkout they are the same path.
+        linked_worktree = os.path.abspath(
+            os.path.join(directory, git_dir)
+        ) != os.path.abspath(os.path.join(directory, git_common_dir))
+
+        return {
+            "directory": directory,
+            "branch": branch,
+            "detached": branch == "HEAD",
+            "linked_worktree": linked_worktree,
+            "default_branch": self._default_branch(directory),
+            "user_email": self._config(directory, "user.email"),
+        }
+
+    def _default_branch(self, directory):
+        # The remote's HEAD is the authoritative answer when the remote
+        # has been fetched at least once.
+        out = self._runner(
+            directory, ["symbolic-ref", "--short", "refs/remotes/origin/HEAD"]
+        )
+        if out:
+            head = out.strip()
+            if head.startswith("origin/"):
+                return head[len("origin/"):]
+
+        # No remote HEAD (never fetched, or no remote). Fall back to
+        # whichever candidate actually resolves in THIS repo.
+        # `init.defaultBranch` is only a candidate, never an answer on its
+        # own: it is a global preference for repos yet to be created, so a
+        # user who sets it to `main` would otherwise make every existing
+        # `master` repo look like it has no default branch.
+        candidates = []
+        configured = self._config(directory, "init.defaultBranch")
+        if configured:
+            candidates.append(configured)
+        candidates.extend(
+            c for c in _DEFAULT_BRANCH_FALLBACKS if c not in candidates
+        )
+
+        for candidate in candidates:
+            for ref in ("refs/remotes/origin/" + candidate, "refs/heads/" + candidate):
+                if self._runner(
+                    directory, ["rev-parse", "--verify", "--quiet", ref]
+                ) is not None:
+                    return candidate
+        return None
+
+    def _config(self, directory, key):
+        out = self._runner(directory, ["config", "--get", key])
+        if not out:
+            return None
+        return out.strip() or None
+
+    def authorship(self, directory):
+        """SOLO / SHARED / UNDETERMINED for the commits on this branch.
+
+        Returns a (state, detail) pair. SOLO means every commit on this
+        branch that is not on the default branch was authored AND committed
+        by the configured user. SHARED means at least one was not.
+        UNDETERMINED means the question could not be answered, and is
+        returned for every probe failure -- no git, no user.email, no
+        comparable ref, unreadable history.
+
+        The distinction between SHARED and UNDETERMINED does not exist in
+        the ancestor of this module, and adding it is the whole point of the
+        port: see the failure-semantics note in the module docstring.
+
+        A branch with no commits of its own yet is vacuously solo — that
+        is the state you are in the moment before the first `git commit`,
+        which is exactly the case this policy exists to allow.
+        """
+        state = self.state(directory)
+        if state is None:
+            return (UNDETERMINED, "not a git working tree")
+
+        email = state.get("user_email")
+        if not email:
+            return (UNDETERMINED, "git user.email is not configured")
+
+        default_branch = state.get("default_branch")
+        if not default_branch:
+            return (UNDETERMINED, "cannot determine the default branch")
+
+        base = None
+        for ref in ("origin/{}".format(default_branch), default_branch):
+            if self._runner(
+                directory, ["rev-parse", "--verify", "--quiet", ref]
+            ) is not None:
+                base = ref
+                break
+        if base is None:
+            return (UNDETERMINED,
+                    "no {} ref to compare against".format(default_branch))
+
+        out = self._runner(
+            directory, ["log", "--format=%ae%n%ce", "{}..HEAD".format(base)]
+        )
+        if out is None:
+            return (UNDETERMINED, "cannot read branch history")
+
+        others = {
+            line.strip() for line in out.splitlines()
+            if line.strip() and line.strip() != email
+        }
+        if others:
+            return (SHARED, "branch has commits by {}".format(
+                ", ".join(sorted(others))
+            ))
+        return (SOLO, "every commit on this branch is {}".format(email))
+
+
+class DenyPolicySet:
+    """Every configured deny policy, sharing one probe cache."""
+
+    def __init__(self, policies):
+        probe = GitProbe()
+        self.policies = [
+            GitDenyPolicy(spec, probe=probe)
+            for name, spec in sorted((policies or {}).items())
+            if not name.startswith("_") and isinstance(spec, dict)
+        ]
+
+    def evaluate(self, argv, directory):
+        for policy in self.policies:
+            reason = policy.evaluate(argv, directory)
+            if reason is not None:
+                return reason
+        return None
+
+
+def load_policies(rules):
+    """Build the deny policy set from loaded shell rules. Returns None when
+    nothing is configured, so the classifier can skip the layer entirely."""
+    policy_set = DenyPolicySet(rules.get("policies", {}))
+    if not any(p.enabled and p.entries for p in policy_set.policies):
+        return None
+    return policy_set
+
+
+def _run_git(directory, args):
+    """Run a read-only git command. Returns stdout, or None on any failure.
+
+    A failed probe must never read as evidence. On the deny side that means
+    None propagates to UNDETERMINED and the command is not denied.
+    """
+    try:
+        proc = subprocess.run(
+            ["git", "-C", directory, "--no-pager"] + args,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            timeout=_GIT_TIMEOUT_SECONDS,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if proc.returncode != 0:
+        return None
+    return proc.stdout.decode("utf-8", "replace")
+
+
+class GitDenyPolicy:
+    """Evaluates configured deny entries against an argv + directory."""
+
+    def __init__(self, spec, probe=None):
+        spec = spec or {}
+        self.enabled = bool(spec.get("enabled", False))
+        if os.environ.get("YOLT_NO_POLICIES"):
+            self.enabled = False
+        self.entries = [e for e in spec.get("deny", []) if isinstance(e, dict)]
+        self.probe = probe or GitProbe()
+
+    def evaluate(self, argv, directory):
+        """Return a reason string when this argv must be DENIED, else None.
+
+        None is "no opinion", and it is the answer for every uncertainty:
+        policy disabled, argv unmatched, directory unresolvable, probe
+        failed, predicate undetermined. Callers only invoke this for argv
+        the static rules already classified `unsafe`, so a None here leaves
+        that `unsafe` standing -- the operator still gets asked.
+        """
+        if not self.enabled or not argv:
+            return None
+
+        # `git -C <path>` retargets the command; the policy must judge the
+        # directory git will actually act on, not the shell's cwd.
+        argv, c_target = _split_dash_c(argv)
+
+        # Every matching entry is evaluated, not just the most specific
+        # one. Two entries legitimately share the `git push` prefix -- one
+        # refusing pushes at the default branch, one refusing force-pushes
+        # over shared history -- and picking a single winner would silently
+        # disable whichever lost.
+        entries = self._match_all(argv)
+        if not entries:
+            return None
+
+        directory = _resolve_directory(c_target, directory)
+        if directory is None:
+            return None
+
+        state = self.probe.state(directory)
+        if state is None:
+            return None
+        # Detached HEAD has no branch to reason about. Not an error, but
+        # nothing here can be established, so no opinion.
+        if state.get("detached"):
+            return None
+
+        for entry in entries:
+            # An entry may scope itself to particular flags, so that
+            # `git push --force` is refused while a plain push is not.
+            only_flags = entry.get("only_flags")
+            if only_flags and not any(flag in argv for flag in only_flags):
+                continue
+            label = " ".join(entry.get("argv", []))
+            for predicate in entry.get("refuse_when", []):
+                reason = self._fires(predicate, argv, state, directory)
+                if reason is not None:
+                    return "{}: {}".format(label, reason)
+        return None
+
+    def _fires(self, predicate, argv, state, directory):
+        """Return a reason when `predicate` is affirmatively true, else None.
+
+        Every branch that cannot establish the fact returns None rather than
+        guessing. That is the fail-open invariant in one place.
+        """
+        if predicate == "default_branch_target":
+            default_branch = state.get("default_branch")
+            if not default_branch:
+                return None
+            target = _push_target(argv, state.get("branch"))
+            if target is None:
+                return None
+            if target == default_branch:
+                return "would push to the default branch ({})".format(
+                    default_branch
+                )
+            return None
+
+        if predicate == "shared_history":
+            verdict, detail = self.probe.authorship(directory)
+            if verdict == SHARED:
+                return detail
+            return None
+
+        if predicate == "primary_checkout":
+            if state.get("linked_worktree") is False:
+                return "runs in the primary checkout, not a linked worktree"
+            return None
+
+        # An unknown predicate name is a configuration error, not a licence
+        # to deny. Schema validation rejects these at load; this is the
+        # belt-and-braces for a rules file that bypassed it.
+        return None
+
+    def _match_all(self, argv):
+        """Every entry whose argv prefix matches, most specific first."""
+        matched = [
+            entry for entry in self.entries
+            if entry.get("argv") and _argv_starts_with(argv, entry["argv"])
+        ]
+        matched.sort(key=lambda e: -len(e.get("argv", [])))
+        retval = matched
+        return retval
+
+
+def _push_target(argv, current_branch):
+    """The branch a `git push` would land on, or None if argv cannot say.
+
+    With no refspec, git pushes the current branch -- so the answer comes
+    from repository state, not from the command. With an explicit refspec,
+    the destination is its right-hand side. Anything this cannot resolve
+    (a variable, a glob, a tag ref) returns None and therefore never denies.
+    """
+    positionals = [
+        tok for tok in argv[1:]
+        if not tok.startswith("-") and tok != "push"
+    ]
+    refspecs = positionals[1:]
+    if not refspecs:
+        return current_branch
+    retval = None
+    for refspec in refspecs:
+        if _has_expansion(refspec):
+            return None
+        candidate = refspec.split(":")[-1] if ":" in refspec else refspec
+        candidate = candidate.replace("refs/heads/", "")
+        if candidate.startswith("refs/"):
+            return None
+        retval = candidate
+    return retval
+
+
+def _argv_starts_with(argv, prefix):
+    """Match a policy prefix against argv, skipping flags so that
+    `git --no-pager commit` still matches `["git", "commit"]`. argv[0] is
+    compared by basename so `/usr/bin/git` matches."""
+    if not argv or not prefix:
+        return False
+    if os.path.basename(argv[0]) != prefix[0]:
+        return False
+
+    remaining = list(prefix[1:])
+    for tok in argv[1:]:
+        if not remaining:
+            break
+        if tok.startswith("-"):
+            continue
+        if tok != remaining[0]:
+            return False
+        remaining.pop(0)
+    return not remaining
+
+
+def _split_dash_c(argv):
+    """Return (argv without any `-C <path>` pair, the last such path).
+
+    Leaving `-C` in place would break both the prefix match (`/path` reads
+    as the subcommand) and the refspec check (`/path` reads as the remote).
+    """
+    if not argv or os.path.basename(argv[0]) != "git":
+        return (argv, None)
+    out = [argv[0]]
+    target = None
+    i = 1
+    while i < len(argv):
+        tok = argv[i]
+        if tok == "-C" and i + 1 < len(argv):
+            target = argv[i + 1]
+            i += 2
+            continue
+        if tok.startswith("-C") and len(tok) > 2:
+            target = tok[2:]
+            i += 1
+            continue
+        out.append(tok)
+        i += 1
+    return (out, target)
+
+
+def _resolve_directory(c_target, directory):
+    """Resolve a `git -C` target against the shell's directory."""
+    if c_target is None:
+        return directory
+    if _has_expansion(c_target):
+        return None
+    target = os.path.expanduser(c_target)
+    if os.path.isabs(target):
+        return target
+    if directory is None:
+        return None
+    return os.path.join(directory, target)
+
+
+def _has_expansion(token):
+    return "$" in token or "`" in token or "*" in token
+
+
+def _pushes_elsewhere(argv, branch):
+    """True when a `git push` names a ref other than the current branch.
+
+    `git push` and `git push origin <current-branch>` stay inside the
+    policy; `git push origin master` or any `src:dst` refspec is a push at
+    something the predicates never examined, so it falls back to `ask`.
+    """
+    positionals = [
+        tok for tok in argv[1:]
+        if not tok.startswith("-") and tok != "push"
+    ]
+    # positionals[0] is the remote; anything after it is a refspec.
+    for refspec in positionals[1:]:
+        if ":" in refspec:
+            return True
+        if refspec != branch:
+            return True
+    return False

--- a/hooks/git_policy.py
+++ b/hooks/git_policy.py
@@ -331,10 +331,10 @@ class GitDenyPolicy:
             default_branch = state.get("default_branch")
             if not default_branch:
                 return None
-            target = _push_target(argv, state.get("branch"))
-            if target is None:
+            targets = _push_targets(argv, state.get("branch"))
+            if not targets:
                 return None
-            if target == default_branch:
+            if default_branch in targets:
                 return "would push to the default branch ({})".format(
                     default_branch
                 )
@@ -367,30 +367,46 @@ class GitDenyPolicy:
         return retval
 
 
-def _push_target(argv, current_branch):
-    """The branch a `git push` would land on, or None if argv cannot say.
+def _push_targets(argv, current_branch):
+    """Every branch a `git push` would land on, or None if argv cannot say.
 
-    With no refspec, git pushes the current branch -- so the answer comes
-    from repository state, not from the command. With an explicit refspec,
-    the destination is its right-hand side. Anything this cannot resolve
-    (a variable, a glob, a tag ref) returns None and therefore never denies.
+    Returns a set. A push can name several refspecs at once, and taking only
+    the last one -- as an earlier version of this did -- lets
+    `git push origin master feature/x` slip past the default-branch guard,
+    because the guard only ever looked at `feature/x`.
+
+    With no refspec, git pushes the current branch, so the answer comes from
+    repository state rather than the command. None means unresolvable, which
+    denies nothing:
+
+    - `--all` / `--mirror` / `--tags` push a whole namespace rather than a
+      named branch, so the destination set is not derivable from argv.
+    - a variable, a glob, or a `refs/` ref outside `refs/heads/`.
     """
+    for bulk in ("--all", "--mirror", "--tags"):
+        if bulk in argv:
+            return None
+
     positionals = [
         tok for tok in argv[1:]
         if not tok.startswith("-") and tok != "push"
     ]
     refspecs = positionals[1:]
     if not refspecs:
-        return current_branch
-    retval = None
+        return {current_branch} if current_branch else None
+
+    targets = set()
     for refspec in refspecs:
         if _has_expansion(refspec):
             return None
         candidate = refspec.split(":")[-1] if ":" in refspec else refspec
-        candidate = candidate.replace("refs/heads/", "")
-        if candidate.startswith("refs/"):
-            return None
-        retval = candidate
+        if candidate.startswith("refs/heads/"):
+            candidate = candidate[len("refs/heads/"):]
+        elif candidate.startswith("refs/"):
+            # A tag or notes ref is not a branch; nothing to compare.
+            continue
+        targets.add(candidate)
+    retval = targets or None
     return retval
 
 

--- a/hooks/grammar_classifier.py
+++ b/hooks/grammar_classifier.py
@@ -23,7 +23,7 @@ import tree_sitter_bash as _tsb
 from tree_sitter import Language, Parser
 
 from rule_classifier import (
-    DECISION_SAFE, DECISION_UNSAFE, DECISION_UNKNOWN,
+    DECISION_SAFE, DECISION_UNSAFE, DECISION_UNKNOWN, DECISION_DENY,
     SUBSTITUTION_PLACEHOLDER,
     RuleClassifier,
     aggregate_decisions,
@@ -49,9 +49,16 @@ class GrammarClassifier:
 
     MAX_RECURSION_DEPTH = 8
 
-    def __init__(self, rules, python_analyzer_factory=None):
+    def __init__(self, rules, python_analyzer_factory=None, cwd=None,
+                 policy=None):
         self.rules = rules
         self.python_analyzer_factory = python_analyzer_factory
+        # The shell's directory when the command starts, and the deny
+        # policy that may consult git state there. `_cwd` is re-derived per
+        # `classify()` call because a leading `cd` moves it.
+        self.cwd = cwd
+        self.policy = policy
+        self._cwd = cwd
         self.safe_write_targets = list(rules.get("safe_write_targets", ["/dev/null"]))
         self.unsafe_write_targets = list(rules.get("unsafe_write_targets", []))
         self._rules = RuleClassifier(
@@ -75,6 +82,9 @@ class GrammarClassifier:
 
         if root.has_error:
             return (DECISION_UNKNOWN, "tree-sitter parse error")
+
+        if _depth == 0:
+            self._cwd = self.cwd
 
         decisions = []
         self._walk(root, src, decisions, _depth)
@@ -215,10 +225,57 @@ class GrammarClassifier:
         for c in node.children:
             self._collect_substitutions(c, src, sub_decisions, _depth + 1)
 
+        # A literal `cd` moves the directory the policy layer will judge,
+        # and it has to be tracked before the sibling commands are
+        # classified: `cd <repo> && git push` is the whole reason this
+        # exists.
+        if cmd_name == "cd":
+            self._track_cd(argv)
+
         result = self._rules.classify_tokens(argv)
+        result = self._maybe_deny_by_policy(argv, result)
         if sub_decisions:
             return aggregate_decisions(sub_decisions + [result])
         return result
+
+    def _track_cd(self, argv):
+        """Follow a literal `cd` so the policy layer judges the directory
+        the later commands actually run in.
+
+        `cd /path/to/worktree && git push --force` is the shape this exists
+        for. Anything the walker cannot resolve statically -- an expansion,
+        `cd -`, a substitution -- sets the tracked directory to None, which
+        disables the policy for the rest of the invocation rather than
+        letting it judge the wrong tree.
+        """
+        args = [a for a in argv[1:] if not a.startswith("-")]
+        if not args:
+            self._cwd = os.path.expanduser("~")
+            return
+        target = args[0]
+        if target == "-" or "$" in target or "`" in target or "*" in target:
+            self._cwd = None
+            return
+        target = os.path.expanduser(target)
+        if os.path.isabs(target):
+            self._cwd = target
+        elif self._cwd is not None:
+            self._cwd = os.path.normpath(os.path.join(self._cwd, target))
+
+    def _maybe_deny_by_policy(self, argv, result):
+        """Give the policy layer a chance to upgrade `unsafe` -> `deny`.
+
+        Only `unsafe` is offered. The policy exists to refuse a narrow set
+        of writes the static rules already flagged; it must never be able
+        to reach something the rules cleared, so `safe` and `unknown` are
+        not routed through it.
+        """
+        if self.policy is None or result[0] != DECISION_UNSAFE:
+            return result
+        reason = self.policy.evaluate(argv, self._cwd)
+        if reason is None:
+            return result
+        return (DECISION_DENY, reason)
 
     def _collect_substitutions(self, node, src, decisions, _depth):
         if node.type in ("command_substitution", "process_substitution"):

--- a/hooks/rule_classifier.py
+++ b/hooks/rule_classifier.py
@@ -32,6 +32,10 @@ from pathlib import Path
 DECISION_SAFE = "safe"
 DECISION_UNSAFE = "unsafe"
 DECISION_UNKNOWN = "unknown"
+# Refused outright rather than asked about. Only the git policy layer
+# produces this, and only by upgrading a decision that was already
+# `unsafe` -- nothing can go straight from safe or unknown to deny.
+DECISION_DENY = "deny"
 
 SUBSTITUTION_PLACEHOLDER = "__YOLT_SUB__"
 
@@ -446,9 +450,18 @@ def match_allow_patterns(command, patterns):
 
 
 def aggregate_decisions(decisions):
-    """Combine (decision, reason) results. Precedence: unsafe > unknown > safe."""
+    """Combine (decision, reason) results.
+
+    Precedence: deny > unsafe > unknown > safe. `deny` outranks everything
+    because one refused segment condemns the whole command line -- there is
+    no way to run `A && B` with B refused.
+    """
     if not decisions:
         return (DECISION_SAFE, "nothing to classify")
+
+    deny_reasons = [r for d, r in decisions if d == DECISION_DENY]
+    if deny_reasons:
+        return (DECISION_DENY, "; ".join(deny_reasons))
 
     unsafe_reasons = [r for d, r in decisions if d == DECISION_UNSAFE]
     unknown_reasons = [r for d, r in decisions if d == DECISION_UNKNOWN]
@@ -619,6 +632,7 @@ _ALLOWED_TOP_LEVEL_KEYS = frozenset({
     "shell_builtins_safe", "shell_keywords",
     "safe_write_targets", "unsafe_write_targets",
     "commands", "interpreters",
+    "policies", "_policies_note",
 })
 
 _ALLOWED_COMMAND_KEYS = frozenset({
@@ -667,6 +681,68 @@ _ALLOWED_NESTED_MODULE_KEYS = frozenset({
 # value silently degrades to `unknown` at classify time, which is exactly
 # the drift this validator exists to catch.
 _ALLOWED_NESTED_MODULE_DEFAULTS = frozenset({"safe", "unsafe"})
+
+
+_ALLOWED_POLICY_KEYS = frozenset({"_note", "enabled", "deny"})
+_ALLOWED_POLICY_ENTRY_KEYS = frozenset({
+    "_note", "argv", "refuse_when", "only_flags",
+})
+
+
+def _validate_policies(policies, errors):
+    """Schema-check the `policies` block.
+
+    A deny policy can only turn `unsafe` into `deny`, so a typo here costs
+    a refusal that should not have happened -- the loud failure, not the
+    silent one. It is still a hard error, because a policy the classifier
+    silently ignores is a guard the operator believes they have and does
+    not.
+    """
+    from git_policy import PREDICATES
+
+    if not isinstance(policies, dict):
+        errors.append("policies: must be a dict")
+        return
+
+    for name, spec in policies.items():
+        if name.startswith("_"):
+            continue
+        path = "policies.{}".format(name)
+        if not isinstance(spec, dict):
+            errors.append("{}: must be a dict".format(path))
+            continue
+        for key in spec:
+            if key not in _ALLOWED_POLICY_KEYS:
+                errors.append("{}: unknown key '{}'".format(path, key))
+
+        entries = spec.get("deny", [])
+        if not isinstance(entries, list):
+            errors.append("{}.deny: must be a list".format(path))
+            continue
+        for i, entry in enumerate(entries):
+            entry_path = "{}.deny[{}]".format(path, i)
+            if not isinstance(entry, dict):
+                errors.append("{}: must be a dict".format(entry_path))
+                continue
+            for key in entry:
+                if key not in _ALLOWED_POLICY_ENTRY_KEYS:
+                    errors.append(
+                        "{}: unknown key '{}'".format(entry_path, key))
+            argv = entry.get("argv")
+            if not isinstance(argv, list) or not argv:
+                errors.append(
+                    "{}.argv: must be a non-empty list".format(entry_path))
+            predicates = entry.get("refuse_when", [])
+            if not isinstance(predicates, list):
+                errors.append(
+                    "{}.refuse_when: must be a list".format(entry_path))
+                continue
+            for predicate in predicates:
+                if predicate not in PREDICATES:
+                    errors.append(
+                        "{}.refuse_when: unknown predicate '{}' "
+                        "(valid: {})".format(
+                            entry_path, predicate, ", ".join(PREDICATES)))
 
 
 def validate_shell_rules(rules):
@@ -729,6 +805,8 @@ def validate_shell_rules(rules):
                         "interpreters.{}.nested_modules.{}: unknown default '{}'"
                         .format(name, mod, mod_default)
                     )
+
+    _validate_policies(rules.get("policies", {}), errors)
 
     return errors
 

--- a/hooks/yolt_analyzer.py
+++ b/hooks/yolt_analyzer.py
@@ -1250,8 +1250,10 @@ def run_hook():
         if str(hooks_dir) not in sys.path:
             sys.path.insert(0, str(hooks_dir))
         from grammar_classifier import GrammarClassifier
+        from git_policy import load_policies
         from rule_classifier import (
             DECISION_UNSAFE,
+            DECISION_DENY,
             ShellRulesValidationError,
             load_shell_rules,
         )
@@ -1276,6 +1278,8 @@ def run_hook():
     classifier = GrammarClassifier(
         shell_rules,
         python_analyzer_factory=_python_factory,
+        cwd=hook_input.get("cwd"),
+        policy=load_policies(shell_rules),
     )
     decision, reason = classifier.classify(command)
     _log_hook_decision(command, decision, reason, permission_mode, agent_id)
@@ -1284,6 +1288,17 @@ def run_hook():
     # and still be carrying a credential into argv. Advisory only — it
     # rides along with whatever decision was reached. Issue #85.
     advisory = format_secret_advisory(command)
+
+    if decision == DECISION_DENY:
+        # The git policy layer refused this outright. Unlike `unsafe` this
+        # does not become `ask` for an operator: the whole point of the
+        # non-delegable list is that these are not questions we want
+        # answered per-prompt, by a person or by a classifier. Issue #97.
+        response = make_hook_response(
+            "deny", "YOLT refuses this outright: {}".format(reason)
+        )
+        print(json.dumps(attach_secret_advisory(response, advisory)))
+        sys.exit(0)
 
     if decision == DECISION_UNSAFE:
         allow_hint = classifier.suggest_allow_pattern(command)

--- a/rules/shell.json
+++ b/rules/shell.json
@@ -727,5 +727,57 @@
       ],
       "_note": "duckdb CLI mirrors sqlite3 surface: DB [SQL], plus -c/-cmd flags."
     }
+  },
+
+  "_policies_note": "Deny policies. A policy runs only when the static rules already classified the command 'unsafe' and its argv matches an entry, and it can only upgrade 'unsafe' to 'deny'. Each name in 'refuse_when' is a condition under which the command is refused; a condition that cannot be established never fires, so no probe failure can produce a deny. Valid predicates: default_branch_target, shared_history, primary_checkout. Set YOLT_NO_POLICIES=1 to disable the layer.",
+
+  "policies": {
+    "git": {
+      "enabled": true,
+      "deny": [
+        {
+          "_note": "Pushing at the default branch. Over 12 days of dogfooding this fired zero times -- every observed push targeted a feature branch -- so it is a net safety guard with no measured friction. 24 of 76 observed pushes carried no refspec, so argv alone cannot tell what they target; that is why it needs a probe.",
+          "argv": [
+            "git",
+            "push"
+          ],
+          "refuse_when": [
+            "default_branch_target"
+          ]
+        },
+        {
+          "_note": "Force-pushing or deleting a branch carrying commits somebody else authored. --force-with-lease is deliberately included: it protects against a moved remote, not against overwriting a coauthor whose commits you already have.",
+          "argv": [
+            "git",
+            "push"
+          ],
+          "only_flags": [
+            "--force",
+            "-f",
+            "-qf",
+            "--delete",
+            "-d"
+          ],
+          "refuse_when": [
+            "shared_history"
+          ]
+        }
+      ]
+    },
+    "git_worktree_convention": {
+      "_note": "House convention, off by default: commits belong in a linked worktree, not the primary checkout. A local preference, not a universal truth, which is why it ships disabled.",
+      "enabled": false,
+      "deny": [
+        {
+          "argv": [
+            "git",
+            "commit"
+          ],
+          "refuse_when": [
+            "primary_checkout"
+          ]
+        }
+      ]
+    }
   }
 }

--- a/tests/test_git_policy.py
+++ b/tests/test_git_policy.py
@@ -21,7 +21,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "hooks"))
 
 from git_policy import (  # noqa: E402
-    SHARED, SOLO, UNDETERMINED, GitDenyPolicy, GitProbe, _push_target,
+    SHARED, SOLO, UNDETERMINED, GitDenyPolicy, GitProbe, _push_targets,
 )
 
 
@@ -184,19 +184,46 @@ class LeavesAloneWhatItShould(unittest.TestCase):
 
 class PushTargetResolution(unittest.TestCase):
     def test_no_refspec_uses_current_branch(self):
-        self.assertEqual(_push_target(["git", "push", "-f"], "master"), "master")
+        self.assertEqual(_push_targets(["git", "push", "-f"], "master"),
+                         {"master"})
 
-    def test_explicit_refspec_wins(self):
+    def test_explicit_refspec(self):
         self.assertEqual(
-            _push_target(["git", "push", "origin", "master"], "feat"), "master")
+            _push_targets(["git", "push", "origin", "master"], "feat"),
+            {"master"})
 
     def test_src_colon_dst_uses_the_destination(self):
         self.assertEqual(
-            _push_target(["git", "push", "origin", "HEAD:master"], "feat"),
-            "master")
+            _push_targets(["git", "push", "origin", "HEAD:master"], "feat"),
+            {"master"})
+
+    def test_every_refspec_counts_not_just_the_last(self):
+        # From the adversarial review on #122. Taking only the last refspec
+        # let `git push origin master feature/x` past the default-branch
+        # guard, because the guard only ever saw `feature/x`.
+        self.assertEqual(
+            _push_targets(["git", "push", "origin", "master", "feature/x"],
+                          "feature/x"),
+            {"master", "feature/x"})
+
+    def test_refs_heads_is_normalised(self):
+        self.assertEqual(
+            _push_targets(["git", "push", "origin", "refs/heads/master"],
+                          "feat"),
+            {"master"})
+
+    def test_tag_ref_is_not_a_branch(self):
+        self.assertIsNone(
+            _push_targets(["git", "push", "origin", "refs/tags/v1"], "feat"))
+
+    def test_bulk_flags_are_unresolvable(self):
+        for flag in ("--all", "--mirror", "--tags"):
+            self.assertIsNone(
+                _push_targets(["git", "push", flag, "origin"], "feat"), flag)
 
     def test_expansion_is_unresolvable(self):
-        self.assertIsNone(_push_target(["git", "push", "origin", "$B"], "feat"))
+        self.assertIsNone(
+            _push_targets(["git", "push", "origin", "$B"], "feat"))
 
 
 if __name__ == "__main__":

--- a/tests/test_git_policy.py
+++ b/tests/test_git_policy.py
@@ -155,6 +155,17 @@ class DeniesWhenItShould(unittest.TestCase):
         self.assertIsNotNone(
             p.evaluate(["git", "push", "origin", "master"], HERE))
 
+    def test_push_all_denies_because_it_includes_the_default_branch(self):
+        p = policy(PUSH_DEFAULT, branch="feature/x")
+        reason = p.evaluate(["git", "push", "--all", "origin"], HERE)
+        self.assertIsNotNone(reason)
+        self.assertIn("every branch", reason)
+
+    def test_explicit_default_branch_alongside_tags(self):
+        p = policy(PUSH_DEFAULT, branch="feature/x")
+        self.assertIsNotNone(
+            p.evaluate(["git", "push", "origin", "master", "--tags"], HERE))
+
     def test_force_push_over_someone_elses_commits(self):
         p = policy(PUSH_FORCE_SHARED,
                    log_authors="me@example.com\nsomeone@else.org")
@@ -216,10 +227,22 @@ class PushTargetResolution(unittest.TestCase):
         self.assertIsNone(
             _push_targets(["git", "push", "origin", "refs/tags/v1"], "feat"))
 
-    def test_bulk_flags_are_unresolvable(self):
-        for flag in ("--all", "--mirror", "--tags"):
-            self.assertIsNone(
-                _push_targets(["git", "push", flag, "origin"], "feat"), flag)
+    def test_tags_does_not_suppress_an_explicit_refspec(self):
+        # From the re-review on #122, and a bug the *previous* fix
+        # introduced: lumping --tags in with --all made
+        # `git push origin master --tags` unresolvable, so the
+        # default-branch guard stopped seeing the explicit `master`.
+        for argv in (["git", "push", "origin", "master", "--tags"],
+                     ["git", "push", "--tags", "origin", "master"]):
+            self.assertEqual(_push_targets(argv, "feat"), {"master"}, argv)
+
+    def test_tags_alone_touches_no_branch(self):
+        self.assertIsNone(_push_targets(["git", "push", "--tags"], "feat"))
+
+    def test_all_and_mirror_include_every_branch(self):
+        for flag in ("--all", "--mirror"):
+            targets = _push_targets(["git", "push", flag, "origin"], "feat")
+            self.assertIn("*", targets, flag)
 
     def test_expansion_is_unresolvable(self):
         self.assertIsNone(

--- a/tests/test_git_policy.py
+++ b/tests/test_git_policy.py
@@ -1,0 +1,249 @@
+"""Deny-side git policy — and above all, that it never denies on a failed probe.
+
+#97 requires this file. Its ancestor (#82) used the same probes to *grant*,
+where every probe failure collapsed to a single False and meant "no grant",
+so the original `ask` stood. Inverted, that collapse is a session-bricking
+bug: an unset `git config user.email` would read as "not solo" and deny every
+force push in the repository.
+
+So the invariant under test is narrow and absolute:
+
+    no probe failure, of any kind, may ever produce a deny.
+
+Everything else here is secondary.
+"""
+
+import os
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "hooks"))
+
+from git_policy import (  # noqa: E402
+    SHARED, SOLO, UNDETERMINED, GitDenyPolicy, GitProbe, _push_target,
+)
+
+
+def fake_runner(*, git_dir=".git", common_dir=".git", branch="feature/x",
+                default_branch="master", email="me@example.com",
+                log_authors="me@example.com\nme@example.com",
+                fail=()):
+    """A stand-in for `_run_git`. `fail` names sub-probes that return None."""
+    def run(directory, args):
+        head = args[0]
+        if head == "rev-parse" and "--git-dir" in args:
+            if "state" in fail:
+                return None
+            return "{}\n{}\n{}\n".format(git_dir, common_dir, branch)
+        if head == "symbolic-ref":
+            if "default_branch" in fail:
+                return None
+            return "origin/{}\n".format(default_branch)
+        if head == "config":
+            if "email" in fail:
+                return None
+            return "{}\n".format(email)
+        if head == "rev-parse" and "--verify" in args:
+            # Two different callers use --verify, and a fixture that cannot
+            # tell them apart cannot simulate either failure honestly.
+            # _default_branch probes fully-qualified refs (refs/heads/main,
+            # refs/remotes/origin/main); authorship probes bare ones
+            # (origin/master, master).
+            fully_qualified = any(a.startswith("refs/") for a in args)
+            if fully_qualified:
+                if "default_branch" in fail:
+                    return None
+            elif "base_ref" in fail:
+                return None
+            return "abc123\n"
+        if head == "log":
+            if "history" in fail:
+                return None
+            return log_authors + "\n"
+        return ""
+    return run
+
+
+def policy(entries, **kw):
+    probe = GitProbe(runner=fake_runner(**kw))
+    # The probe consults os.path.isdir before running anything.
+    return GitDenyPolicy({"enabled": True, "deny": entries}, probe=probe)
+
+
+PUSH_DEFAULT = [{"argv": ["git", "push"],
+                 "refuse_when": ["default_branch_target"]}]
+PUSH_FORCE_SHARED = [{"argv": ["git", "push"],
+                      "only_flags": ["--force", "-f"],
+                      "refuse_when": ["shared_history"]}]
+
+HERE = str(Path(__file__).resolve().parent)
+
+
+class FailedProbeNeverDenies(unittest.TestCase):
+    """The load-bearing invariant. Each case is a real failure mode."""
+
+    def test_git_unavailable_or_not_a_repo(self):
+        p = policy(PUSH_DEFAULT, fail=("state",))
+        self.assertIsNone(p.evaluate(["git", "push"], HERE))
+
+    def test_user_email_unset_does_not_deny_force_push(self):
+        # The exact bug a verbatim port would have shipped: no user.email
+        # means authorship is unknowable, not "someone else wrote it".
+        p = policy(PUSH_FORCE_SHARED, fail=("email",))
+        self.assertIsNone(p.evaluate(["git", "push", "--force"], HERE))
+
+    def test_no_comparable_base_ref(self):
+        p = policy(PUSH_FORCE_SHARED, fail=("base_ref",))
+        self.assertIsNone(p.evaluate(["git", "push", "--force"], HERE))
+
+    def test_unreadable_history(self):
+        p = policy(PUSH_FORCE_SHARED, fail=("history",))
+        self.assertIsNone(p.evaluate(["git", "push", "--force"], HERE))
+
+    def test_default_branch_undeterminable(self):
+        p = policy(PUSH_DEFAULT, fail=("default_branch",), branch="master")
+        self.assertIsNone(p.evaluate(["git", "push"], HERE))
+
+    def test_detached_head(self):
+        p = policy(PUSH_DEFAULT, branch="HEAD")
+        self.assertIsNone(p.evaluate(["git", "push"], HERE))
+
+    def test_directory_unknown(self):
+        p = policy(PUSH_DEFAULT)
+        self.assertIsNone(p.evaluate(["git", "push"], None))
+
+    def test_dash_c_target_with_expansion(self):
+        p = policy(PUSH_DEFAULT, branch="master")
+        self.assertIsNone(p.evaluate(["git", "-C", "$DIR", "push"], HERE))
+
+    def test_env_kill_switch(self):
+        os.environ["YOLT_NO_POLICIES"] = "1"
+        try:
+            p = policy(PUSH_DEFAULT, branch="master")
+            self.assertIsNone(p.evaluate(["git", "push"], HERE))
+        finally:
+            del os.environ["YOLT_NO_POLICIES"]
+
+
+class AuthorshipIsTriState(unittest.TestCase):
+    def test_solo(self):
+        probe = GitProbe(runner=fake_runner())
+        self.assertEqual(probe.authorship(HERE)[0], SOLO)
+
+    def test_shared(self):
+        probe = GitProbe(runner=fake_runner(
+            log_authors="me@example.com\nsomeone@else.org"))
+        self.assertEqual(probe.authorship(HERE)[0], SHARED)
+
+    def test_undetermined_is_not_shared(self):
+        for mode in ("email", "base_ref", "history", "default_branch"):
+            probe = GitProbe(runner=fake_runner(fail=(mode,)))
+            self.assertEqual(probe.authorship(HERE)[0], UNDETERMINED, mode)
+
+
+class DeniesWhenItShould(unittest.TestCase):
+    def test_push_with_no_refspec_while_on_default_branch(self):
+        # argv says nothing about the target; only repo state does.
+        p = policy(PUSH_DEFAULT, branch="master")
+        reason = p.evaluate(["git", "push", "-f"], HERE)
+        self.assertIsNotNone(reason)
+        self.assertIn("default branch", reason)
+
+    def test_push_naming_the_default_branch_explicitly(self):
+        p = policy(PUSH_DEFAULT, branch="feature/x")
+        self.assertIsNotNone(
+            p.evaluate(["git", "push", "origin", "master"], HERE))
+
+    def test_force_push_over_someone_elses_commits(self):
+        p = policy(PUSH_FORCE_SHARED,
+                   log_authors="me@example.com\nsomeone@else.org")
+        reason = p.evaluate(["git", "push", "--force"], HERE)
+        self.assertIsNotNone(reason)
+        self.assertIn("someone@else.org", reason)
+
+
+class LeavesAloneWhatItShould(unittest.TestCase):
+    def test_push_to_feature_branch(self):
+        p = policy(PUSH_DEFAULT, branch="feature/x")
+        self.assertIsNone(p.evaluate(["git", "push"], HERE))
+
+    def test_force_push_over_only_your_own_commits(self):
+        p = policy(PUSH_FORCE_SHARED)
+        self.assertIsNone(p.evaluate(["git", "push", "--force"], HERE))
+
+    def test_non_force_push_is_outside_the_force_entry(self):
+        p = policy(PUSH_FORCE_SHARED,
+                   log_authors="me@example.com\nsomeone@else.org")
+        self.assertIsNone(p.evaluate(["git", "push"], HERE))
+
+    def test_unmatched_argv(self):
+        p = policy(PUSH_DEFAULT, branch="master")
+        self.assertIsNone(p.evaluate(["git", "status"], HERE))
+
+
+class PushTargetResolution(unittest.TestCase):
+    def test_no_refspec_uses_current_branch(self):
+        self.assertEqual(_push_target(["git", "push", "-f"], "master"), "master")
+
+    def test_explicit_refspec_wins(self):
+        self.assertEqual(
+            _push_target(["git", "push", "origin", "master"], "feat"), "master")
+
+    def test_src_colon_dst_uses_the_destination(self):
+        self.assertEqual(
+            _push_target(["git", "push", "origin", "HEAD:master"], "feat"),
+            "master")
+
+    def test_expansion_is_unresolvable(self):
+        self.assertIsNone(_push_target(["git", "push", "origin", "$B"], "feat"))
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+
+class ThroughTheClassifier(unittest.TestCase):
+    """Drive the deny path through GrammarClassifier, not just the policy.
+
+    The unit tests above call GitDenyPolicy directly, which meant three
+    separate wiring bugs -- an unimported DECISION_DENY in two modules and a
+    `cd` hook that never landed -- passed every one of them while the hook
+    crashed or silently ignored a `cd`. Anything that only exercises the
+    policy object cannot see the wiring.
+    """
+
+    def _classifier(self, cwd, **kw):
+        import json
+        from grammar_classifier import GrammarClassifier
+        from rule_classifier import load_shell_rules
+        rules_dir = Path(__file__).resolve().parent.parent / "rules"
+        rules = load_shell_rules(rules_dir=rules_dir)
+        probe = GitProbe(runner=fake_runner(**kw))
+        policy = GitDenyPolicy(rules["policies"]["git"], probe=probe)
+        return GrammarClassifier(rules, cwd=cwd, policy=policy)
+
+    def test_deny_reaches_the_decision(self):
+        c = self._classifier(HERE, branch="master")
+        decision, reason = c.classify("git push")
+        self.assertEqual(decision, "deny")
+        self.assertIn("default branch", reason)
+
+    def test_feature_branch_still_only_asks(self):
+        c = self._classifier(HERE, branch="feature/x")
+        self.assertEqual(c.classify("git push")[0], "unsafe")
+
+    def test_cd_moves_the_judged_directory(self):
+        # `cd` to a tracked path, then push. Without cd tracking the policy
+        # judges the wrong tree and the deny never fires.
+        c = self._classifier("/nonexistent-start", branch="master")
+        decision, _reason = c.classify("cd {} && git push".format(HERE))
+        self.assertEqual(decision, "deny")
+
+    def test_unresolvable_cd_disables_the_policy(self):
+        c = self._classifier(HERE, branch="master")
+        self.assertEqual(c.classify("cd $D && git push")[0], "unsafe")
+
+    def test_deny_outranks_unsafe_siblings(self):
+        c = self._classifier(HERE, branch="master")
+        self.assertEqual(c.classify("rm -rf /tmp/x && git push")[0], "deny")


### PR DESCRIPTION
Closes #97. Targets the umbrella, not master. No version bump.

## What carried over, and what could not

#82 built three deterministic git-state predicates and wired them to **grant**
approval. The predicates are good; the direction was wrong. This keeps them
and inverts them.

Ported as-is: `GitProbe`, the literal-`cd` tracker, `git -C` retargeting,
per-directory memoization, schema validation.

**The failure handling could not be ported, and that is the substance of this
PR.** #97 flagged this as the one place a verbatim port would be actively
wrong. It was more concrete than that:

`solo_author` returned `(False, ...)` for *both* "someone else authored these
commits" and every probe failure — `user.email` unset, `origin/master` never
fetched, unreadable history. Granting, that conflation is safe: any False
means no grant and the `ask` stands. **Denying, a repo with no configured
`user.email` would deny every force push in it**, and a git outage would deny
everything.

So authorship is tri-state here — `SOLO` / `SHARED` / `UNDETERMINED` — and
every probe failure resolves to `UNDETERMINED`, which produces no opinion.

The invariant, asserted by nine tests: **no probe failure of any kind can
produce a deny.**

## Entries chosen against the corpus, not guessed

Measured with `scripts/replay_unsafe.py` over the 12-day dogfood corpus:

**1. Push at the default branch** — enabled. Fired **zero times across 76
observed pushes**; every one targeted a feature branch. A net safety guard
with no measured friction.

It still needs a probe, and this is the case for the whole issue: **24 of
those 76 pushes carried no refspec at all** — including `git push -f` and
`git push -qf`. They push whatever is checked out, and argv cannot know what
that is. Only `rev-parse --abbrev-ref HEAD` can.

**2. Force-push or delete over commits somebody else authored** — enabled.
`--force-with-lease` is deliberately in scope: it guards against a moved
remote, not against overwriting a coauthor whose commits you already have
locally. It was 32 of the 76 pushes, so this is the shape that matters.

**3. Commits from the primary checkout** — **disabled**. A house convention,
not a universal truth, so it ships off.

## One deviation from the issue text, flagged deliberately

#97 specifies that a probe failure "must fall through to `unknown`". This
implements *no deny; the pre-existing decision stands*, which for these
commands means `unsafe` → `ask`.

Reasoning: falling to `unknown` degrades toward **less** friction, since
`unknown` exits silently post-Phase-1. Leaving `unsafe` in place degrades
toward **more**, which is the direction #82's failure handling went and the
direction the issue's own argument favours. The invariant the issue actually
cares about — a failed probe never denies — holds either way. If you want the
literal wording, it is a one-line change in `_maybe_deny_by_policy`.

## Decision vocabulary

`DECISION_DENY` is a fourth decision at the top of precedence (deny > unsafe >
unknown > safe), reachable **only** by upgrading something already classified
`unsafe`. Nothing reaches deny from `safe` or `unknown`. Deny outranks its
siblings because one refused segment condemns the line — there is no way to
run `A && B` with B refused.

## Verified against live git, not only fixtures

| command | from | result |
| --- | --- | --- |
| `git push` | master checkout | **DENY** (default branch) |
| `git push -f` | master checkout | **DENY** |
| `git push` | feature worktree | ask |
| `git push --force-with-lease` | feature worktree, solo | ask |
| `git push origin master` | feature worktree | **DENY** |
| `cd <master> && git push` | feature worktree | **DENY** (cd tracked) |
| `git -C <master> push` | feature worktree | **DENY** (-C retargeted) |
| `git push origin $BRANCH` | master checkout | no deny (unresolvable) |
| `git push` | `/tmp`, not a repo | ask (probe failed) |
| `git push` + `YOLT_NO_POLICIES=1` | master checkout | ask |

687 tests pass, up from 659 — 28 new, none broken.

## Worth knowing for review

Three wiring bugs got through the unit tests, all the same shape: I patched
against the pre-Phase-1 code from #82's diff, and Phase 1 had deleted the
anchors. `DECISION_DENY` went unimported in two modules and the `cd` hook
never landed — and every one of those passed the policy unit tests, because
those call `GitDenyPolicy` directly and never touch the wiring. The
`ThroughTheClassifier` test class exists specifically to close that gap and
was added after the end-to-end run caught what the units could not.

https://claude.ai/code/session_01FNxtEDNZi4Cwveyqt4HQ9j
